### PR TITLE
Fix expired-token refresh and login back-navigation regressions

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/auth/domain/SessionManager.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/auth/domain/SessionManager.kt
@@ -80,6 +80,23 @@ class SessionManager @Inject constructor(
                     expiresAt = tokenExpiry
                 )
 
+                // Restore user from storage first so refreshToken() can
+                // read the current refresh token from the session state.
+                val displayName = securePreferences.getDisplayName().first() ?: ""
+                val email = securePreferences.getUserEmail().first() ?: ""
+                val avatarUrl = securePreferences.getUserAvatarUrl().first() ?: ""
+                val user = User(
+                    uuid = userUuid,
+                    displayName = displayName,
+                    email = email,
+                    avatarUrl = avatarUrl
+                )
+
+                _userSession.value = UserSession.Authenticated(
+                    user = user,
+                    authToken = authToken
+                )
+
                 // Check if token is expired
                 val currentTime = System.currentTimeMillis()
                 if (currentTime >= tokenExpiry) {
@@ -92,21 +109,6 @@ class SessionManager @Inject constructor(
                         enterAnonymousSession()
                     }
                 } else {
-                    // Token is still valid, restore user from storage
-                    val displayName = securePreferences.getDisplayName().first() ?: ""
-                    val email = securePreferences.getUserEmail().first() ?: ""
-                    val avatarUrl = securePreferences.getUserAvatarUrl().first() ?: ""
-                    val user = User(
-                        uuid = userUuid,
-                        displayName = displayName,
-                        email = email,
-                        avatarUrl = avatarUrl
-                    )
-
-                    _userSession.value = UserSession.Authenticated(
-                        user = user,
-                        authToken = authToken
-                    )
                     Timber.d("Session loaded successfully for user: ${user.uuid}")
                 }
             } else {

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
@@ -63,9 +63,7 @@ class NavigationActions(private val navController: NavHostController) {
 
     fun navigateToLogin() {
         navController.navigate(ScreenBaseRoutes.LOGIN) {
-            popUpTo(navController.graph.id) {
-                inclusive = true
-            }
+            launchSingleTop = true
         }
     }
 


### PR DESCRIPTION
Restore Authenticated state before calling refreshToken() in loadSession() so the refresh token can be read from the session. Previously the Loading state caused refreshToken() to always fail, silently downgrading users to anonymous.

Remove popUpTo back-stack clearing from navigateToLogin() so pressing back from the login screen returns to Home instead of exiting the app.