### PR TITLE
Add bookmark toggle to Recipe Details screen

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -135,7 +136,7 @@ fun RecipeDetailsContent(
                             if (isBookmarked) R.string.remove_from_collection_content_description
                             else R.string.save_to_collection_content_description
                         ),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = if (isBookmarked) Color(0xFFFFD700) else MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
@@ -15,9 +15,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
@@ -67,7 +72,11 @@ fun RecipeDetailsScreen(
         LoadingContent()
     } else {
         if (uiState.recipe != null) {
-            RecipeDetailsContent(uiState.recipe!!)
+            RecipeDetailsContent(
+                recipe = uiState.recipe!!,
+                isBookmarked = uiState.isBookmarked,
+                onToggleBookmark = viewModel::toggleBookmark,
+            )
         } else {
             EmptyContent(
                 title = R.string.recipe_not_found_error,
@@ -95,6 +104,8 @@ fun RecipeDetailsScreen(
 @Composable
 fun RecipeDetailsContent(
     recipe: Recipe,
+    isBookmarked: Boolean = false,
+    onToggleBookmark: () -> Unit = {},
 ) {
     val tabTitles = listOf(stringResource(R.string.ingredients), stringResource(R.string.steps))
     val pagerState = rememberPagerState { tabTitles.size }
@@ -105,12 +116,29 @@ fun RecipeDetailsContent(
             .fillMaxSize()
     ) {
         Column(modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.padding_medium))) {
-            Text(
-                text = recipe.title,
-                style = MaterialTheme.typography.headlineLarge,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_medium))
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = dimensionResource(id = R.dimen.padding_medium)),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = recipe.title,
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = onToggleBookmark) {
+                    Icon(
+                        imageVector = if (isBookmarked) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
+                        contentDescription = stringResource(
+                            if (isBookmarked) R.string.remove_from_collection_content_description
+                            else R.string.save_to_collection_content_description
+                        ),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
 
             // Log image loading attempt
             Timber.tag("RecipeDetailsScreen").d(
@@ -252,6 +280,14 @@ fun StepsList(steps: List<RecipeStep>) {
 @Composable
 fun RecipeDetailsFullScreenPreview() {
     ChefAITheme {
-        RecipeDetailsContent(RecipeData.recipe)
+        RecipeDetailsContent(recipe = RecipeData.recipe, isBookmarked = false)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RecipeDetailsBookmarkedPreview() {
+    ChefAITheme {
+        RecipeDetailsContent(recipe = RecipeData.recipe, isBookmarked = true)
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModel.kt
@@ -4,35 +4,42 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.auth.domain.model.UserSession
+import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
 import com.tenmilelabs.chefai.core.domain.model.Recipe
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
 import com.tenmilelabs.chefai.core.util.Async
 import com.tenmilelabs.chefai.core.util.WhileUiSubscribed
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 
-/**
- * UiState for the task list screen.
- */
 data class RecipesDetailsUiState(
     val recipe: Recipe? = null,
     val isLoading: Boolean = false,
+    val isBookmarked: Boolean = false,
     val userMessage: Int? = null,
 )
 
-
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class RecipeDetailsViewModel @Inject constructor(
     recipesRepository: RecipesRepository,
+    private val collectionsRepository: CollectionsRepository,
+    private val sessionManager: SessionManager,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -50,8 +57,19 @@ class RecipeDetailsViewModel @Inject constructor(
         }
         .catch { emit(Async.Error(R.string.loading_recipe_details_error)) }
 
-    val uiState: StateFlow<RecipesDetailsUiState> = combine(_isLoading, _recipeAsync, _userMessage)
-    { isLoading, recipeAsync, userMessage ->
+    private val _isBookmarked: Flow<Boolean> = sessionManager.userSession
+        .flatMapLatest { session ->
+            val userId = when (session) {
+                is UserSession.Loading -> return@flatMapLatest flowOf(false)
+                is UserSession.Anonymous -> session.localUserId
+                is UserSession.Authenticated -> session.user.uuid
+            }
+            collectionsRepository.observeBookmarkedRecipeIds(userId).map { ids -> recipeUuid in ids }
+        }
+
+    val uiState: StateFlow<RecipesDetailsUiState> = combine(
+        _isLoading, _recipeAsync, _userMessage, _isBookmarked
+    ) { isLoading, recipeAsync, userMessage, isBookmarked ->
         when (recipeAsync) {
             Async.Loading -> {
                 RecipesDetailsUiState(isLoading = true)
@@ -65,6 +83,7 @@ class RecipeDetailsViewModel @Inject constructor(
                 RecipesDetailsUiState(
                     recipe = recipeAsync.data,
                     isLoading = isLoading,
+                    isBookmarked = isBookmarked,
                 )
             }
         }
@@ -77,5 +96,16 @@ class RecipeDetailsViewModel @Inject constructor(
 
     fun snackbarMessageShown() {
         _userMessage.value = null
+    }
+
+    fun toggleBookmark() {
+        val userId = sessionManager.getCurrentUserId() ?: return
+        viewModelScope.launch {
+            if (uiState.value.isBookmarked) {
+                collectionsRepository.removeBookmark(userId, recipeUuid)
+            } else {
+                collectionsRepository.addBookmark(userId, recipeUuid)
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="recipe_image_content_description">Recipe Image</string>
     <string name="recipe_not_found_error">Recipe Not Found!</string>
     <string name="save_to_collection_content_description">Save to collection</string>
+    <string name="remove_from_collection_content_description">Remove from collection</string>
     <string name="recipe_not_found_error_subtitle">Oops! This was not supposed to happen. Please navigate back and try again later.</string>
     <string name="recipe_steps">Recipe Instructions</string>
     <string name="recipes_screen_title">Recipes</string>

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModelTest.kt
@@ -4,11 +4,15 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.collections.data.repository.FakeCollectionsRepository
+import com.tenmilelabs.chefai.core.testutil.createTestSessionManager
 import com.tenmilelabs.chefai.core.testutil.recipe1
 import com.tenmilelabs.chefai.core.testutil.recipeId1
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
 import com.tenmilelabs.chefai.core.util.MainCoroutineRule
+import com.tenmilelabs.chefai.auth.domain.SessionManager
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipesRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -23,19 +27,24 @@ class RecipeDetailsViewModelTest {
 
     private lateinit var viewModel: RecipeDetailsViewModel
     private lateinit var recipesRepository: FakeRecipesRepository
+    private lateinit var collectionsRepository: FakeCollectionsRepository
+    private lateinit var sessionManager: SessionManager
     private lateinit var savedStateHandle: SavedStateHandle
 
     @Before
     fun setup() {
         recipesRepository = FakeRecipesRepository()
+        collectionsRepository = FakeCollectionsRepository()
+        sessionManager = createTestSessionManager(
+            testScope = CoroutineScope(mainCoroutineRule.testDispatcher)
+        )
         savedStateHandle = SavedStateHandle().apply {
             set(AppDestinationArgs.RECIPE_ID_ARG, recipeId1.toString())
         }
-        // ViewModel is re-initialized for each test to ensure clean state
     }
 
     private fun initializeViewModel() {
-        viewModel = RecipeDetailsViewModel(recipesRepository, savedStateHandle)
+        viewModel = RecipeDetailsViewModel(recipesRepository, collectionsRepository, sessionManager, savedStateHandle)
     }
 
     @Test
@@ -128,28 +137,66 @@ class RecipeDetailsViewModelTest {
 
     @Test
     fun `loadRecipe - success - isLoading reflects _isLoading state`() = runTest {
-        // This test demonstrates how _isLoading (if it were mutable from outside)
-        // would interact, though current ViewModel doesn't expose _isLoading manipulation.
-        // For current ViewModel, _isLoading is always false initially.
-        // If we could set _isLoading = MutableStateFlow(true) from VM after init,
-        // this test would be more relevant. Given the current code, this is more
-        // of a sanity check on the combine logic for the isLoading part of Async.Success.
-
         initializeViewModel()
 
         viewModel.uiState.test {
-            // 1. Initial Loading state from stateIn initialValue
             assertThat(awaitItem().isLoading).isTrue()
 
-            // 2. Repository emits data. _isLoading is still its default (false)
             recipesRepository.emitRecipe(recipeId1, recipe1)
 
-            // 3. Success state
             val successState = awaitItem()
-            // In the Async.Success branch, isLoading = isLoading (which is _isLoading.value)
-            // Since _isLoading is private and defaults to false, this should be false.
             assertThat(successState.isLoading).isFalse()
             assertThat(successState.recipe).isEqualTo(recipe1)
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `initial bookmark state is false`() = runTest {
+        initializeViewModel()
+        viewModel.uiState.test {
+            assertThat(awaitItem().isLoading).isTrue()
+
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+
+            val successState = awaitItem()
+            assertThat(successState.isBookmarked).isFalse()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleBookmark - adds bookmark when not bookmarked`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        initializeViewModel()
+
+        viewModel.uiState.test {
+            assertThat(awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            assertThat(awaitItem().isBookmarked).isFalse()
+
+            viewModel.toggleBookmark()
+            assertThat(awaitItem().isBookmarked).isTrue()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleBookmark - removes bookmark when already bookmarked`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        collectionsRepository.addBookmark(userId, recipeId1)
+        initializeViewModel()
+
+        viewModel.uiState.test {
+            assertThat(awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            assertThat(awaitItem().isBookmarked).isTrue()
+
+            viewModel.toggleBookmark()
+            assertThat(awaitItem().isBookmarked).isFalse()
 
             cancelAndConsumeRemainingEvents()
         }


### PR DESCRIPTION
## Summary
- Adds `CollectionsRepository` and `SessionManager` to `RecipeDetailsViewModel` to reactively observe bookmark state for the current recipe
- Adds `toggleBookmark()` action that delegates to the existing collections layer (`addBookmark`/`removeBookmark`)
- Renders a filled `Bookmark` / outlined `BookmarkBorder` `IconButton` next to the recipe title in `RecipeDetailsContent`

## Changes
- **`RecipeDetailsViewModel`** — new `isBookmarked: Boolean` in `UiState`; `_isBookmarked` flow via `flatMapLatest` on session + `observeBookmarkedRecipeIds`; `toggleBookmark()` function
- **`RecipeDetailsScreen`** — title row now a `Row` with the recipe name and bookmark `IconButton`; added bookmarked/unbookmarked previews
- **`strings.xml`** — added `remove_from_collection_content_description`
- **`RecipeDetailsViewModelTest`** — injected `FakeCollectionsRepository` + `createTestSessionManager`; added 3 bookmark tests

## Test plan
- [ ] Build passes — `./gradlew :app:testDebugUnitTest`
- [ ] Tap bookmark icon on a recipe detail: icon fills and recipe appears in the Recipes (collection) tab
- [ ] Tap again: icon becomes outline and recipe is removed from collection
- [ ] Works for both anonymous and authenticated sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)