### PR TITLE
Add meal planning feature with wizard flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,12 +156,16 @@ After completing any code change (bug fix, feature, refactor), always run the un
 
 ---
 
-## Current Gaps (Feb 2026)
-| Area | Status                                            |
-|------|---------------------------------------------------|
-| HomeScreen | Static placeholder data, explore server driven UI |
-| Meal Plans | Stub only                                         |
-| Conflict resolution | SyncState.CONFLICT defined but unused             |
+## Current Gaps (Mar 2026)
+| Area | Status                                                                              |
+|------|-------------------------------------------------------------------------------------|
+| HomeScreen | Static placeholder data, explore server driven UI                             |
+| Meal Plans — Android UI | Done (wizard + list screen, local persistence as DRAFT)              |
+| Meal Plans — Backend sync | Not started — spec in `docs/prompts/meal-plans-backend-prompt.md`  |
+| Meal Plans — AI generation | Not started — blocked on `POST /meal-plans/{id}/generate` BE work  |
+| Meal Plans — Android sync wiring | Not started — extend `SyncOrchestrator` + `SyncDtos`         |
+| Conflict resolution | SyncState.CONFLICT defined but unused                                     |
+| RecipesViewModel user wiring | Hardcoded test UUID, needs real user from SessionManager           |
 
 **Next milestone**: Complete all tasks to prepare for Monstro Demo
 

--- a/app/schemas/com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase/6.json
+++ b/app/schemas/com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase/6.json
@@ -1,0 +1,1284 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "1800722ba8a5f955041f32d52e65e3f7",
+    "entities": [
+      {
+        "tableName": "allergens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_allergens_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_allergens_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarked_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` BLOB NOT NULL, `recipeId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`userId`, `recipeId`), FOREIGN KEY(`userId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "recipeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarked_recipes_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarked_recipes_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_bookmarked_recipes_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarked_recipes_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ingredients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `allergenId` BLOB, `sourcePrimaryId` BLOB, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`allergenId`) REFERENCES `allergens`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT , FOREIGN KEY(`sourcePrimaryId`) REFERENCES `source_classifications`(`uuid`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allergenId",
+            "columnName": "allergenId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "sourcePrimaryId",
+            "columnName": "sourcePrimaryId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ingredients_allergenId",
+            "unique": false,
+            "columnNames": [
+              "allergenId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_allergenId` ON `${TABLE_NAME}` (`allergenId`)"
+          },
+          {
+            "name": "index_ingredients_sourcePrimaryId",
+            "unique": false,
+            "columnNames": [
+              "sourcePrimaryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_sourcePrimaryId` ON `${TABLE_NAME}` (`sourcePrimaryId`)"
+          },
+          {
+            "name": "index_ingredients_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "allergens",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "allergenId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "source_classifications",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourcePrimaryId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "labels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_labels_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_labels_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `userId` BLOB NOT NULL, `name` TEXT NOT NULL, `status` TEXT NOT NULL, `preferencesJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`userId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preferencesJson",
+            "columnName": "preferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plans_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plans_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_meal_plans_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plans_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `mealPlanId` BLOB NOT NULL, `dayIndex` INTEGER NOT NULL, `dinnerRecipeId` BLOB, `lunchRecipeId` BLOB, PRIMARY KEY(`uuid`), FOREIGN KEY(`mealPlanId`) REFERENCES `meal_plans`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanId",
+            "columnName": "mealPlanId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dinnerRecipeId",
+            "columnName": "dinnerRecipeId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "lunchRecipeId",
+            "columnName": "lunchRecipeId",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanId` ON `${TABLE_NAME}` (`mealPlanId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plans",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `isNewRecipe` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `selectedImageUri` TEXT, `prepTimeMinutes` TEXT NOT NULL, `cookTimeMinutes` TEXT NOT NULL, `servings` TEXT NOT NULL, `externalUrl` TEXT NOT NULL, `ingredientsJson` TEXT NOT NULL, `stepsJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `labelsJson` TEXT NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`recipeId`))",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNewRecipe",
+            "columnName": "isNewRecipe",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedImageUri",
+            "columnName": "selectedImageUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "prepTimeMinutes",
+            "columnName": "prepTimeMinutes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cookTimeMinutes",
+            "columnName": "cookTimeMinutes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalUrl",
+            "columnName": "externalUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelsJson",
+            "columnName": "labelsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId"
+          ]
+        }
+      },
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `imageUrlThumbnail` TEXT NOT NULL, `prepTimeMinutes` INTEGER NOT NULL, `cookTimeMinutes` INTEGER NOT NULL, `servings` INTEGER NOT NULL, `creatorId` BLOB NOT NULL, `recipeExternalUrl` TEXT, `privacy` TEXT NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`creatorId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrlThumbnail",
+            "columnName": "imageUrlThumbnail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prepTimeMinutes",
+            "columnName": "prepTimeMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cookTimeMinutes",
+            "columnName": "cookTimeMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorId",
+            "columnName": "creatorId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeExternalUrl",
+            "columnName": "recipeExternalUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "privacy",
+            "columnName": "privacy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipes_creatorId",
+            "unique": false,
+            "columnNames": [
+              "creatorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipes_creatorId` ON `${TABLE_NAME}` (`creatorId`)"
+          },
+          {
+            "name": "index_recipes_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipes_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "creatorId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_ingredients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `ingredientId` BLOB NOT NULL, `quantity` REAL NOT NULL, `unit` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `ingredientId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`ingredientId`) REFERENCES `ingredients`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientId",
+            "columnName": "ingredientId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "ingredientId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_ingredients_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_recipe_ingredients_ingredientId",
+            "unique": false,
+            "columnNames": [
+              "ingredientId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_ingredientId` ON `${TABLE_NAME}` (`ingredientId`)"
+          },
+          {
+            "name": "index_recipe_ingredients_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "ingredients",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ingredientId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_labels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `labelId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `labelId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`labelId`) REFERENCES `labels`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelId",
+            "columnName": "labelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "labelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_labels_labelId",
+            "unique": false,
+            "columnNames": [
+              "labelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_labels_labelId` ON `${TABLE_NAME}` (`labelId`)"
+          },
+          {
+            "name": "index_recipe_labels_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_labels_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "labels",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "labelId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `recipeId` BLOB NOT NULL, `orderIndex` INTEGER NOT NULL, `instruction` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instruction",
+            "columnName": "instruction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_steps_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_steps_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_recipe_steps_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_steps_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `tagId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `tagId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_recipe_tags_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_tags_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_classifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `category` TEXT NOT NULL, `subcategory` TEXT, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcategory",
+            "columnName": "subcategory",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_classifications_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_source_classifications_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityType` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`entityType`))",
+        "fields": [
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityType"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `email` TEXT NOT NULL, `avatarUrl` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1800722ba8a5f955041f32d52e65e3f7')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
@@ -10,6 +10,8 @@ import com.tenmilelabs.chefai.collections.data.repository.DefaultCollectionsRepo
 import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
 import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
+import com.tenmilelabs.chefai.mealplans.data.repository.DefaultMealPlanRepository
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.Binds
@@ -96,4 +98,11 @@ abstract class TestRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindCollectionsRepository(repository: DefaultCollectionsRepository): CollectionsRepository
+
+    /**
+     * Binds the meal plan repository (same as production).
+     */
+    @Binds
+    @Singleton
+    abstract fun bindMealPlanRepository(repository: DefaultMealPlanRepository): MealPlanRepository
 }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestDatabaseModule.kt
@@ -77,6 +77,9 @@ object TestDatabaseModule {
     fun provideBookmarkedRecipeDao(database: ChefAIDataBase) = database.bookmarkedRecipeDao()
 
     @Provides
+    fun provideMealPlanDao(database: ChefAIDataBase) = database.mealPlanDao()
+
+    @Provides
     @Singleton
     fun provideTransactionRunner(database: ChefAIDataBase): TransactionRunner =
         RoomTransactionRunner(database)

--- a/app/src/main/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandler.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandler.kt
@@ -41,9 +41,12 @@ class AccountSwitchHandler @Inject constructor(
                 AccountSwitchOutcome.NO_CHANGE
             }
             anonymousUserId != null -> {
-                Timber.i("Authenticated account changed from $previousUserId to $newUserId while anonymous data exists, removing previous authenticated user data only")
+                Timber.i("Authenticated account changed from $previousUserId to $newUserId while anonymous data exists, removing previous authenticated user recipes only")
+                // Delete only recipes (server can restore them on next sync).
+                // We intentionally keep the UserEntity and its meal plans: all queries
+                // filter by userId so they're invisible to other users, and when the
+                // original user logs back in their local plans will still be there.
                 recipeDao.deleteRecipesForUser(previousUserId)
-                userDao.deleteUser(previousUserId)
                 AccountSwitchOutcome.PRESERVED_ANONYMOUS_DATA
             }
             else -> {

--- a/app/src/main/java/com/tenmilelabs/chefai/auth/domain/usecase/AccountUpgradeUseCase.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/auth/domain/usecase/AccountUpgradeUseCase.kt
@@ -3,6 +3,7 @@ package com.tenmilelabs.chefai.auth.domain.usecase
 import com.tenmilelabs.chefai.core.data.local.room.TransactionRunner
 import com.tenmilelabs.chefai.core.data.local.room.UserEntity
 import com.tenmilelabs.chefai.core.data.local.room.dao.BookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.MealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeLabelCrossRefDao
@@ -36,7 +37,8 @@ class AccountUpgradeUseCase @Inject constructor(
     private val recipeIngredientDao: RecipeIngredientDao,
     private val recipeTagCrossRefDao: RecipeTagCrossRefDao,
     private val recipeLabelCrossRefDao: RecipeLabelCrossRefDao,
-    private val bookmarkedRecipeDao: BookmarkedRecipeDao
+    private val bookmarkedRecipeDao: BookmarkedRecipeDao,
+    private val mealPlanDao: MealPlanDao,
 ) {
 
     /**
@@ -56,8 +58,10 @@ class AccountUpgradeUseCase @Inject constructor(
         }
 
         val recipeCount = recipeDao.countRecipesForUser(anonymousUserId)
-        if (recipeCount == 0) {
-            Timber.d("No anonymous recipes to upgrade (new device or empty). Creating auth user only.")
+        val mealPlanCount = mealPlanDao.countMealPlansForUser(anonymousUserId)
+
+        if (recipeCount == 0 && mealPlanCount == 0) {
+            Timber.d("No anonymous data to upgrade (new device or empty). Creating auth user only.")
             ensureAuthenticatedUserEntity(authenticatedUser)
             return 0
         }
@@ -69,35 +73,40 @@ class AccountUpgradeUseCase @Inject constructor(
             // Step 1: Create the authenticated UserEntity first (FK target must exist)
             ensureAuthenticatedUserEntity(authenticatedUser)
 
-            // Step 2: Get recipe IDs before reassignment (needed for child entity updates)
-            val recipeIds = recipeDao.getRecipeIdsForUser(anonymousUserId)
-
-            // Step 3: Reassign all recipes from anonymous to authenticated + mark PENDING
-            recipeDao.reassignCreatorAndMarkPending(
-                oldCreatorId = anonymousUserId,
-                newCreatorId = authenticatedUser.uuid,
-                updatedAt = now
-            )
-
-            // Step 4: Mark all child entities as PENDING for sync
-            if (recipeIds.isNotEmpty()) {
-                recipeStepDao.markPendingForRecipes(recipeIds, now)
-                recipeIngredientDao.markPendingForRecipes(recipeIds, now)
-                recipeTagCrossRefDao.markPendingForRecipes(recipeIds, now)
-                recipeLabelCrossRefDao.markPendingForRecipes(recipeIds, now)
+            // Step 2: Reassign recipes (and their child entities) if any exist
+            if (recipeCount > 0) {
+                val recipeIds = recipeDao.getRecipeIdsForUser(anonymousUserId)
+                recipeDao.reassignCreatorAndMarkPending(
+                    oldCreatorId = anonymousUserId,
+                    newCreatorId = authenticatedUser.uuid,
+                    updatedAt = now
+                )
+                if (recipeIds.isNotEmpty()) {
+                    recipeStepDao.markPendingForRecipes(recipeIds, now)
+                    recipeIngredientDao.markPendingForRecipes(recipeIds, now)
+                    recipeTagCrossRefDao.markPendingForRecipes(recipeIds, now)
+                    recipeLabelCrossRefDao.markPendingForRecipes(recipeIds, now)
+                }
             }
 
-            // Step 4b: Reassign bookmarks from anonymous to authenticated user
+            // Step 3: Reassign bookmarks from anonymous to authenticated user
             bookmarkedRecipeDao.reassignUserAndMarkPending(
                 oldUserId = anonymousUserId,
                 newUserId = authenticatedUser.uuid,
                 updatedAt = now
             )
 
-            // Step 5: Delete the anonymous UserEntity (no recipes point to it anymore)
+            // Step 4: Reassign meal plans from anonymous to authenticated user
+            mealPlanDao.reassignUserAndMarkPending(
+                oldUserId = anonymousUserId,
+                newUserId = authenticatedUser.uuid,
+                updatedAt = now
+            )
+
+            // Step 5: Delete the anonymous UserEntity (nothing points to it anymore)
             userDao.deleteUser(anonymousUserId)
 
-            Timber.d("Account upgrade complete: $recipeCount recipes reassigned")
+            Timber.d("Account upgrade complete: $recipeCount recipes, $mealPlanCount meal plans reassigned")
             recipeCount
         }
     }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/MealPlanDayEntity.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/MealPlanDayEntity.kt
@@ -1,0 +1,29 @@
+package com.tenmilelabs.chefai.core.data.local.room
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+@Entity(
+    tableName = "meal_plan_days",
+    foreignKeys = [
+        ForeignKey(
+            entity = MealPlanEntity::class,
+            parentColumns = ["uuid"],
+            childColumns = ["mealPlanId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("mealPlanId")
+    ]
+)
+data class MealPlanDayEntity(
+    @PrimaryKey val uuid: UUID,
+    val mealPlanId: UUID,
+    val dayIndex: Int,
+    val dinnerRecipeId: UUID?,
+    val lunchRecipeId: UUID?,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/MealPlanEntity.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/MealPlanEntity.kt
@@ -1,0 +1,36 @@
+package com.tenmilelabs.chefai.core.data.local.room
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.tenmilelabs.chefai.core.data.local.util.SyncState
+import com.tenmilelabs.chefai.core.data.local.util.SyncableEntity
+import java.util.UUID
+
+@Entity(
+    tableName = "meal_plans",
+    foreignKeys = [
+        ForeignKey(
+            entity = UserEntity::class,
+            parentColumns = ["uuid"],
+            childColumns = ["userId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("userId"),
+        Index(value = ["syncState", "updatedAt"])
+    ]
+)
+data class MealPlanEntity(
+    @PrimaryKey override val uuid: UUID,
+    val userId: UUID,
+    val name: String,
+    val status: String,
+    val preferencesJson: String,
+    val createdAt: Long,
+    override val updatedAt: Long,
+    override val deletedAt: Long?,
+    override val syncState: SyncState = SyncState.PENDING,
+) : SyncableEntity

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/ChefAIDataBase.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/ChefAIDataBase.kt
@@ -9,6 +9,8 @@ import com.tenmilelabs.chefai.core.data.local.room.AllergenEntity
 import com.tenmilelabs.chefai.core.data.local.room.BookmarkedRecipeEntity
 import com.tenmilelabs.chefai.core.data.local.room.IngredientEntity
 import com.tenmilelabs.chefai.core.data.local.room.LabelEntity
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanDayEntity
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanEntity
 import com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity
 import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
 import com.tenmilelabs.chefai.core.data.local.room.RecipeIngredientEntity
@@ -27,6 +29,8 @@ import com.tenmilelabs.chefai.core.data.local.room.UuidConverters
         BookmarkedRecipeEntity::class,
         IngredientEntity::class,
         LabelEntity::class,
+        MealPlanEntity::class,
+        MealPlanDayEntity::class,
         RecipeDraftEntity::class,
         RecipeEntity::class,
         RecipeIngredientEntity::class,
@@ -38,7 +42,7 @@ import com.tenmilelabs.chefai.core.data.local.room.UuidConverters
         TagEntity::class,
         UserEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 @TypeConverters(
@@ -60,6 +64,7 @@ abstract class ChefAIDataBase : RoomDatabase() {
     abstract fun recipeLabelCrossRefDao(): RecipeLabelCrossRefDao
     abstract fun syncMetadataDao(): SyncMetadataDao
     abstract fun recipeDraftDao(): RecipeDraftDao
+    abstract fun mealPlanDao(): MealPlanDao
 }
 
 val MIGRATION_2_3 = object : Migration(2, 3) {
@@ -122,6 +127,43 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
         )
         db.execSQL("CREATE INDEX index_bookmarked_recipes_recipeId ON bookmarked_recipes(recipeId)")
         db.execSQL("CREATE INDEX index_bookmarked_recipes_syncState_updatedAt ON bookmarked_recipes(syncState, updatedAt)")
+    }
+}
+
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS meal_plans (
+                uuid BLOB NOT NULL PRIMARY KEY,
+                userId BLOB NOT NULL,
+                name TEXT NOT NULL,
+                status TEXT NOT NULL,
+                preferencesJson TEXT NOT NULL,
+                createdAt INTEGER NOT NULL,
+                updatedAt INTEGER NOT NULL,
+                deletedAt INTEGER,
+                syncState TEXT NOT NULL,
+                FOREIGN KEY(userId) REFERENCES users(uuid) ON DELETE CASCADE
+            )
+        """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX index_meal_plans_userId ON meal_plans(userId)")
+        db.execSQL("CREATE INDEX index_meal_plans_syncState_updatedAt ON meal_plans(syncState, updatedAt)")
+
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS meal_plan_days (
+                uuid BLOB NOT NULL PRIMARY KEY,
+                mealPlanId BLOB NOT NULL,
+                dayIndex INTEGER NOT NULL,
+                dinnerRecipeId BLOB,
+                lunchRecipeId BLOB,
+                FOREIGN KEY(mealPlanId) REFERENCES meal_plans(uuid) ON DELETE CASCADE
+            )
+        """.trimIndent()
+        )
+        db.execSQL("CREATE INDEX index_meal_plan_days_mealPlanId ON meal_plan_days(mealPlanId)")
     }
 }
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/MealPlanDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/MealPlanDao.kt
@@ -33,6 +33,12 @@ interface MealPlanDao {
     @Query("UPDATE meal_plans SET syncState = :syncState, updatedAt = :updatedAt WHERE uuid = :uuid")
     suspend fun updateSyncState(uuid: UUID, syncState: SyncState, updatedAt: Long)
 
+    @Query("UPDATE meal_plans SET userId = :newUserId, syncState = 'PENDING', updatedAt = :updatedAt WHERE userId = :oldUserId")
+    suspend fun reassignUserAndMarkPending(oldUserId: UUID, newUserId: UUID, updatedAt: Long)
+
+    @Query("SELECT COUNT(*) FROM meal_plans WHERE userId = :userId AND deletedAt IS NULL")
+    suspend fun countMealPlansForUser(userId: UUID): Int
+
     // Days
 
     @Query("SELECT * FROM meal_plan_days WHERE mealPlanId = :mealPlanId ORDER BY dayIndex ASC")

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/MealPlanDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/MealPlanDao.kt
@@ -1,0 +1,49 @@
+package com.tenmilelabs.chefai.core.data.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanDayEntity
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanEntity
+import com.tenmilelabs.chefai.core.data.local.util.SyncState
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+@Dao
+interface MealPlanDao {
+
+    @Query("SELECT * FROM meal_plans WHERE userId = :userId AND deletedAt IS NULL ORDER BY createdAt DESC")
+    fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlanEntity>>
+
+    @Query("SELECT * FROM meal_plans WHERE uuid = :uuid")
+    suspend fun getMealPlanById(uuid: UUID): MealPlanEntity?
+
+    @Query("SELECT * FROM meal_plans WHERE uuid = :uuid")
+    fun observeMealPlanById(uuid: UUID): Flow<MealPlanEntity?>
+
+    @Upsert
+    suspend fun upsertMealPlan(mealPlan: MealPlanEntity)
+
+    @Query("UPDATE meal_plans SET deletedAt = :deletedAt, syncState = 'DELETED', updatedAt = :deletedAt WHERE uuid = :uuid")
+    suspend fun softDelete(uuid: UUID, deletedAt: Long)
+
+    @Query("SELECT * FROM meal_plans WHERE syncState IN ('PENDING', 'DELETED')")
+    suspend fun getAllDirty(): List<MealPlanEntity>
+
+    @Query("UPDATE meal_plans SET syncState = :syncState, updatedAt = :updatedAt WHERE uuid = :uuid")
+    suspend fun updateSyncState(uuid: UUID, syncState: SyncState, updatedAt: Long)
+
+    // Days
+
+    @Query("SELECT * FROM meal_plan_days WHERE mealPlanId = :mealPlanId ORDER BY dayIndex ASC")
+    fun observeDaysForMealPlan(mealPlanId: UUID): Flow<List<MealPlanDayEntity>>
+
+    @Query("SELECT * FROM meal_plan_days WHERE mealPlanId = :mealPlanId ORDER BY dayIndex ASC")
+    suspend fun getDaysForMealPlan(mealPlanId: UUID): List<MealPlanDayEntity>
+
+    @Upsert
+    suspend fun upsertDays(days: List<MealPlanDayEntity>)
+
+    @Query("DELETE FROM meal_plan_days WHERE mealPlanId = :mealPlanId")
+    suspend fun deleteDaysForMealPlan(mealPlanId: UUID)
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -6,6 +6,9 @@ import com.tenmilelabs.chefai.auth.data.local.SecurePreferences
 import com.tenmilelabs.chefai.auth.data.local.SecurePreferencesInterface
 import com.tenmilelabs.chefai.collections.data.repository.DefaultCollectionsRepository
 import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
+import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_5_6
+import com.tenmilelabs.chefai.mealplans.data.repository.DefaultMealPlanRepository
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
 import com.tenmilelabs.chefai.core.data.local.room.RoomTransactionRunner
 import com.tenmilelabs.chefai.core.data.local.room.TransactionRunner
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
@@ -43,6 +46,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindCollectionsRepository(repository: DefaultCollectionsRepository): CollectionsRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindMealPlanRepository(repository: DefaultMealPlanRepository): MealPlanRepository
 }
 
 
@@ -59,7 +66,7 @@ object DatabaseModules {
             "ChefAI.db"
         )
             .createFromAsset("database/ChefAI.db")
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
             .build()
     }
 
@@ -104,6 +111,9 @@ object DatabaseModules {
 
     @Provides
     fun provideRecipeDraftDao(database: ChefAIDataBase) = database.recipeDraftDao()
+
+    @Provides
+    fun provideMealPlanDao(database: ChefAIDataBase) = database.mealPlanDao()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 /**
  * Screens used in [AppDestinations].
  */
-private object ScreenBaseRoutes {
+internal object ScreenBaseRoutes {
     const val HOME = "home_screen"
     const val MEAL_PLANS = "meal_plans_screen"
     const val RECIPES = "recipes_screen"
@@ -19,6 +19,10 @@ private object ScreenBaseRoutes {
     const val SETTINGS = "settings_screen"
     const val LOGIN = "login_screen"
     const val REGISTER = "register_screen"
+    const val MEAL_PLAN_WIZARD = "meal_plan_wizard"
+    const val MEAL_PLAN_WIZARD_BASICS = "meal_plan_wizard_basics"
+    const val MEAL_PLAN_WIZARD_PREFERENCES = "meal_plan_wizard_preferences"
+    const val MEAL_PLAN_WIZARD_ADVANCED = "meal_plan_wizard_advanced"
 }
 
 /**
@@ -43,6 +47,7 @@ enum class AppDestinations(
         "${ScreenBaseRoutes.RECIPE_DETAILS}/{$RECIPE_ID_ARG}"
     ),
     CREATE_RECIPE(R.string.app_dest_title_create_recipe, ScreenBaseRoutes.CREATE_RECIPE),
+    MEAL_PLAN_WIZARD(R.string.app_dest_title_meal_plan_wizard, ScreenBaseRoutes.MEAL_PLAN_WIZARD),
     SETTINGS(R.string.app_dest_title_settings, ScreenBaseRoutes.SETTINGS),
     LOGIN(R.string.app_dest_title_login, ScreenBaseRoutes.LOGIN),
     REGISTER(R.string.app_dest_title_register, ScreenBaseRoutes.REGISTER),
@@ -69,6 +74,10 @@ class NavigationActions(private val navController: NavHostController) {
 
     fun navigateToRegister() {
         navController.navigate(ScreenBaseRoutes.REGISTER)
+    }
+
+    fun navigateToMealPlanWizard() {
+        navController.navigate(ScreenBaseRoutes.MEAL_PLAN_WIZARD)
     }
 
     fun navigateToHome() {

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -17,8 +17,16 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.LaunchedEffect
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.createGraph
 import com.tenmilelabs.chefai.R
@@ -26,6 +34,11 @@ import com.tenmilelabs.chefai.auth.ui.LoginScreen
 import com.tenmilelabs.chefai.auth.ui.RegisterScreen
 import com.tenmilelabs.chefai.home.ui.HomeScreen
 import com.tenmilelabs.chefai.mealplans.ui.MealPlansScreen
+import com.tenmilelabs.chefai.mealplans.ui.create.CreateMealPlanEvent
+import com.tenmilelabs.chefai.mealplans.ui.create.CreateMealPlanViewModel
+import com.tenmilelabs.chefai.mealplans.ui.create.WizardAdvancedScreen
+import com.tenmilelabs.chefai.mealplans.ui.create.WizardBasicsScreen
+import com.tenmilelabs.chefai.mealplans.ui.create.WizardPreferencesScreen
 import com.tenmilelabs.chefai.recipes.ui.RecipesScreen
 import com.tenmilelabs.chefai.recipes.ui.create.CreateRecipeScreen
 import com.tenmilelabs.chefai.recipes.ui.details.RecipeDetailsScreen
@@ -63,7 +76,69 @@ fun ChefAINavGraph(
             )
         }
         composable(route = AppDestinations.MEAL_PLANS.route) {
-            MealPlansScreen()
+            MealPlansScreen(
+                onCreateMealPlan = { navActions.navigateToMealPlanWizard() },
+                snackbarHostState = snackbarHostState,
+            )
+        }
+        navigation(
+            startDestination = ScreenBaseRoutes.MEAL_PLAN_WIZARD_BASICS,
+            route = ScreenBaseRoutes.MEAL_PLAN_WIZARD,
+        ) {
+            composable(ScreenBaseRoutes.MEAL_PLAN_WIZARD_BASICS) { entry ->
+                val parentEntry = remember(entry) {
+                    navController.getBackStackEntry(ScreenBaseRoutes.MEAL_PLAN_WIZARD)
+                }
+                val wizardViewModel: CreateMealPlanViewModel = hiltViewModel(parentEntry)
+                WizardBasicsScreen(
+                    viewModel = wizardViewModel,
+                    onNext = {
+                        navController.navigate(ScreenBaseRoutes.MEAL_PLAN_WIZARD_PREFERENCES)
+                    },
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable(ScreenBaseRoutes.MEAL_PLAN_WIZARD_PREFERENCES) { entry ->
+                val parentEntry = remember(entry) {
+                    navController.getBackStackEntry(ScreenBaseRoutes.MEAL_PLAN_WIZARD)
+                }
+                val wizardViewModel: CreateMealPlanViewModel = hiltViewModel(parentEntry)
+                WizardPreferencesScreen(
+                    viewModel = wizardViewModel,
+                    onNext = {
+                        navController.navigate(ScreenBaseRoutes.MEAL_PLAN_WIZARD_ADVANCED)
+                    },
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable(ScreenBaseRoutes.MEAL_PLAN_WIZARD_ADVANCED) { entry ->
+                val parentEntry = remember(entry) {
+                    navController.getBackStackEntry(ScreenBaseRoutes.MEAL_PLAN_WIZARD)
+                }
+                val wizardViewModel: CreateMealPlanViewModel = hiltViewModel(parentEntry)
+
+                LaunchedEffect(Unit) {
+                    wizardViewModel.uiEvents.collect { event ->
+                        when (event) {
+                            is CreateMealPlanEvent.MealPlanCreated -> {
+                                navController.popBackStack(
+                                    route = AppDestinations.MEAL_PLANS.route,
+                                    inclusive = false,
+                                )
+                            }
+                            is CreateMealPlanEvent.ShowError -> {
+                                snackbarHostState.showSnackbar("Failed to create meal plan")
+                            }
+                        }
+                    }
+                }
+
+                WizardAdvancedScreen(
+                    viewModel = wizardViewModel,
+                    onDone = { /* handled by event collection above */ },
+                    onBack = { navController.popBackStack() },
+                )
+            }
         }
         composable(
             route = AppDestinations.RECIPE_DETAILS.route,
@@ -111,9 +186,18 @@ fun ChefAINavGraph(
             NavController.OnDestinationChangedListener { _: NavController, destination: NavDestination, _ ->
                 val newRoute = destination.route ?: AppDestinations.HOME.route
 
-                titleRes = AppDestinations.entries
-                    .filter { it.route == destination.route }
-                    .map { it.title }.firstOrNull() ?: R.string.app_name
+                val wizardRoutes = setOf(
+                    ScreenBaseRoutes.MEAL_PLAN_WIZARD_BASICS,
+                    ScreenBaseRoutes.MEAL_PLAN_WIZARD_PREFERENCES,
+                    ScreenBaseRoutes.MEAL_PLAN_WIZARD_ADVANCED,
+                )
+                titleRes = if (destination.route in wizardRoutes) {
+                    R.string.app_dest_title_meal_plan_wizard
+                } else {
+                    AppDestinations.entries
+                        .filter { it.route == destination.route }
+                        .map { it.title }.firstOrNull() ?: R.string.app_name
+                }
 
                 isTopLevelDestination =
                     TopLevelDestination.entries.any { it.appDestination.route == destination.route }
@@ -154,29 +238,48 @@ fun ChefAINavGraph(
             }
         },
         bottomBar = {
-            // Don't show bottom bar on login or register screens
-            if (currentRoute != AppDestinations.LOGIN.route && currentRoute != AppDestinations.REGISTER.route) {
+            val wizardRoutes = setOf(
+                ScreenBaseRoutes.MEAL_PLAN_WIZARD_BASICS,
+                ScreenBaseRoutes.MEAL_PLAN_WIZARD_PREFERENCES,
+                ScreenBaseRoutes.MEAL_PLAN_WIZARD_ADVANCED,
+            )
+            val hideBottomBar = currentRoute == AppDestinations.LOGIN.route ||
+                currentRoute == AppDestinations.REGISTER.route ||
+                currentRoute in wizardRoutes
+            if (!hideBottomBar) {
                 BottomNavigationBar(navController)
             }
         },
         floatingActionButton = {
-            // Only show FAB on Recipes screen
-            if (currentRoute == AppDestinations.RECIPES.route) {
-                FloatingActionButtonMenu(
-                    expanded = isFabMenuExpanded,
-                    onExpandedChange = {
-                        isFabMenuExpanded = !isFabMenuExpanded
-                    },
-                    onCreateRecipeClick = {
-                        isFabMenuExpanded = false
-                        navActions.navigateToCreateRecipe()
-                    },
-                    onImportRecipeClick = {
-                        isFabMenuExpanded = false
-                        // TODO: Navigate to import recipe screen
-                        // navActions.navigateToImportRecipe()
+            when (currentRoute) {
+                AppDestinations.RECIPES.route -> {
+                    FloatingActionButtonMenu(
+                        expanded = isFabMenuExpanded,
+                        onExpandedChange = {
+                            isFabMenuExpanded = !isFabMenuExpanded
+                        },
+                        onCreateRecipeClick = {
+                            isFabMenuExpanded = false
+                            navActions.navigateToCreateRecipe()
+                        },
+                        onImportRecipeClick = {
+                            isFabMenuExpanded = false
+                            // TODO: Navigate to import recipe screen
+                            // navActions.navigateToImportRecipe()
+                        }
+                    )
+                }
+                AppDestinations.MEAL_PLANS.route -> {
+                    FloatingActionButton(
+                        onClick = { navActions.navigateToMealPlanWizard() },
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "Create meal plan",
+                        )
                     }
-                )
+                }
             }
         }
     ) { innerPadding ->

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/mapper/MealPlanMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/mapper/MealPlanMapper.kt
@@ -1,0 +1,48 @@
+package com.tenmilelabs.chefai.mealplans.data.mapper
+
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanDayEntity
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanEntity
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanDay
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanPreferences
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import kotlinx.serialization.json.Json
+
+private val json = Json { ignoreUnknownKeys = true }
+
+fun MealPlanEntity.toDomain(days: List<MealPlanDayEntity>): MealPlan = MealPlan(
+    uuid = uuid,
+    userId = userId,
+    name = name,
+    preferences = json.decodeFromString<MealPlanPreferences>(preferencesJson),
+    status = MealPlanStatus.valueOf(status),
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    days = days.map { it.toDomain() },
+)
+
+fun MealPlanDayEntity.toDomain(): MealPlanDay = MealPlanDay(
+    uuid = uuid,
+    dayIndex = dayIndex,
+    dinnerRecipeId = dinnerRecipeId,
+    lunchRecipeId = lunchRecipeId,
+)
+
+fun MealPlan.toEntity(): MealPlanEntity = MealPlanEntity(
+    uuid = uuid,
+    userId = userId,
+    name = name,
+    status = status.name,
+    preferencesJson = json.encodeToString(MealPlanPreferences.serializer(), preferences),
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    deletedAt = null,
+)
+
+fun MealPlanDay.toEntity(mealPlanId: java.util.UUID): MealPlanDayEntity = MealPlanDayEntity(
+    uuid = uuid,
+    mealPlanId = mealPlanId,
+    dayIndex = dayIndex,
+    dinnerRecipeId = dinnerRecipeId,
+    lunchRecipeId = lunchRecipeId,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/repository/DefaultMealPlanRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/repository/DefaultMealPlanRepository.kt
@@ -1,0 +1,37 @@
+package com.tenmilelabs.chefai.mealplans.data.repository
+
+import com.tenmilelabs.chefai.core.data.local.room.dao.MealPlanDao
+import com.tenmilelabs.chefai.mealplans.data.mapper.toDomain
+import com.tenmilelabs.chefai.mealplans.data.mapper.toEntity
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DefaultMealPlanRepository @Inject constructor(
+    private val mealPlanDao: MealPlanDao,
+) : MealPlanRepository {
+
+    override fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlan>> =
+        mealPlanDao.observeMealPlansForUser(userId).map { entities ->
+            entities.map { entity ->
+                val days = mealPlanDao.getDaysForMealPlan(entity.uuid)
+                entity.toDomain(days)
+            }
+        }
+
+    override suspend fun createMealPlan(mealPlan: MealPlan) {
+        mealPlanDao.upsertMealPlan(mealPlan.toEntity())
+        if (mealPlan.days.isNotEmpty()) {
+            mealPlanDao.upsertDays(mealPlan.days.map { it.toEntity(mealPlan.uuid) })
+        }
+    }
+
+    override suspend fun deleteMealPlan(uuid: UUID) {
+        mealPlanDao.softDelete(uuid, System.currentTimeMillis())
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/DietaryRestriction.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/DietaryRestriction.kt
@@ -1,0 +1,12 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+enum class DietaryRestriction(val emoji: String, val label: String) {
+    NONE("\uD83C\uDF74", "No restrictions"),
+    VEGAN("\uD83C\uDF31", "Vegan"),
+    VEGETARIAN("\uD83E\uDD6C", "Vegetarian"),
+    LOW_CARB("\uD83E\uDD69", "Low Carb"),
+    GLUTEN_FREE("\uD83C\uDF3E", "Gluten-Free"),
+    DAIRY_FREE("\uD83E\uDD5B", "Dairy-Free"),
+    KETO("\uD83E\uDD51", "Keto"),
+    PALEO("\uD83E\uDDB4", "Paleo"),
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlan.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlan.kt
@@ -1,0 +1,14 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+import java.util.UUID
+
+data class MealPlan(
+    val uuid: UUID,
+    val userId: UUID,
+    val name: String,
+    val preferences: MealPlanPreferences,
+    val status: MealPlanStatus,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val days: List<MealPlanDay>,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlanDay.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlanDay.kt
@@ -1,0 +1,10 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+import java.util.UUID
+
+data class MealPlanDay(
+    val uuid: UUID,
+    val dayIndex: Int,
+    val dinnerRecipeId: UUID?,
+    val lunchRecipeId: UUID?,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlanPreferences.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlanPreferences.kt
@@ -1,0 +1,16 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MealPlanPreferences(
+    val planLengthDays: Int,
+    val mealType: MealType,
+    val dietaryRestrictions: Set<DietaryRestriction>,
+    val recipeSource: RecipeSource,
+    val maxPrepTimeMinutes: Int?,
+    val servingsPerMeal: Int,
+    val batchCooking: Boolean,
+    val leftoverFriendly: Boolean,
+    val varietyPreference: VarietyPreference,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlanStatus.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealPlanStatus.kt
@@ -1,0 +1,8 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+enum class MealPlanStatus {
+    DRAFT,
+    GENERATING,
+    READY,
+    ARCHIVED,
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealType.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/MealType.kt
@@ -1,0 +1,6 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+enum class MealType(val emoji: String, val label: String) {
+    DINNER("\uD83C\uDF7D\uFE0F", "Dinners only"),
+    DINNER_AND_LUNCH("\uD83C\uDF7D\uFE0F\uD83E\uDD57", "Dinners + Lunches"),
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/RecipeSource.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/RecipeSource.kt
@@ -1,0 +1,6 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+enum class RecipeSource(val emoji: String, val label: String) {
+    COLLECTION_ONLY("\uD83D\uDCDA", "My collection only"),
+    INCLUDE_PUBLIC("\uD83C\uDF0D", "Include public recipes"),
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/VarietyPreference.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/model/VarietyPreference.kt
@@ -1,0 +1,7 @@
+package com.tenmilelabs.chefai.mealplans.domain.model
+
+enum class VarietyPreference(val emoji: String, val label: String) {
+    HIGH("\uD83C\uDFA8", "Maximum variety"),
+    MEDIUM("\u2696\uFE0F", "Balanced"),
+    LOW("\u267B\uFE0F", "Repeat favorites"),
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/repository/MealPlanRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/repository/MealPlanRepository.kt
@@ -1,0 +1,14 @@
+package com.tenmilelabs.chefai.mealplans.domain.repository
+
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+interface MealPlanRepository {
+
+    fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlan>>
+
+    suspend fun createMealPlan(mealPlan: MealPlan)
+
+    suspend fun deleteMealPlan(uuid: UUID)
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansScreen.kt
@@ -1,23 +1,97 @@
 package com.tenmilelabs.chefai.mealplans.ui
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.util.EmptyContent
+import com.tenmilelabs.chefai.core.util.LoadingContent
+import com.tenmilelabs.chefai.mealplans.ui.components.MealPlanCard
+import java.util.UUID
 
 @Composable
-fun MealPlansScreen() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = "Meal Plans Screen",
-            style = MaterialTheme.typography.headlineLarge
-        )
+fun MealPlansScreen(
+    onCreateMealPlan: () -> Unit = {},
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
+    viewModel: MealPlansViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvents.collect { event ->
+            when (event) {
+                is MealPlansEvent.ShowSnackbar -> {
+                    snackbarHostState.showSnackbar(context.getString(event.message))
+                }
+            }
+        }
+    }
+
+    MealPlansContent(
+        uiState = uiState,
+        onDeleteMealPlan = viewModel::onDeleteMealPlan,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun MealPlansContent(
+    uiState: MealPlansUiState,
+    onDeleteMealPlan: (UUID) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (uiState) {
+        is MealPlansUiState.Loading -> {
+            LoadingContent(modifier = modifier)
+        }
+
+        is MealPlansUiState.Error -> {
+            EmptyContent(
+                title = R.string.meal_plan_error,
+                subtitle = R.string.no_meal_plans_subtitle,
+                noRecipesIconRes = R.drawable.ic_skillet_cooktop_24dp,
+                modifier = modifier,
+            )
+        }
+
+        is MealPlansUiState.Success -> {
+            if (uiState.mealPlans.isEmpty()) {
+                EmptyContent(
+                    title = R.string.no_meal_plans_title,
+                    subtitle = R.string.no_meal_plans_subtitle,
+                    noRecipesIconRes = R.drawable.ic_skillet_cooktop_24dp,
+                    modifier = modifier,
+                )
+            } else {
+                LazyColumn(
+                    modifier = modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    items(
+                        items = uiState.mealPlans,
+                        key = { it.uuid }
+                    ) { mealPlan ->
+                        MealPlanCard(
+                            mealPlan = mealPlan,
+                            onDelete = { onDeleteMealPlan(mealPlan.uuid) },
+                        )
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansViewModel.kt
@@ -1,16 +1,79 @@
 package com.tenmilelabs.chefai.mealplans.ui
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.auth.domain.model.UserSession
+import com.tenmilelabs.chefai.core.util.WhileUiSubscribed
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.util.UUID
+import java.util.concurrent.CancellationException
 import javax.inject.Inject
 
-@HiltViewModel
-class MealPlansViewModel @Inject constructor() : ViewModel() {
+sealed interface MealPlansUiState {
+    data object Loading : MealPlansUiState
+    data class Success(val mealPlans: List<MealPlan>) : MealPlansUiState
+    data object Error : MealPlansUiState
+}
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is meal plans Fragment"
+sealed interface MealPlansEvent {
+    data class ShowSnackbar(val message: Int) : MealPlansEvent
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class MealPlansViewModel @Inject constructor(
+    private val mealPlanRepository: MealPlanRepository,
+    sessionManager: SessionManager,
+) : ViewModel() {
+
+    private val _uiEvent = MutableSharedFlow<MealPlansEvent>(replay = 1)
+    val uiEvents: SharedFlow<MealPlansEvent> = _uiEvent.asSharedFlow()
+
+    val uiState: StateFlow<MealPlansUiState> = sessionManager.userSession
+        .flatMapLatest { session ->
+            when (session) {
+                is UserSession.Loading -> emptyFlow()
+                is UserSession.Anonymous -> mealPlanRepository.observeMealPlansForUser(session.localUserId)
+                is UserSession.Authenticated -> mealPlanRepository.observeMealPlansForUser(session.user.uuid)
+            }
+        }
+        .map<List<MealPlan>, MealPlansUiState> { plans ->
+            MealPlansUiState.Success(plans)
+        }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            emit(MealPlansUiState.Error)
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = WhileUiSubscribed,
+            initialValue = MealPlansUiState.Loading
+        )
+
+    fun onDeleteMealPlan(uuid: UUID) {
+        viewModelScope.launch {
+            try {
+                mealPlanRepository.deleteMealPlan(uuid)
+                _uiEvent.emit(MealPlansEvent.ShowSnackbar(R.string.meal_plan_deleted))
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                _uiEvent.emit(MealPlansEvent.ShowSnackbar(R.string.meal_plan_error))
+            }
+        }
     }
-    val text: LiveData<String> = _text
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/MealPlanCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/MealPlanCard.kt
@@ -1,0 +1,111 @@
+package com.tenmilelabs.chefai.mealplans.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+
+@Composable
+fun MealPlanCard(
+    mealPlan: MealPlan,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = mealPlan.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                StatusBadge(status = mealPlan.status)
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Delete meal plan",
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = buildPreferenceSummary(mealPlan),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusBadge(
+    status: MealPlanStatus,
+    modifier: Modifier = Modifier,
+) {
+    val (text, color) = when (status) {
+        MealPlanStatus.DRAFT -> "📝 Draft" to MaterialTheme.colorScheme.tertiary
+        MealPlanStatus.GENERATING -> "⏳ Generating" to MaterialTheme.colorScheme.primary
+        MealPlanStatus.READY -> "✅ Ready" to MaterialTheme.colorScheme.primary
+        MealPlanStatus.ARCHIVED -> "📦 Archived" to MaterialTheme.colorScheme.outline
+    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = color,
+        modifier = modifier.padding(end = 4.dp),
+    )
+}
+
+private fun buildPreferenceSummary(mealPlan: MealPlan): String {
+    val prefs = mealPlan.preferences
+    val parts = mutableListOf<String>()
+
+    parts.add("${prefs.mealType.emoji} ${prefs.planLengthDays} days")
+    parts.add("👥 ${prefs.servingsPerMeal} servings")
+
+    val dietary = prefs.dietaryRestrictions.filter {
+        it != com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction.NONE
+    }
+    if (dietary.isNotEmpty()) {
+        parts.add(dietary.joinToString(" ") { it.emoji })
+    }
+
+    if (prefs.batchCooking) parts.add("❄️ Batch")
+    if (prefs.leftoverFriendly) parts.add("♻️ Leftovers")
+
+    return parts.joinToString(" · ")
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/MealPlanCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/MealPlanCard.kt
@@ -19,9 +19,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
 import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanPreferences
 import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import com.tenmilelabs.chefai.mealplans.domain.model.MealType
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
+import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
+import java.util.UUID
 
 @Composable
 fun MealPlanCard(
@@ -88,6 +96,90 @@ private fun StatusBadge(
         color = color,
         modifier = modifier.padding(end = 4.dp),
     )
+}
+
+private val previewPreferences = MealPlanPreferences(
+    planLengthDays = 5,
+    mealType = MealType.DINNER_AND_LUNCH,
+    dietaryRestrictions = setOf(DietaryRestriction.VEGAN),
+    recipeSource = RecipeSource.INCLUDE_PUBLIC,
+    maxPrepTimeMinutes = 30,
+    servingsPerMeal = 4,
+    batchCooking = true,
+    leftoverFriendly = false,
+    varietyPreference = VarietyPreference.HIGH,
+)
+
+@Preview(name = "Draft — Light", showBackground = true)
+@Composable
+private fun MealPlanCardDraftLightPreview() {
+    ChefAITheme(darkTheme = false) {
+        MealPlanCard(
+            mealPlan = MealPlan(
+                uuid = UUID.randomUUID(),
+                userId = UUID.randomUUID(),
+                name = "5-day meal plan",
+                status = MealPlanStatus.DRAFT,
+                preferences = previewPreferences,
+                createdAt = System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis(),
+                days = emptyList(),
+            ),
+            onDelete = {},
+        )
+    }
+}
+
+@Preview(name = "Ready — Dark", showBackground = true)
+@Composable
+private fun MealPlanCardReadyDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        MealPlanCard(
+            mealPlan = MealPlan(
+                uuid = UUID.randomUUID(),
+                userId = UUID.randomUUID(),
+                name = "7-day batch cook plan",
+                status = MealPlanStatus.READY,
+                preferences = previewPreferences.copy(
+                    planLengthDays = 7,
+                    mealType = MealType.DINNER,
+                    dietaryRestrictions = setOf(DietaryRestriction.LOW_CARB, DietaryRestriction.GLUTEN_FREE),
+                    batchCooking = true,
+                    leftoverFriendly = true,
+                ),
+                createdAt = System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis(),
+                days = emptyList(),
+            ),
+            onDelete = {},
+        )
+    }
+}
+
+@Preview(name = "Generating — Light", showBackground = true)
+@Composable
+private fun MealPlanCardGeneratingLightPreview() {
+    ChefAITheme(darkTheme = false) {
+        MealPlanCard(
+            mealPlan = MealPlan(
+                uuid = UUID.randomUUID(),
+                userId = UUID.randomUUID(),
+                name = "3-day quick plan",
+                status = MealPlanStatus.GENERATING,
+                preferences = previewPreferences.copy(
+                    planLengthDays = 3,
+                    mealType = MealType.DINNER,
+                    dietaryRestrictions = emptySet(),
+                    maxPrepTimeMinutes = 20,
+                    servingsPerMeal = 2,
+                ),
+                createdAt = System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis(),
+                days = emptyList(),
+            ),
+            onDelete = {},
+        )
+    }
 }
 
 private fun buildPreferenceSummary(mealPlan: MealPlan): String {

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/WizardProgressBar.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/WizardProgressBar.kt
@@ -1,0 +1,64 @@
+package com.tenmilelabs.chefai.mealplans.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+
+private val stepLabels = listOf(
+    R.string.wizard_step_basics,
+    R.string.wizard_step_preferences,
+    R.string.wizard_step_extras,
+)
+
+@Composable
+fun WizardProgressBar(
+    currentStep: Int,
+    totalSteps: Int,
+    modifier: Modifier = Modifier,
+) {
+    val progress by animateFloatAsState(
+        targetValue = (currentStep + 1f) / totalSteps,
+        animationSpec = tween(durationMillis = 300),
+        label = "wizard_progress",
+    )
+
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            stepLabels.forEachIndexed { index, labelRes ->
+                Text(
+                    text = stringResource(labelRes),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = if (index == currentStep) FontWeight.Bold else FontWeight.Normal,
+                    color = if (index <= currentStep) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.outline
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth().height(6.dp),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanUiState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanUiState.kt
@@ -1,0 +1,43 @@
+package com.tenmilelabs.chefai.mealplans.ui.create
+
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+import com.tenmilelabs.chefai.mealplans.domain.model.MealType
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
+import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
+
+data class CreateMealPlanUiState(
+    val currentStep: Int = 0,
+    val totalSteps: Int = 3,
+    // Step 1: Basics
+    val planLengthDays: Int = 5,
+    val mealType: MealType = MealType.DINNER,
+    val servingsPerMeal: Int = 2,
+    // Step 2: Preferences
+    val dietaryRestrictions: Set<DietaryRestriction> = emptySet(),
+    val recipeSource: RecipeSource = RecipeSource.COLLECTION_ONLY,
+    val maxPrepTimeMinutes: Int? = null,
+    // Step 3: Advanced
+    val batchCooking: Boolean = false,
+    val leftoverFriendly: Boolean = false,
+    val varietyPreference: VarietyPreference = VarietyPreference.MEDIUM,
+    // Status
+    val isSaving: Boolean = false,
+)
+
+sealed interface WizardAction {
+    data class SetPlanLength(val days: Int) : WizardAction
+    data class SetMealType(val type: MealType) : WizardAction
+    data class SetServings(val count: Int) : WizardAction
+    data class ToggleDietaryRestriction(val restriction: DietaryRestriction) : WizardAction
+    data class SetRecipeSource(val source: RecipeSource) : WizardAction
+    data class SetMaxPrepTime(val minutes: Int?) : WizardAction
+    data class SetBatchCooking(val enabled: Boolean) : WizardAction
+    data class SetLeftoverFriendly(val enabled: Boolean) : WizardAction
+    data class SetVarietyPreference(val preference: VarietyPreference) : WizardAction
+    data object SaveMealPlan : WizardAction
+}
+
+sealed interface CreateMealPlanEvent {
+    data object MealPlanCreated : CreateMealPlanEvent
+    data class ShowError(val message: Int) : CreateMealPlanEvent
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModel.kt
@@ -1,0 +1,107 @@
+package com.tenmilelabs.chefai.mealplans.ui.create
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanPreferences
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.concurrent.CancellationException
+import javax.inject.Inject
+
+@HiltViewModel
+class CreateMealPlanViewModel @Inject constructor(
+    private val mealPlanRepository: MealPlanRepository,
+    private val sessionManager: SessionManager,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CreateMealPlanUiState())
+    val uiState: StateFlow<CreateMealPlanUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<CreateMealPlanEvent>()
+    val uiEvents: SharedFlow<CreateMealPlanEvent> = _uiEvent.asSharedFlow()
+
+    fun onAction(action: WizardAction) {
+        when (action) {
+            is WizardAction.SetPlanLength -> _uiState.update { it.copy(planLengthDays = action.days) }
+            is WizardAction.SetMealType -> _uiState.update { it.copy(mealType = action.type) }
+            is WizardAction.SetServings -> _uiState.update { it.copy(servingsPerMeal = action.count.coerceIn(1, 12)) }
+            is WizardAction.ToggleDietaryRestriction -> toggleDietaryRestriction(action.restriction)
+            is WizardAction.SetRecipeSource -> _uiState.update { it.copy(recipeSource = action.source) }
+            is WizardAction.SetMaxPrepTime -> _uiState.update { it.copy(maxPrepTimeMinutes = action.minutes) }
+            is WizardAction.SetBatchCooking -> _uiState.update { it.copy(batchCooking = action.enabled) }
+            is WizardAction.SetLeftoverFriendly -> _uiState.update { it.copy(leftoverFriendly = action.enabled) }
+            is WizardAction.SetVarietyPreference -> _uiState.update { it.copy(varietyPreference = action.preference) }
+            is WizardAction.SaveMealPlan -> saveMealPlan()
+        }
+    }
+
+    private fun toggleDietaryRestriction(restriction: DietaryRestriction) {
+        _uiState.update { state ->
+            val current = state.dietaryRestrictions
+            val updated = if (restriction == DietaryRestriction.NONE) {
+                // Selecting "None" clears all others
+                if (DietaryRestriction.NONE in current) emptySet() else setOf(DietaryRestriction.NONE)
+            } else {
+                // Selecting a specific restriction removes NONE
+                val withoutNone = current - DietaryRestriction.NONE
+                if (restriction in withoutNone) withoutNone - restriction else withoutNone + restriction
+            }
+            state.copy(dietaryRestrictions = updated)
+        }
+    }
+
+    private fun saveMealPlan() {
+        val userId = sessionManager.getCurrentUserId() ?: return
+        val state = _uiState.value
+        if (state.isSaving) return
+
+        _uiState.update { it.copy(isSaving = true) }
+
+        viewModelScope.launch {
+            try {
+                val now = System.currentTimeMillis()
+                val mealPlan = MealPlan(
+                    uuid = UuidV7Generator.newId(),
+                    userId = userId,
+                    name = "${state.planLengthDays}-day meal plan",
+                    preferences = MealPlanPreferences(
+                        planLengthDays = state.planLengthDays,
+                        mealType = state.mealType,
+                        dietaryRestrictions = state.dietaryRestrictions,
+                        recipeSource = state.recipeSource,
+                        maxPrepTimeMinutes = state.maxPrepTimeMinutes,
+                        servingsPerMeal = state.servingsPerMeal,
+                        batchCooking = state.batchCooking,
+                        leftoverFriendly = state.leftoverFriendly,
+                        varietyPreference = state.varietyPreference,
+                    ),
+                    status = MealPlanStatus.DRAFT,
+                    createdAt = now,
+                    updatedAt = now,
+                    days = emptyList(),
+                )
+                mealPlanRepository.createMealPlan(mealPlan)
+                _uiEvent.emit(CreateMealPlanEvent.MealPlanCreated)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                _uiEvent.emit(CreateMealPlanEvent.ShowError(R.string.meal_plan_save_error))
+            } finally {
+                _uiState.update { it.copy(isSaving = false) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardAdvancedScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardAdvancedScreen.kt
@@ -1,0 +1,145 @@
+package com.tenmilelabs.chefai.mealplans.ui.create
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
+import com.tenmilelabs.chefai.mealplans.ui.components.WizardProgressBar
+import com.tenmilelabs.chefai.mealplans.ui.create.components.ToggleOptionRow
+
+@Composable
+fun WizardAdvancedScreen(
+    viewModel: CreateMealPlanViewModel,
+    onDone: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    WizardAdvancedContent(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onBack = onBack,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun WizardAdvancedContent(
+    uiState: CreateMealPlanUiState,
+    onAction: (WizardAction) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        WizardProgressBar(
+            currentStep = 2,
+            totalSteps = uiState.totalSteps,
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            Text(
+                text = "Final touches ✨",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+
+            ToggleOptionRow(
+                title = stringResource(R.string.wizard_batch_cooking_title),
+                subtitle = stringResource(R.string.wizard_batch_cooking_subtitle),
+                checked = uiState.batchCooking,
+                onCheckedChange = { onAction(WizardAction.SetBatchCooking(it)) },
+            )
+
+            ToggleOptionRow(
+                title = stringResource(R.string.wizard_leftover_title),
+                subtitle = stringResource(R.string.wizard_leftover_subtitle),
+                checked = uiState.leftoverFriendly,
+                onCheckedChange = { onAction(WizardAction.SetLeftoverFriendly(it)) },
+            )
+
+            Column {
+                Text(
+                    text = stringResource(R.string.wizard_variety_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 12.dp),
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    VarietyPreference.entries.forEach { pref ->
+                        FilterChip(
+                            selected = uiState.varietyPreference == pref,
+                            onClick = { onAction(WizardAction.SetVarietyPreference(pref)) },
+                            label = { Text("${pref.emoji} ${pref.label}") },
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier.weight(1f),
+                enabled = !uiState.isSaving,
+            ) {
+                Text(stringResource(R.string.wizard_back))
+            }
+            Button(
+                onClick = { onAction(WizardAction.SaveMealPlan) },
+                modifier = Modifier.weight(1f),
+                enabled = !uiState.isSaving,
+            ) {
+                if (uiState.isSaving) {
+                    CircularProgressIndicator(
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text(stringResource(R.string.wizard_create_plan))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardBasicsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardBasicsScreen.kt
@@ -1,0 +1,97 @@
+package com.tenmilelabs.chefai.mealplans.ui.create
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.mealplans.ui.components.WizardProgressBar
+import com.tenmilelabs.chefai.mealplans.ui.create.components.DayLengthSelector
+import com.tenmilelabs.chefai.mealplans.ui.create.components.MealTypeSelector
+import com.tenmilelabs.chefai.mealplans.ui.create.components.ServingsSelector
+
+@Composable
+fun WizardBasicsScreen(
+    viewModel: CreateMealPlanViewModel,
+    onNext: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    WizardBasicsContent(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onNext = onNext,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun WizardBasicsContent(
+    uiState: CreateMealPlanUiState,
+    onAction: (WizardAction) -> Unit,
+    onNext: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        WizardProgressBar(
+            currentStep = 0,
+            totalSteps = uiState.totalSteps,
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            Text(
+                text = "Let's plan your meals! 🍳",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+
+            DayLengthSelector(
+                selectedDays = uiState.planLengthDays,
+                onDaysSelected = { onAction(WizardAction.SetPlanLength(it)) },
+            )
+
+            MealTypeSelector(
+                selectedType = uiState.mealType,
+                onTypeSelected = { onAction(WizardAction.SetMealType(it)) },
+            )
+
+            ServingsSelector(
+                servings = uiState.servingsPerMeal,
+                onServingsChanged = { onAction(WizardAction.SetServings(it)) },
+            )
+        }
+
+        Button(
+            onClick = onNext,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+        ) {
+            Text(stringResource(R.string.wizard_next))
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardPreferencesScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardPreferencesScreen.kt
@@ -1,0 +1,111 @@
+package com.tenmilelabs.chefai.mealplans.ui.create
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
+import com.tenmilelabs.chefai.mealplans.ui.components.WizardProgressBar
+import com.tenmilelabs.chefai.mealplans.ui.create.components.DietaryChipGroup
+import com.tenmilelabs.chefai.mealplans.ui.create.components.PrepTimeSelector
+import com.tenmilelabs.chefai.mealplans.ui.create.components.RecipeSourceSelector
+
+@Composable
+fun WizardPreferencesScreen(
+    viewModel: CreateMealPlanViewModel,
+    onNext: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    WizardPreferencesContent(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onNext = onNext,
+        onBack = onBack,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun WizardPreferencesContent(
+    uiState: CreateMealPlanUiState,
+    onAction: (WizardAction) -> Unit,
+    onNext: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        WizardProgressBar(
+            currentStep = 1,
+            totalSteps = uiState.totalSteps,
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(32.dp),
+        ) {
+            Text(
+                text = "Tell us your preferences 🎯",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+
+            DietaryChipGroup(
+                selectedRestrictions = uiState.dietaryRestrictions,
+                onToggle = { onAction(WizardAction.ToggleDietaryRestriction(it)) },
+            )
+
+            RecipeSourceSelector(
+                selectedSource = uiState.recipeSource,
+                onSourceSelected = { onAction(WizardAction.SetRecipeSource(it)) },
+            )
+
+            PrepTimeSelector(
+                selectedMinutes = uiState.maxPrepTimeMinutes,
+                onMinutesSelected = { onAction(WizardAction.SetMaxPrepTime(it)) },
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(R.string.wizard_back))
+            }
+            Button(
+                onClick = onNext,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(R.string.wizard_next))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/DayLengthSelector.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/DayLengthSelector.kt
@@ -1,0 +1,56 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun DayLengthSelector(
+    selectedDays: Int,
+    onDaysSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.wizard_plan_length_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            (1..7).forEach { day ->
+                val label = if (day == 1) {
+                    stringResource(R.string.wizard_day_format, day)
+                } else {
+                    stringResource(R.string.wizard_days_format, day)
+                }
+                FilterChip(
+                    selected = selectedDays == day,
+                    onClick = { onDaysSelected(day) },
+                    label = { Text(label) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/DietaryChipGroup.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/DietaryChipGroup.kt
@@ -1,0 +1,52 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun DietaryChipGroup(
+    selectedRestrictions: Set<DietaryRestriction>,
+    onToggle: (DietaryRestriction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.wizard_dietary_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            DietaryRestriction.entries.forEach { restriction ->
+                FilterChip(
+                    selected = restriction in selectedRestrictions,
+                    onClick = { onToggle(restriction) },
+                    label = { Text("${restriction.emoji} ${restriction.label}") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/MealTypeSelector.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/MealTypeSelector.kt
@@ -1,0 +1,51 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.mealplans.domain.model.MealType
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun MealTypeSelector(
+    selectedType: MealType,
+    onTypeSelected: (MealType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.wizard_meal_type_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            MealType.entries.forEach { type ->
+                FilterChip(
+                    selected = selectedType == type,
+                    onClick = { onTypeSelected(type) },
+                    label = { Text("${type.emoji} ${type.label}") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/PrepTimeSelector.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/PrepTimeSelector.kt
@@ -1,0 +1,58 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+
+private val prepTimeOptions: List<Int?> = listOf(15, 30, 45, 60, null)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PrepTimeSelector(
+    selectedMinutes: Int?,
+    onMinutesSelected: (Int?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.wizard_prep_time_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            prepTimeOptions.forEach { minutes ->
+                val label = if (minutes != null) {
+                    "⏱️ ${stringResource(R.string.wizard_minutes_format, minutes)}"
+                } else {
+                    "⏱️ ${stringResource(R.string.wizard_no_limit)}"
+                }
+                FilterChip(
+                    selected = selectedMinutes == minutes,
+                    onClick = { onMinutesSelected(minutes) },
+                    label = { Text(label) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/RecipeSourceSelector.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/RecipeSourceSelector.kt
@@ -1,0 +1,51 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun RecipeSourceSelector(
+    selectedSource: RecipeSource,
+    onSourceSelected: (RecipeSource) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.wizard_recipe_source_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            RecipeSource.entries.forEach { source ->
+                FilterChip(
+                    selected = selectedSource == source,
+                    onClick = { onSourceSelected(source) },
+                    label = { Text("${source.emoji} ${source.label}") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/ServingsSelector.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/ServingsSelector.kt
@@ -1,0 +1,70 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+
+@Composable
+fun ServingsSelector(
+    servings: Int,
+    onServingsChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.wizard_servings_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            FilledIconButton(
+                onClick = { onServingsChanged(servings - 1) },
+                enabled = servings > 1,
+                modifier = Modifier.size(40.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
+            ) {
+                Text("−", style = MaterialTheme.typography.titleLarge)
+            }
+
+            Text(
+                text = "👥 $servings",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+            )
+
+            FilledIconButton(
+                onClick = { onServingsChanged(servings + 1) },
+                enabled = servings < 12,
+                modifier = Modifier.size(40.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                ),
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Increase servings")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/ToggleOptionRow.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/ToggleOptionRow.kt
@@ -1,0 +1,50 @@
+package com.tenmilelabs.chefai.mealplans.ui.create.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ToggleOptionRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,4 +118,37 @@
     <string name="error_registration_failed">Registration failed. Please try again.</string>
     <string name="error_loading_home">Error Loading Home Screen</string>
 
+    <!-- Meal Plans -->
+    <string name="no_meal_plans_title">No meal plans yet</string>
+    <string name="no_meal_plans_subtitle">Tap + to create your first meal plan and let us help you eat well this week!</string>
+    <string name="meal_plan_error">Failed to load meal plans</string>
+    <string name="meal_plan_deleted">Meal plan deleted</string>
+    <string name="meal_plan_created">Meal plan created! 🎉</string>
+    <string name="meal_plan_save_error">Failed to save meal plan</string>
+    <string name="meal_plan_default_name">Week plan</string>
+
+    <!-- Meal Plan Wizard -->
+    <string name="app_dest_title_meal_plan_wizard">Create Meal Plan</string>
+    <string name="wizard_step_basics">📋 The Basics</string>
+    <string name="wizard_step_preferences">🎯 Preferences</string>
+    <string name="wizard_step_extras">✨ Final Touches</string>
+    <string name="wizard_plan_length_title">📅 How many days?</string>
+    <string name="wizard_meal_type_title">🍽️ Which meals?</string>
+    <string name="wizard_servings_title">👥 How many servings?</string>
+    <string name="wizard_dietary_title">🥗 Any dietary preferences?</string>
+    <string name="wizard_recipe_source_title">📖 Where should recipes come from?</string>
+    <string name="wizard_prep_time_title">⏱️ Max prep time per meal?</string>
+    <string name="wizard_batch_cooking_title">❄️ Batch cook &amp; freeze?</string>
+    <string name="wizard_batch_cooking_subtitle">Cook larger portions and freeze for later</string>
+    <string name="wizard_leftover_title">♻️ Use leftovers across days?</string>
+    <string name="wizard_leftover_subtitle">Repurpose leftovers into new meals</string>
+    <string name="wizard_variety_title">🎨 How much variety?</string>
+    <string name="wizard_next">Next</string>
+    <string name="wizard_back">Back</string>
+    <string name="wizard_create_plan">Create Plan 🎉</string>
+    <string name="wizard_no_limit">No limit</string>
+    <string name="wizard_minutes_format">%1$d min</string>
+    <string name="wizard_days_format">%1$d days</string>
+    <string name="wizard_day_format">%1$d day</string>
+
 </resources>

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/domain/SessionManagerTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/domain/SessionManagerTest.kt
@@ -14,6 +14,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeStepDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
@@ -76,7 +77,8 @@ class SessionManagerTest {
                 recipeIngredientDao = fakeRecipeIngredientDao,
                 recipeTagCrossRefDao = fakeRecipeTagCrossRefDao,
                 recipeLabelCrossRefDao = fakeRecipeLabelCrossRefDao,
-                bookmarkedRecipeDao = FakeBookmarkedRecipeDao()
+                bookmarkedRecipeDao = FakeBookmarkedRecipeDao(),
+                mealPlanDao = FakeMealPlanDao(),
             )
         }
 
@@ -646,7 +648,7 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `login as different user after logout preserves new anonymous data but removes previous authenticated data`() = testScope.runTest {
+    fun `login as different user after logout preserves new anonymous data and removes previous authenticated recipes but keeps user entity`() = testScope.runTest {
         sessionManager.loadSession()
         val initialAnonymousSession = sessionManager.userSession.first() as UserSession.Anonymous
 
@@ -693,7 +695,10 @@ class SessionManagerTest {
         coVerify(exactly = 0) { mockDatabase.clearAllTables() }
         val authSession = sessionManager.userSession.first() as UserSession.Authenticated
         assertThat(fakeRecipeDao.getRecipeById(user1Recipe.uuid)).isNull()
-        assertThat(fakeUserDao.getUserById(user1Id)).isNull()
+        // User entity is preserved so their meal plans survive an account switch and are
+        // available again when they log back in. Queries already filter by userId so the
+        // entity is invisible to the current user.
+        assertThat(fakeUserDao.getUserById(user1Id)).isNotNull()
         assertThat(fakeRecipeDao.getRecipeById(anonymousRecipe.uuid)?.creatorId).isEqualTo(authSession.user.uuid)
     }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/domain/usecase/AccountUpgradeUseCaseTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/domain/usecase/AccountUpgradeUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeStepDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
@@ -36,6 +37,7 @@ class AccountUpgradeUseCaseTest {
     private lateinit var fakeRecipeTagCrossRefDao: FakeRecipeTagCrossRefDao
     private lateinit var fakeRecipeLabelCrossRefDao: FakeRecipeLabelCrossRefDao
     private lateinit var bookmarkedRecipeDao: FakeBookmarkedRecipeDao
+    private lateinit var fakeMealPlanDao: FakeMealPlanDao
 
     private val anonymousId = UuidV7Generator.newId()
     private val authUser = User(
@@ -54,6 +56,7 @@ class AccountUpgradeUseCaseTest {
         fakeRecipeTagCrossRefDao = FakeRecipeTagCrossRefDao()
         fakeRecipeLabelCrossRefDao = FakeRecipeLabelCrossRefDao()
         bookmarkedRecipeDao = FakeBookmarkedRecipeDao()
+        fakeMealPlanDao = FakeMealPlanDao()
 
         useCase = AccountUpgradeUseCase(
             transactionRunner = FakeTransactionRunner(),
@@ -63,7 +66,8 @@ class AccountUpgradeUseCaseTest {
             recipeIngredientDao = fakeRecipeIngredientDao,
             recipeTagCrossRefDao = fakeRecipeTagCrossRefDao,
             recipeLabelCrossRefDao = fakeRecipeLabelCrossRefDao,
-            bookmarkedRecipeDao = bookmarkedRecipeDao
+            bookmarkedRecipeDao = bookmarkedRecipeDao,
+            mealPlanDao = fakeMealPlanDao,
         )
     }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/ui/LoginViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/ui/LoginViewModelTest.kt
@@ -17,6 +17,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeStepDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncManager
@@ -70,7 +71,7 @@ class LoginViewModelTest {
                     FakeTransactionRunner(), fakeUserDao, fakeRecipeDao,
                     FakeRecipeStepDao(), FakeRecipeIngredientDao(),
                     FakeRecipeTagCrossRefDao(), FakeRecipeLabelCrossRefDao(),
-                    FakeBookmarkedRecipeDao()
+                    FakeBookmarkedRecipeDao(), FakeMealPlanDao(),
                 )
             },
             syncSchedulerProvider = { FakeSyncManager() },

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/ui/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/ui/RegisterViewModelTest.kt
@@ -16,6 +16,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeStepDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncManager
@@ -69,7 +70,7 @@ class RegisterViewModelTest {
                     FakeTransactionRunner(), fakeUserDao, fakeRecipeDao,
                     FakeRecipeStepDao(), FakeRecipeIngredientDao(),
                     FakeRecipeTagCrossRefDao(), FakeRecipeLabelCrossRefDao(),
-                    FakeBookmarkedRecipeDao()
+                    FakeBookmarkedRecipeDao(), FakeMealPlanDao(),
                 )
             },
             syncSchedulerProvider = { FakeSyncManager() },

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeMealPlanDao.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeMealPlanDao.kt
@@ -1,0 +1,82 @@
+package com.tenmilelabs.chefai.core.data.local.room.dao
+
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanDayEntity
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanEntity
+import com.tenmilelabs.chefai.core.data.local.util.SyncState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+
+class FakeMealPlanDao : MealPlanDao {
+
+    private val plans = mutableMapOf<UUID, MealPlanEntity>()
+    private val days = mutableMapOf<UUID, MealPlanDayEntity>()
+    private val plansFlow = MutableStateFlow<Map<UUID, MealPlanEntity>>(emptyMap())
+
+    private fun notifyChange() {
+        plansFlow.value = plans.toMap()
+    }
+
+    override fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlanEntity>> =
+        plansFlow.map { map ->
+            map.values.filter { it.userId == userId && it.deletedAt == null }
+                .sortedByDescending { it.createdAt }
+        }
+
+    override suspend fun getMealPlanById(uuid: UUID): MealPlanEntity? = plans[uuid]
+
+    override fun observeMealPlanById(uuid: UUID): Flow<MealPlanEntity?> =
+        plansFlow.map { it[uuid] }
+
+    override suspend fun upsertMealPlan(mealPlan: MealPlanEntity) {
+        plans[mealPlan.uuid] = mealPlan
+        notifyChange()
+    }
+
+    override suspend fun softDelete(uuid: UUID, deletedAt: Long) {
+        plans[uuid]?.let {
+            plans[uuid] = it.copy(deletedAt = deletedAt, syncState = SyncState.DELETED, updatedAt = deletedAt)
+        }
+        notifyChange()
+    }
+
+    override suspend fun getAllDirty(): List<MealPlanEntity> =
+        plans.values.filter { it.syncState == SyncState.PENDING || it.syncState == SyncState.DELETED }
+
+    override suspend fun updateSyncState(uuid: UUID, syncState: SyncState, updatedAt: Long) {
+        plans[uuid]?.let {
+            plans[uuid] = it.copy(syncState = syncState, updatedAt = updatedAt)
+        }
+        notifyChange()
+    }
+
+    override suspend fun reassignUserAndMarkPending(oldUserId: UUID, newUserId: UUID, updatedAt: Long) {
+        val toReassign = plans.values.filter { it.userId == oldUserId }.toList()
+        for (entity in toReassign) {
+            plans[entity.uuid] = entity.copy(
+                userId = newUserId,
+                syncState = SyncState.PENDING,
+                updatedAt = updatedAt
+            )
+        }
+        notifyChange()
+    }
+
+    override suspend fun countMealPlansForUser(userId: UUID): Int =
+        plans.values.count { it.userId == userId && it.deletedAt == null }
+
+    override fun observeDaysForMealPlan(mealPlanId: UUID): Flow<List<MealPlanDayEntity>> =
+        plansFlow.map { days.values.filter { it.mealPlanId == mealPlanId }.sortedBy { it.dayIndex } }
+
+    override suspend fun getDaysForMealPlan(mealPlanId: UUID): List<MealPlanDayEntity> =
+        days.values.filter { it.mealPlanId == mealPlanId }.sortedBy { it.dayIndex }
+
+    override suspend fun upsertDays(days: List<MealPlanDayEntity>) {
+        days.forEach { this.days[it.uuid] = it }
+    }
+
+    override suspend fun deleteDaysForMealPlan(mealPlanId: UUID) {
+        days.keys.removeAll(days.values.filter { it.mealPlanId == mealPlanId }.map { it.uuid }.toSet())
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
@@ -9,6 +9,7 @@ import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.FakeTransactionRunner
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
@@ -68,7 +69,8 @@ fun createTestSessionManager(
                 FakeRecipeIngredientDao(),
                 FakeRecipeTagCrossRefDao(),
                 FakeRecipeLabelCrossRefDao(),
-                FakeBookmarkedRecipeDao()
+                FakeBookmarkedRecipeDao(),
+                FakeMealPlanDao(),
             )
         },
         syncSchedulerProvider = { FakeSyncScheduler() },
@@ -106,7 +108,7 @@ fun createRealSessionManagerWithFakes(
                 FakeTransactionRunner(), fakeUserDao, FakeRecipeDao(),
                 FakeRecipeStepDao(), FakeRecipeIngredientDao(),
                 FakeRecipeTagCrossRefDao(), FakeRecipeLabelCrossRefDao(),
-                FakeBookmarkedRecipeDao()
+                FakeBookmarkedRecipeDao(), FakeMealPlanDao(),
             )
         },
         syncSchedulerProvider = { FakeSyncManager() },

--- a/app/src/test/java/com/tenmilelabs/chefai/mealplans/data/repository/FakeMealPlanRepository.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/mealplans/data/repository/FakeMealPlanRepository.kt
@@ -1,0 +1,36 @@
+package com.tenmilelabs.chefai.mealplans.data.repository
+
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+
+class FakeMealPlanRepository : MealPlanRepository {
+
+    private val plans = MutableStateFlow<List<MealPlan>>(emptyList())
+
+    var shouldThrowOnCreate: Boolean = false
+    var shouldThrowOnDelete: Boolean = false
+    var shouldThrowOnObserve: Boolean = false
+
+    override fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlan>> {
+        if (shouldThrowOnObserve) throw RuntimeException("Fake observe error")
+        return plans.map { list -> list.filter { it.userId == userId } }
+    }
+
+    override suspend fun createMealPlan(mealPlan: MealPlan) {
+        if (shouldThrowOnCreate) throw RuntimeException("Fake create error")
+        plans.value = plans.value + mealPlan
+    }
+
+    override suspend fun deleteMealPlan(uuid: UUID) {
+        if (shouldThrowOnDelete) throw RuntimeException("Fake delete error")
+        plans.value = plans.value.filter { it.uuid != uuid }
+    }
+
+    fun emitPlans(vararg mealPlans: MealPlan) {
+        plans.value = mealPlans.toList()
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansViewModelTest.kt
@@ -1,0 +1,220 @@
+package com.tenmilelabs.chefai.mealplans.ui
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.core.testutil.createTestSessionManager
+import com.tenmilelabs.chefai.core.util.MainCoroutineRule
+import com.tenmilelabs.chefai.mealplans.data.repository.FakeMealPlanRepository
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanPreferences
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import com.tenmilelabs.chefai.mealplans.domain.model.MealType
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
+import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+class MealPlansViewModelTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private lateinit var repository: FakeMealPlanRepository
+    private lateinit var sessionManager: SessionManager
+    private lateinit var viewModel: MealPlansViewModel
+
+    @Before
+    fun setup() {
+        repository = FakeMealPlanRepository()
+        sessionManager = createTestSessionManager(CoroutineScope(mainCoroutineRule.testDispatcher))
+        viewModel = MealPlansViewModel(
+            mealPlanRepository = repository,
+            sessionManager = sessionManager,
+        )
+    }
+
+    private fun makePlan(
+        userId: UUID,
+        name: String = "Test Plan",
+        status: MealPlanStatus = MealPlanStatus.DRAFT,
+    ) = MealPlan(
+        uuid = UUID.randomUUID(),
+        userId = userId,
+        name = name,
+        preferences = MealPlanPreferences(
+            planLengthDays = 5,
+            mealType = MealType.DINNER,
+            dietaryRestrictions = emptySet<DietaryRestriction>(),
+            recipeSource = RecipeSource.COLLECTION_ONLY,
+            maxPrepTimeMinutes = null,
+            servingsPerMeal = 2,
+            batchCooking = false,
+            leftoverFriendly = false,
+            varietyPreference = VarietyPreference.MEDIUM,
+        ),
+        status = status,
+        createdAt = System.currentTimeMillis(),
+        updatedAt = System.currentTimeMillis(),
+        days = emptyList(),
+    )
+
+    // --- Initial state ---
+
+    @Test
+    fun `initial uiState is Loading or immediately Success when session is pre-loaded`() = runTest {
+        // With UnconfinedTestDispatcher + a pre-loaded session the upstream emits synchronously,
+        // so the first observable state is Success(empty) rather than Loading.
+        viewModel.uiState.test {
+            val first = awaitItem()
+            assertThat(first is MealPlansUiState.Loading || first is MealPlansUiState.Success).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- Success states ---
+
+    @Test
+    fun `uiState is Success with empty list when no plans exist for user`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        repository.emitPlans() // empty
+
+        viewModel.uiState.test {
+            val state = awaitItem().let { if (it is MealPlansUiState.Loading) awaitItem() else it }
+            assertThat(state).isInstanceOf(MealPlansUiState.Success::class.java)
+            assertThat((state as MealPlansUiState.Success).mealPlans).isEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `uiState is Success with plans for the current user`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        val plan1 = makePlan(userId, "Plan A")
+        val plan2 = makePlan(userId, "Plan B")
+        repository.emitPlans(plan1, plan2)
+
+        viewModel.uiState.test {
+            val state = awaitItem().let { if (it is MealPlansUiState.Loading) awaitItem() else it }
+            assertThat(state).isInstanceOf(MealPlansUiState.Success::class.java)
+            val plans = (state as MealPlansUiState.Success).mealPlans
+            assertThat(plans).hasSize(2)
+            assertThat(plans.map { it.name }).containsExactly("Plan A", "Plan B")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `uiState excludes plans belonging to a different user`() = runTest {
+        val currentUserId = sessionManager.getCurrentUserId()!!
+        val otherUserId = UUID.randomUUID()
+        repository.emitPlans(
+            makePlan(currentUserId, "My Plan"),
+            makePlan(otherUserId, "Other Plan"),
+        )
+
+        viewModel.uiState.test {
+            val state = awaitItem().let { if (it is MealPlansUiState.Loading) awaitItem() else it }
+            val plans = (state as MealPlansUiState.Success).mealPlans
+            assertThat(plans).hasSize(1)
+            assertThat(plans.first().name).isEqualTo("My Plan")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `uiState updates reactively when plans change`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        val plan1 = makePlan(userId, "Plan A")
+        repository.emitPlans(plan1)
+
+        viewModel.uiState.test {
+            // Consume initial emission (1 plan)
+            val first = awaitItem().let { if (it is MealPlansUiState.Loading) awaitItem() else it }
+            assertThat((first as MealPlansUiState.Success).mealPlans).hasSize(1)
+
+            // Add a second plan
+            val plan2 = makePlan(userId, "Plan B")
+            repository.emitPlans(plan1, plan2)
+            val updated = awaitItem()
+            assertThat((updated as MealPlansUiState.Success).mealPlans).hasSize(2)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- Error state ---
+
+    @Test
+    fun `uiState is Error when repository throws`() = runTest {
+        val errorRepository = FakeMealPlanRepository().also { it.shouldThrowOnObserve = true }
+        val errorViewModel = MealPlansViewModel(
+            mealPlanRepository = errorRepository,
+            sessionManager = sessionManager,
+        )
+
+        errorViewModel.uiState.test {
+            val state = awaitItem().let { if (it is MealPlansUiState.Loading) awaitItem() else it }
+            assertThat(state).isInstanceOf(MealPlansUiState.Error::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- Delete ---
+
+    @Test
+    fun `onDeleteMealPlan removes plan from repository`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        val plan = makePlan(userId, "To Delete")
+        repository.emitPlans(plan)
+
+        viewModel.uiState.test {
+            awaitItem().let { if (it is MealPlansUiState.Loading) awaitItem() else it }
+
+            viewModel.onDeleteMealPlan(plan.uuid)
+
+            val updated = awaitItem()
+            assertThat((updated as MealPlansUiState.Success).mealPlans).isEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDeleteMealPlan emits ShowSnackbar with deleted message on success`() = runTest {
+        val userId = sessionManager.getCurrentUserId()!!
+        val plan = makePlan(userId)
+        repository.emitPlans(plan)
+
+        viewModel.uiEvents.test {
+            viewModel.onDeleteMealPlan(plan.uuid)
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(MealPlansEvent.ShowSnackbar::class.java)
+            assertThat((event as MealPlansEvent.ShowSnackbar).message)
+                .isEqualTo(R.string.meal_plan_deleted)
+        }
+    }
+
+    @Test
+    fun `onDeleteMealPlan emits ShowSnackbar with error message when repository throws`() = runTest {
+        repository.shouldThrowOnDelete = true
+        val userId = sessionManager.getCurrentUserId()!!
+        val plan = makePlan(userId)
+        repository.emitPlans(plan)
+
+        viewModel.uiEvents.test {
+            viewModel.onDeleteMealPlan(plan.uuid)
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(MealPlansEvent.ShowSnackbar::class.java)
+            assertThat((event as MealPlansEvent.ShowSnackbar).message)
+                .isEqualTo(R.string.meal_plan_error)
+        }
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModelTest.kt
@@ -1,0 +1,232 @@
+package com.tenmilelabs.chefai.mealplans.ui.create
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.core.testutil.createTestSessionManager
+import com.tenmilelabs.chefai.core.util.MainCoroutineRule
+import com.tenmilelabs.chefai.mealplans.data.repository.FakeMealPlanRepository
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+import com.tenmilelabs.chefai.mealplans.domain.model.MealType
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
+import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class CreateMealPlanViewModelTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private lateinit var repository: FakeMealPlanRepository
+    private lateinit var sessionManager: SessionManager
+    private lateinit var viewModel: CreateMealPlanViewModel
+
+    @Before
+    fun setup() {
+        repository = FakeMealPlanRepository()
+        sessionManager = createTestSessionManager(CoroutineScope(mainCoroutineRule.testDispatcher))
+        viewModel = CreateMealPlanViewModel(
+            mealPlanRepository = repository,
+            sessionManager = sessionManager,
+        )
+    }
+
+    // --- Default state ---
+
+    @Test
+    fun `initial state has correct defaults`() = runTest {
+        val state = viewModel.uiState.value
+        assertThat(state.planLengthDays).isEqualTo(5)
+        assertThat(state.mealType).isEqualTo(MealType.DINNER)
+        assertThat(state.servingsPerMeal).isEqualTo(2)
+        assertThat(state.dietaryRestrictions).isEmpty()
+        assertThat(state.recipeSource).isEqualTo(RecipeSource.COLLECTION_ONLY)
+        assertThat(state.maxPrepTimeMinutes).isNull()
+        assertThat(state.batchCooking).isFalse()
+        assertThat(state.leftoverFriendly).isFalse()
+        assertThat(state.varietyPreference).isEqualTo(VarietyPreference.MEDIUM)
+        assertThat(state.isSaving).isFalse()
+    }
+
+    // --- Step 1: Basics ---
+
+    @Test
+    fun `SetPlanLength updates planLengthDays`() = runTest {
+        viewModel.onAction(WizardAction.SetPlanLength(7))
+        assertThat(viewModel.uiState.value.planLengthDays).isEqualTo(7)
+    }
+
+    @Test
+    fun `SetMealType updates mealType`() = runTest {
+        viewModel.onAction(WizardAction.SetMealType(MealType.DINNER_AND_LUNCH))
+        assertThat(viewModel.uiState.value.mealType).isEqualTo(MealType.DINNER_AND_LUNCH)
+    }
+
+    @Test
+    fun `SetServings updates servingsPerMeal`() = runTest {
+        viewModel.onAction(WizardAction.SetServings(4))
+        assertThat(viewModel.uiState.value.servingsPerMeal).isEqualTo(4)
+    }
+
+    @Test
+    fun `SetServings clamps value to minimum of 1`() = runTest {
+        viewModel.onAction(WizardAction.SetServings(0))
+        assertThat(viewModel.uiState.value.servingsPerMeal).isEqualTo(1)
+    }
+
+    @Test
+    fun `SetServings clamps value to maximum of 12`() = runTest {
+        viewModel.onAction(WizardAction.SetServings(99))
+        assertThat(viewModel.uiState.value.servingsPerMeal).isEqualTo(12)
+    }
+
+    // --- Step 2: Preferences ---
+
+    @Test
+    fun `ToggleDietaryRestriction adds restriction when not selected`() = runTest {
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.VEGAN))
+        assertThat(viewModel.uiState.value.dietaryRestrictions).contains(DietaryRestriction.VEGAN)
+    }
+
+    @Test
+    fun `ToggleDietaryRestriction removes restriction when already selected`() = runTest {
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.VEGAN))
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.VEGAN))
+        assertThat(viewModel.uiState.value.dietaryRestrictions).doesNotContain(DietaryRestriction.VEGAN)
+    }
+
+    @Test
+    fun `ToggleDietaryRestriction selecting NONE clears others and sets NONE`() = runTest {
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.VEGAN))
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.GLUTEN_FREE))
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.NONE))
+        assertThat(viewModel.uiState.value.dietaryRestrictions).containsExactly(DietaryRestriction.NONE)
+    }
+
+    @Test
+    fun `ToggleDietaryRestriction toggling NONE twice clears everything`() = runTest {
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.NONE))
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.NONE))
+        assertThat(viewModel.uiState.value.dietaryRestrictions).isEmpty()
+    }
+
+    @Test
+    fun `ToggleDietaryRestriction selecting specific restriction removes NONE`() = runTest {
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.NONE))
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.VEGAN))
+        assertThat(viewModel.uiState.value.dietaryRestrictions).containsExactly(DietaryRestriction.VEGAN)
+    }
+
+    @Test
+    fun `SetRecipeSource updates recipeSource`() = runTest {
+        viewModel.onAction(WizardAction.SetRecipeSource(RecipeSource.INCLUDE_PUBLIC))
+        assertThat(viewModel.uiState.value.recipeSource).isEqualTo(RecipeSource.INCLUDE_PUBLIC)
+    }
+
+    @Test
+    fun `SetMaxPrepTime updates maxPrepTimeMinutes`() = runTest {
+        viewModel.onAction(WizardAction.SetMaxPrepTime(30))
+        assertThat(viewModel.uiState.value.maxPrepTimeMinutes).isEqualTo(30)
+    }
+
+    @Test
+    fun `SetMaxPrepTime with null clears the limit`() = runTest {
+        viewModel.onAction(WizardAction.SetMaxPrepTime(30))
+        viewModel.onAction(WizardAction.SetMaxPrepTime(null))
+        assertThat(viewModel.uiState.value.maxPrepTimeMinutes).isNull()
+    }
+
+    // --- Step 3: Advanced ---
+
+    @Test
+    fun `SetBatchCooking updates batchCooking`() = runTest {
+        viewModel.onAction(WizardAction.SetBatchCooking(true))
+        assertThat(viewModel.uiState.value.batchCooking).isTrue()
+    }
+
+    @Test
+    fun `SetLeftoverFriendly updates leftoverFriendly`() = runTest {
+        viewModel.onAction(WizardAction.SetLeftoverFriendly(true))
+        assertThat(viewModel.uiState.value.leftoverFriendly).isTrue()
+    }
+
+    @Test
+    fun `SetVarietyPreference updates varietyPreference`() = runTest {
+        viewModel.onAction(WizardAction.SetVarietyPreference(VarietyPreference.HIGH))
+        assertThat(viewModel.uiState.value.varietyPreference).isEqualTo(VarietyPreference.HIGH)
+    }
+
+    // --- Save ---
+
+    @Test
+    fun `SaveMealPlan emits MealPlanCreated on success`() = runTest {
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            assertThat(awaitItem()).isEqualTo(CreateMealPlanEvent.MealPlanCreated)
+        }
+    }
+
+    @Test
+    fun `SaveMealPlan persists plan with correct preferences`() = runTest {
+        viewModel.onAction(WizardAction.SetPlanLength(3))
+        viewModel.onAction(WizardAction.SetMealType(MealType.DINNER_AND_LUNCH))
+        viewModel.onAction(WizardAction.SetServings(4))
+        viewModel.onAction(WizardAction.ToggleDietaryRestriction(DietaryRestriction.VEGAN))
+
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            awaitItem()
+        }
+
+        val userId = sessionManager.getCurrentUserId()!!
+        val saved = repository.observeMealPlansForUser(userId).first()
+        assertThat(saved).hasSize(1)
+        val plan = saved.first()
+        assertThat(plan.preferences.planLengthDays).isEqualTo(3)
+        assertThat(plan.preferences.mealType).isEqualTo(MealType.DINNER_AND_LUNCH)
+        assertThat(plan.preferences.servingsPerMeal).isEqualTo(4)
+        assertThat(plan.preferences.dietaryRestrictions).containsExactly(DietaryRestriction.VEGAN)
+        assertThat(plan.name).contains("3")
+    }
+
+    @Test
+    fun `SaveMealPlan resets isSaving to false after success`() = runTest {
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            awaitItem()
+        }
+        assertThat(viewModel.uiState.value.isSaving).isFalse()
+    }
+
+    @Test
+    fun `SaveMealPlan emits ShowError when repository throws`() = runTest {
+        repository.shouldThrowOnCreate = true
+
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(CreateMealPlanEvent.ShowError::class.java)
+            assertThat((event as CreateMealPlanEvent.ShowError).message)
+                .isEqualTo(R.string.meal_plan_save_error)
+        }
+    }
+
+    @Test
+    fun `SaveMealPlan resets isSaving to false after error`() = runTest {
+        repository.shouldThrowOnCreate = true
+
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            awaitItem()
+        }
+        assertThat(viewModel.uiState.value.isSaving).isFalse()
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
@@ -18,6 +18,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeStepDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeTagDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
@@ -112,7 +113,7 @@ class DefaultRecipeRepositoryTest {
                     FakeTransactionRunner(), fakeUserDao, accountSwitchRecipeDao,
                     FakeRecipeStepDao(), FakeRecipeIngredientDao(),
                     FakeRecipeTagCrossRefDao(), FakeRecipeLabelCrossRefDao(),
-                    FakeBookmarkedRecipeDao()
+                    FakeBookmarkedRecipeDao(), FakeMealPlanDao(),
                 )
             },
             syncSchedulerProvider = { FakeSyncManager() },

--- a/docs/adrs/adr-009-navigation-scoped-viewmodel-for-wizards.md
+++ b/docs/adrs/adr-009-navigation-scoped-viewmodel-for-wizards.md
@@ -1,0 +1,58 @@
+# ADR 009 – Navigation-Scoped ViewModel for Multi-Screen Wizard Flows
+
+**Date:** March 2026
+**Status:** Accepted
+**Author:** Jose Mucientes
+
+---
+
+## Context
+
+The meal planning feature introduces a multi-screen wizard (3 steps: Basics → Preferences → Extras) that collects user preferences before creating a meal plan. State must be shared across all three screens and survive navigation between them, but should be destroyed when the user exits the wizard entirely (back to the Meal Plans list).
+
+Three patterns were considered:
+
+1. **Single ViewModel per screen** — each screen has its own VM; state is passed via `NavBackStackEntry` arguments between steps. Simple but breaks down when shared state grows: preferences form one cohesive object and serialising/deserialising it across navigation arguments is fragile.
+
+2. **Parent Activity / Application-scoped ViewModel** — survives the wizard but leaks beyond it. State is never cleaned up until the app is killed. Not appropriate here.
+
+3. **Navigation-graph-scoped ViewModel** — the wizard screens are wrapped in a nested `NavGraph`. The ViewModel is retrieved via `navController.getBackStackEntry(nestedGraphRoute)`, scoping its lifetime to the nested graph. When the user exits the graph (completes or cancels), the ViewModel is cleared automatically.
+
+---
+
+## Decision
+
+Use a **navigation-graph-scoped ViewModel** for multi-screen wizard flows.
+
+- Define a nested `NavGraph` for the wizard in `ChefAINavGraph.kt`.
+- All wizard screens obtain the shared ViewModel via:
+  ```kotlin
+  val parentEntry = navController.getBackStackEntry(MealPlanDestinations.CREATE_GRAPH)
+  val viewModel: CreateMealPlanViewModel = hiltViewModel(parentEntry)
+  ```
+- The ViewModel holds the full `MealPlanPreferences` draft state and exposes a single `StateFlow<CreateMealPlanUiState>`.
+- Individual screens dispatch typed `UiEvent`s to the ViewModel (e.g. `UpdatePlanLength`, `ToggleDietaryRestriction`). No screen owns a fragment of the state independently.
+
+---
+
+## Consequences
+
+**Positive:**
+- Wizard state is automatically cleaned up when the user exits the nested graph — no manual teardown.
+- All screens read from the same `StateFlow`; no state synchronisation bugs.
+- Easy to unit-test: the ViewModel has no navigation dependency, just a repository.
+- Pattern is reusable for any future wizard flows (e.g. onboarding, recipe import).
+
+**Negative / Trade-offs:**
+- Requires a nested `NavGraph` declaration. Slightly more boilerplate in `ChefAINavGraph.kt`.
+- `navController.getBackStackEntry()` crashes if called when the entry is no longer in the back stack (e.g. after pop). Must guard against this; the current implementation calls it only from composables within the nested graph.
+
+---
+
+## Applicability
+
+Use this pattern whenever:
+- 2+ screens need to share mutable state as part of a single user flow.
+- The state lifetime should be scoped to that flow, not the whole app.
+
+Do **not** use this pattern for persistent cross-feature state (e.g. current user session) — that belongs in a Singleton-scoped ViewModel or the repository layer.

--- a/docs/claude/decisions.md
+++ b/docs/claude/decisions.md
@@ -12,6 +12,7 @@ All ADRs live in [`docs/adrs/`](../adrs/). This file is a quick-reference index.
 | 004 | [Data Layer Composition](../adrs/adr-004-data-layer.md) | Nov 2025 | Dual-source repositories (Room + Ktor). Outbox = syncState field. |
 | 005 | [Feature-Based Packages](../adrs/adr-0005-feature-based-package-structure.md) | Nov 2025 | Feature packages over layer packages. Start in feature, move to core/ when shared. |
 | 006 | [Anonymous-First Sync](../adrs/adr-006-sync-protocol.md) | Feb 2026 | App works without login. Anonymous → Authenticated upgrade merges data. |
+| 009 | [Navigation-Scoped ViewModel for Wizards](../adrs/adr-009-navigation-scoped-viewmodel-for-wizards.md) | Mar 2026 | Multi-screen wizard flows use a nested NavGraph-scoped ViewModel; state lives exactly as long as the flow. |
 
 ## RFCs
 

--- a/docs/prompts/meal-plans-backend-prompt.md
+++ b/docs/prompts/meal-plans-backend-prompt.md
@@ -1,0 +1,237 @@
+# Backend Prompt: Meal Plans — Persistence & AI Generation
+
+> Generated: March 2026
+> Related PR: #118
+> Android feature branch: `claude/suspicious-kapitsa`
+
+---
+
+## Context
+
+The Android client has a fully implemented meal planning feature. Users configure a meal plan via a 3-step wizard and the plan is saved locally in Room as `DRAFT` status. The backend needs to:
+
+1. Persist meal plans and their days via the existing push/pull sync protocol
+2. Expose an AI generation endpoint that populates a plan's days with matching recipes
+
+The backend stack is **Kotlin + Ktor + PostgreSQL + Exposed DSL + JWT auth**. Follow the same patterns used for recipes/bookmarks sync.
+
+---
+
+## 1. Database Schema
+
+```sql
+CREATE TABLE meal_plans (
+    id          UUID        PRIMARY KEY,
+    user_id     UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name        TEXT        NOT NULL,
+    status      TEXT        NOT NULL,  -- DRAFT | GENERATING | READY | ARCHIVED
+    preferences JSONB       NOT NULL,
+    created_at  BIGINT      NOT NULL,
+    updated_at  BIGINT      NOT NULL,
+    deleted_at  BIGINT      NULL
+);
+
+CREATE INDEX idx_meal_plans_user_id    ON meal_plans(user_id);
+CREATE INDEX idx_meal_plans_updated_at ON meal_plans(updated_at);
+
+CREATE TABLE meal_plan_days (
+    id               UUID    PRIMARY KEY,
+    meal_plan_id     UUID    NOT NULL REFERENCES meal_plans(id) ON DELETE CASCADE,
+    day_index        INT     NOT NULL,  -- 0-based
+    dinner_recipe_id UUID    NULL REFERENCES recipes(id),
+    lunch_recipe_id  UUID    NULL REFERENCES recipes(id),
+    UNIQUE (meal_plan_id, day_index)
+);
+
+CREATE INDEX idx_meal_plan_days_meal_plan_id ON meal_plan_days(meal_plan_id);
+```
+
+**`preferences` JSONB shape** (mirrors `MealPlanPreferences` on the client):
+
+```json
+{
+  "planLengthDays": 5,
+  "mealType": "DINNER_AND_LUNCH",
+  "dietaryRestrictions": ["VEGAN", "GLUTEN_FREE"],
+  "recipeSource": "INCLUDE_PUBLIC",
+  "maxPrepTimeMinutes": 30,
+  "servingsPerMeal": 4,
+  "batchCooking": true,
+  "leftoverFriendly": false,
+  "varietyPreference": "HIGH"
+}
+```
+
+Enum values:
+- `mealType`: `DINNER` | `DINNER_AND_LUNCH`
+- `dietaryRestrictions`: `NONE` | `VEGAN` | `VEGETARIAN` | `LOW_CARB` | `GLUTEN_FREE` | `DAIRY_FREE` | `KETO` | `PALEO`
+- `recipeSource`: `COLLECTION_ONLY` | `INCLUDE_PUBLIC`
+- `varietyPreference`: `HIGH` | `MEDIUM` | `LOW`
+
+---
+
+## 2. Sync Protocol Extensions
+
+Extend the existing `POST /sync/push` and `GET /sync/pull` endpoints — **do not add new endpoints**. Add meal plans alongside the existing `recipes` / `bookmarkedRecipes` fields.
+
+### 2a. Push — Request
+
+Add `mealPlans: List<SyncMealPlanDto>` to `SyncPushRequest`:
+
+```json
+{
+  "recipes": [...],
+  "bookmarkedRecipes": [...],
+  "mealPlans": [
+    {
+      "uuid": "01957a7e-...",
+      "name": "My Week Plan",
+      "status": "DRAFT",
+      "preferencesJson": "{\"planLengthDays\":5,...}",
+      "createdAt": 1743000000000,
+      "updatedAt": 1743000001000,
+      "deletedAt": null,
+      "days": [
+        {
+          "uuid": "01957a7f-...",
+          "dayIndex": 0,
+          "dinnerRecipeId": null,
+          "lunchRecipeId": null
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Push logic (per meal plan):**
+- Upsert `meal_plans` row. Conflict resolution: last-writer-wins on `updated_at`.
+- Replace all `meal_plan_days` rows for this plan atomically (delete existing, insert new).
+- If `deleted_at` is non-null, soft-delete: keep row, set `deleted_at`, do not include in future pulls.
+- Return accepted/conflict/error per plan UUID, following the same shape as recipes.
+
+### Push — Response additions
+
+```json
+{
+  "accepted": [...],
+  "conflicts": [...],
+  "errors": [...],
+  "serverTimestamp": 1743000002000,
+  "mealPlans": {
+    "accepted": [{"uuid": "01957a7e-...", "serverUpdatedAt": 1743000002000}],
+    "conflicts": [],
+    "errors": []
+  }
+}
+```
+
+### 2b. Pull — Response
+
+Add `mealPlans: List<SyncMealPlanDto>` to `SyncPullResponse`:
+
+```json
+{
+  "recipes": [...],
+  "serverTimestamp": 1743000002000,
+  "hasMore": false,
+  "mealPlans": [
+    {
+      "uuid": "01957a7e-...",
+      "name": "My Week Plan",
+      "status": "READY",
+      "preferencesJson": "{...}",
+      "createdAt": 1743000000000,
+      "updatedAt": 1743000002000,
+      "deletedAt": null,
+      "days": [
+        {
+          "uuid": "01957a7f-...",
+          "dayIndex": 0,
+          "dinnerRecipeId": "recipe-uuid-1",
+          "lunchRecipeId": "recipe-uuid-2"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Pull filter: `WHERE user_id = :userId AND updated_at > :since`. Include soft-deleted plans (`deleted_at IS NOT NULL`) so the client can tombstone them locally. Nest `meal_plan_days` inside each plan in the response — no separate pull for days.
+
+---
+
+## 3. AI Generation Endpoint
+
+```
+POST /meal-plans/{mealPlanId}/generate
+Authorization: Bearer <jwt>
+```
+
+**What it does:**
+
+1. Validate the caller owns this meal plan.
+2. Set `status = GENERATING` immediately and return `202 Accepted` with the updated plan (so the client can show a loading state).
+3. Asynchronously (coroutine / background job):
+   - Query candidate recipes based on preferences (see filtering rules below).
+   - Assign recipes to days respecting variety/batch preferences.
+   - Upsert `meal_plan_days` rows.
+   - Set `status = READY`, update `updated_at`.
+   - The client will pick up the update on next pull.
+
+**Response (202):**
+```json
+{
+  "uuid": "01957a7e-...",
+  "status": "GENERATING",
+  "updatedAt": 1743000005000
+}
+```
+
+**Recipe candidate filtering rules** (from `preferences`):
+
+| Preference | Filter |
+|---|---|
+| `recipeSource = COLLECTION_ONLY` | `recipe_id IN (SELECT recipe_id FROM bookmarked_recipes WHERE user_id = :userId AND deleted_at IS NULL)` |
+| `recipeSource = INCLUDE_PUBLIC` | `privacy = 'PUBLIC'` OR bookmarked |
+| `dietaryRestrictions` (non-NONE) | recipes must be tagged with ALL selected restriction tags |
+| `maxPrepTimeMinutes` non-null | `prep_time_minutes + cook_time_minutes <= maxPrepTimeMinutes` |
+| `mealType = DINNER` | only populate `dinner_recipe_id`; leave `lunch_recipe_id = null` |
+| `mealType = DINNER_AND_LUNCH` | populate both slots per day |
+
+**Assignment rules:**
+- `varietyPreference = HIGH` → no repeat recipes across the plan
+- `varietyPreference = MEDIUM` → recipes may repeat after 3 days gap
+- `varietyPreference = LOW` → free repetition (pick highest-rated / most bookmarked)
+- `batchCooking = true` → prefer recipes that appear in consecutive days (intentional repeats for batch prep)
+- `servingsPerMeal` — pass through to the response; no filtering needed server-side (client uses it for shopping list generation later)
+- If not enough candidates exist to fill all slots: fill what's possible, set `status = READY` with partial days (nulls are valid).
+
+**Error response (404 / 403):**
+```json
+{"error": "NOT_FOUND", "message": "Meal plan not found or not owned by caller"}
+```
+
+---
+
+## 4. Client-side sync wiring needed (Android, follow-up PR)
+
+The Android client needs these additions to complete the integration — not in scope for this backend task but listed here so both sides are aligned:
+
+- Add `SyncMealPlanDto` / `SyncMealPlanDayDto` to `SyncDtos.kt`
+- Extend `SyncPushRequest` with `mealPlans`
+- Extend `SyncPullResponse` with `mealPlans`
+- Add meal plan push/pull logic to `SyncOrchestrator`
+- After a plan transitions to `GENERATING` or `READY` on pull, update local Room status and trigger UI update via the existing `MealPlansViewModel` flow
+
+---
+
+## 5. Definition of Done
+
+- [ ] Migration script creating `meal_plans` and `meal_plan_days` tables
+- [ ] `POST /sync/push` accepts and persists `mealPlans` array
+- [ ] `GET /sync/pull` returns `mealPlans` for the authenticated user filtered by `since`
+- [ ] `POST /meal-plans/{id}/generate` returns `202`, sets status to `GENERATING`, populates days async, then sets `READY`
+- [ ] Soft-deletes propagate correctly through push and appear in pull with `deletedAt` set
+- [ ] Unit tests for the generation candidate-filtering and assignment logic
+- [ ] Integration test: push DRAFT plan → call generate → pull → verify days populated


### PR DESCRIPTION
<!-- obsidian --><h2 data-heading="PR Summary — Meal Planning Feature + Auth Bug Fixes">PR Summary — Meal Planning Feature + Auth Bug Fixes</h2>
<h3 data-heading="What this PR contains">What this PR contains</h3>
<p>This PR has two distinct parts committed on <code>claude/suspicious-kapitsa</code>:</p>
<hr>
<h3 data-heading="Part 1 — Meal Plans Android UI (commits &#x60;a35689c&#x60;, &#x60;2c19344&#x60;)">Part 1 — Meal Plans Android UI (commits <code>a35689c</code>, <code>2c19344</code>)</h3>
<p><strong>New feature: Meal Plans tab (3rd bottom tab)</strong></p>
<p>The <code>mealplans/</code> feature package is fully built out from a stub. Users can view saved plans and create new ones through a 3-step wizard.</p>
<h4 data-heading="Navigation changes">Navigation changes</h4>
<ul>
<li><code>AppDestinations.kt</code> — added <code>CREATE_MEAL_PLAN_GRAPH</code> and 3 wizard step routes</li>
<li><code>ChefAINavGraph.kt</code> — added a <strong>nested NavGraph</strong> for the wizard so the shared ViewModel is scoped to the flow (see ADR-009 below). Bottom bar hides while the wizard is open.</li>
</ul>
<h4 data-heading="Domain layer (&#x60;mealplans/domain/&#x60;)">Domain layer (<code>mealplans/domain/</code>)</h4>

File | Purpose
-- | --
MealPlan.kt | Root domain model
MealPlanDay.kt | A single day in the plan (dinner + optional lunch recipe UUIDs)
MealPlanPreferences.kt | All user-configured preferences (serialised to JSON in Room)
MealPlanStatus.kt | DRAFT \\| GENERATING \\| READY \\| ARCHIVED
MealType.kt | DINNER \\| DINNER_AND_LUNCH
DietaryRestriction.kt | NONE \\| VEGAN \\| VEGETARIAN \\| LOW_CARB \\| GLUTEN_FREE \\| DAIRY_FREE \\| KETO \\| PALEO
RecipeSource.kt | COLLECTION_ONLY \\| INCLUDE_PUBLIC
VarietyPreference.kt | HIGH \\| MEDIUM \\| LOW
MealPlanRepository.kt | Repository interface


<h4 data-heading="Architecture decision">Architecture decision</h4>
<p><strong>ADR-009</strong> (<code>docs/adrs/adr-009-navigation-scoped-viewmodel-for-wizards.md</code>) — documents the navigation-graph-scoped ViewModel pattern used for the wizard. Worth reading before reviewing <code>ChefAINavGraph.kt</code> and <code>CreateMealPlanViewModel.kt</code>.</p>
<h4 data-heading="Backend spec">Backend spec</h4>
<p>The meal plan sync and AI generation backend work is fully specced in <strong><code>docs/prompts/meal-plans-backend-prompt.md</code></strong>. The Android client is local-only until that work is complete.</p>
<hr>
<h3 data-heading="Part 2 — Auth bug fixes for meal plan data (commit &#x60;42f2314&#x60;)">Part 2 — Auth bug fixes for meal plan data (commit <code>42f2314</code>)</h3>
<p>Three bugs found during testing, all in how meal plan data moves across auth state transitions. <strong>No backend changes required for these fixes.</strong></p>
<h4 data-heading="Bug 1 + 3 (same root): Anonymous plans invisible after login / visible after logout">Bug 1 + 3 (same root): Anonymous plans invisible after login / visible after logout</h4>
<p><strong>Root cause:</strong> <code>AccountUpgradeUseCase</code> migrated recipes and bookmarks from <code>anonUUID → authUUID</code> on login, but <strong>not meal plans</strong>. Since the anonymous <code>localUserId</code> is preserved across logout, plans created while anonymous stayed under <code>anonUUID</code> and would reappear after logout.</p>
<p><strong>Fix:</strong></p>
<ul>
<li><code>MealPlanDao</code> — added <code>reassignUserAndMarkPending(oldUserId, newUserId, updatedAt)</code> and <code>countMealPlansForUser(userId)</code></li>
<li><code>AccountUpgradeUseCase</code> — injected <code>MealPlanDao</code>, extended early-exit guard to check meal plan count, added meal plan reassignment inside the upgrade transaction</li>
</ul>
<h4 data-heading="Bug 2: Plans lost after cycling through another account">Bug 2: Plans lost after cycling through another account</h4>
<p><strong>Root cause:</strong> <code>AccountSwitchHandler.PRESERVED_ANONYMOUS_DATA</code> called <code>userDao.deleteUser(previousUserId)</code>, which cascade-deleted <code>meal_plans</code> (FK <code>ON DELETE CASCADE</code>). When the original user logged back in, their plans were gone.</p>
<p><strong>Fix:</strong></p>
<ul>
<li><code>AccountSwitchHandler</code> — removed <code>userDao.deleteUser(previousUserId)</code> from <code>PRESERVED_ANONYMOUS_DATA</code> branch. Only recipes are removed (server can restore them). The user entity is kept so their meal plans survive the switch. All queries already filter by <code>userId</code>, so the entity is invisible to other users.</li>
</ul>
<h4 data-heading="Test changes">Test changes</h4>
<ul>
<li><code>FakeMealPlanDao</code> — new in-memory fake following the existing fake DAO pattern</li>
<li><code>AccountUpgradeUseCaseTest</code>, <code>SessionManagerTest</code>, <code>LoginViewModelTest</code>, <code>RegisterViewModelTest</code>, <code>DefaultRecipeRepositoryTest</code>, <code>FakeSessionManager</code> — all updated to pass <code>FakeMealPlanDao</code> to <code>AccountUpgradeUseCase</code></li>
<li><code>SessionManagerTest</code> — updated assertion + test name to reflect the new contract (user entity preserved on account switch)</li>
</ul>