### PR TITLE
Meal Plan: Add Details Screen, Generation and Sync

### DIFF
--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestSyncModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestSyncModule.kt
@@ -5,6 +5,10 @@ import com.tenmilelabs.chefai.core.data.sync.ConnectivityObserver
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncNetworkDataSource
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncScheduler
 import com.tenmilelabs.chefai.core.data.sync.NetworkMonitor
+import com.tenmilelabs.chefai.core.data.sync.PullResult
+import com.tenmilelabs.chefai.core.data.sync.PushResult
+import com.tenmilelabs.chefai.core.data.sync.SyncExecutor
+import com.tenmilelabs.chefai.core.data.sync.SyncResult
 import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
 import com.tenmilelabs.chefai.core.data.sync.network.SyncNetworkDataSource
 import dagger.Module
@@ -35,6 +39,15 @@ object TestSyncModule {
     @Provides
     @Singleton
     fun provideFakeSyncScheduler(): SyncScheduler = FakeSyncScheduler()
+
+    @Provides
+    @Singleton
+    fun provideFakeSyncExecutor(): SyncExecutor = object : SyncExecutor {
+        override suspend fun sync(): SyncResult = SyncResult(
+            pushResult = PushResult(accepted = 0, conflicts = 0, errors = 0),
+            pullResult = PullResult(upserted = 0, deleted = 0, pages = 1),
+        )
+    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncExecutor.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncExecutor.kt
@@ -1,0 +1,12 @@
+package com.tenmilelabs.chefai.core.data.sync
+
+/**
+ * Executes a full sync cycle (push + pull) and suspends until complete.
+ *
+ * Unlike [SyncScheduler] which fires-and-forgets via WorkManager, this interface
+ * lets callers await the result — useful when the next step depends on sync completion
+ * (e.g., push a meal plan, then call generate, then pull results).
+ */
+interface SyncExecutor {
+    suspend fun sync(): SyncResult
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
@@ -8,6 +8,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.AllergenDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.BookmarkedRecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.IngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.LabelDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.MealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeLabelCrossRefDao
@@ -23,6 +24,8 @@ import com.tenmilelabs.chefai.core.data.sync.mapper.toIngredientEntities
 import com.tenmilelabs.chefai.core.data.sync.mapper.toIngredientEntity
 import com.tenmilelabs.chefai.core.data.sync.mapper.toLabelCrossRefs
 import com.tenmilelabs.chefai.core.data.sync.mapper.toLabelEntity
+import com.tenmilelabs.chefai.core.data.sync.mapper.toMealPlanDayEntity
+import com.tenmilelabs.chefai.core.data.sync.mapper.toMealPlanEntity
 import com.tenmilelabs.chefai.core.data.sync.mapper.toRecipeEntity
 import com.tenmilelabs.chefai.core.data.sync.mapper.toSourceClassificationEntity
 import com.tenmilelabs.chefai.core.data.sync.mapper.toStepEntities
@@ -32,6 +35,7 @@ import com.tenmilelabs.chefai.core.data.sync.mapper.toTagEntity
 import com.tenmilelabs.chefai.core.data.sync.mapper.toUserEntity
 import com.tenmilelabs.chefai.core.data.sync.network.SyncNetworkDataSource
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncBookmarkPushDto
+import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncMealPlanDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPushRequest
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPushResponse
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncRecipeDto
@@ -76,17 +80,18 @@ class SyncOrchestrator @Inject constructor(
     private val recipeTagCrossRefDao: RecipeTagCrossRefDao,
     private val recipeLabelCrossRefDao: RecipeLabelCrossRefDao,
     private val bookmarkedRecipeDao: BookmarkedRecipeDao,
+    private val mealPlanDao: MealPlanDao,
     private val sessionManager: SessionManager,
     private val syncMetadataDao: SyncMetadataDao,
     private val transactionRunner: TransactionRunner,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) {
+) : SyncExecutor {
     companion object {
         const val ENTITY_TYPE_RECIPES = "recipes"
         private const val PUSH_BATCH_SIZE = 50
     }
 
-    suspend fun sync(): SyncResult = withContext(ioDispatcher) {
+    override suspend fun sync(): SyncResult = withContext(ioDispatcher) {
         val pushResult = push()
         val pullResult = pull()
         SyncResult(pushResult, pullResult)
@@ -110,12 +115,18 @@ class SyncOrchestrator @Inject constructor(
             emptyList()
         }
 
-        if (dirtyRecipes.isEmpty() && dirtyBookmarks.isEmpty()) {
+        val dirtyMealPlans = mealPlanDao.getAllDirty()
+        val syncMealPlans = dirtyMealPlans.map { plan ->
+            val days = mealPlanDao.getDaysForMealPlan(plan.uuid)
+            plan.toSyncDto(days)
+        }
+
+        if (dirtyRecipes.isEmpty() && dirtyBookmarks.isEmpty() && dirtyMealPlans.isEmpty()) {
             Timber.d("Push: Nothing dirty to push")
             return PushResult(0, 0, 0)
         }
 
-        Timber.d("Push: Found ${dirtyRecipes.size} dirty recipes, ${dirtyBookmarks.size} dirty bookmarks")
+        Timber.d("Push: Found ${dirtyRecipes.size} dirty recipes, ${dirtyBookmarks.size} dirty bookmarks, ${dirtyMealPlans.size} dirty meal plans")
 
         val syncRecipes = dirtyRecipes.map { recipe -> buildSyncRecipeDto(recipe) }
         val syncBookmarks = dirtyBookmarks.map { it.toSyncPushDto() }
@@ -127,10 +138,12 @@ class SyncOrchestrator @Inject constructor(
         // Batch recipes; bookmarks ride along in every batch (or a final bookmark-only batch)
         val recipeBatches = syncRecipes.chunked(PUSH_BATCH_SIZE).ifEmpty { listOf(emptyList()) }
         recipeBatches.forEachIndexed { index, recipeBatch ->
-            // Only include bookmarks in the last batch to avoid duplicate processing
+            // Only include bookmarks and meal plans in the last batch to avoid duplicate processing
             val bookmarkBatch = if (index == recipeBatches.lastIndex) syncBookmarks else emptyList()
-            Timber.d("Push: Sending batch of ${recipeBatch.size} recipes, ${bookmarkBatch.size} bookmarks")
-            val response = syncNetworkDataSource.pushRecipes(SyncPushRequest(recipeBatch, bookmarkBatch))
+            val mealPlanBatch = if (index == recipeBatches.lastIndex) syncMealPlans else emptyList()
+            Timber.d("Push: Sending batch of ${recipeBatch.size} recipes, ${bookmarkBatch.size} bookmarks, ${mealPlanBatch.size} meal plans")
+            // TODO decouple synchronization of unrelated entities such a recipes and meal plans.
+            val response = syncNetworkDataSource.pushRecipes(SyncPushRequest(recipeBatch, bookmarkBatch, mealPlanBatch))
             processPushResponse(response)
             totalAccepted += response.accepted.size
             totalConflicts += response.conflicts.size
@@ -214,6 +227,22 @@ class SyncOrchestrator @Inject constructor(
         for (error in response.bookmarkErrors) {
             Timber.w("Bookmark push error for recipeId=${error.recipeId}: ${error.reason} - ${error.message}")
         }
+
+        // Process accepted meal plans
+        for (accepted in response.mealPlans.accepted) {
+            val uuid = UUID.fromString(accepted.uuid)
+            mealPlanDao.updateSyncState(uuid, SyncState.SYNCED, accepted.serverUpdatedAt)
+        }
+
+        // Meal plan conflicts: server wins — next pull will overwrite
+        if (response.mealPlans.conflicts.isNotEmpty()) {
+            Timber.w("MealPlan push conflicts: ${response.mealPlans.conflicts}")
+        }
+
+        // Meal plan errors: log, keep as PENDING for retry
+        for (error in response.mealPlans.errors) {
+            Timber.w("MealPlan push error for ${error.uuid}: ${error.reason} - ${error.message}")
+        }
     }
 
     private suspend fun pull(): PullResult {
@@ -222,11 +251,13 @@ class SyncOrchestrator @Inject constructor(
         var totalUpserted = 0
         var totalDeleted = 0
 
+        val authenticatedUserId = sessionManager.getCurrentUserId()
+
         Timber.d("Pull: starting from checkpoint=$since")
 
         do {
             val response = syncNetworkDataSource.pullRecipes(since = since, limit = 100)
-            Timber.d("Pull: received ${response.recipes.size} recipes, hasMore=${response.hasMore}")
+            Timber.d("Pull: received ${response.recipes.size} recipes, ${response.mealPlans.size} meal plans, hasMore=${response.hasMore}")
 
             transactionRunner {
                 // Upsert reference data in FK dependency order before recipes:
@@ -251,12 +282,21 @@ class SyncOrchestrator @Inject constructor(
                 for (bookmark in response.bookmarkedRecipes) {
                     applyPulledBookmark(bookmark)
                 }
+
+                // Meal plans require an authenticated user for the FK
+                if (authenticatedUserId != null && response.mealPlans.isNotEmpty()) {
+                    for (dto in response.mealPlans) {
+                        applyPulledMealPlan(dto, authenticatedUserId, response.serverTimestamp)
+                    }
+                } else if (response.mealPlans.isNotEmpty()) {
+                    Timber.w("Pull: Skipping ${response.mealPlans.size} meal plan(s) — no authenticated user")
+                }
             }
 
-            // Bookmark timestamps are independent of recipe timestamps — advance cursor
-            // to max of both so neither set of deltas is re-fetched on the next pull.
+            // Advance cursor to max of all entity timestamps so no deltas are re-fetched.
             val bookmarkMaxTs = response.bookmarkedRecipes.maxOfOrNull { it.updatedAt } ?: 0L
-            val newCursor = maxOf(response.serverTimestamp, bookmarkMaxTs)
+            val mealPlanMaxTs = response.mealPlans.maxOfOrNull { it.updatedAt } ?: 0L
+            val newCursor = maxOf(response.serverTimestamp, bookmarkMaxTs, mealPlanMaxTs)
             syncMetadataDao.upsert(SyncMetadataEntity(ENTITY_TYPE_RECIPES, newCursor))
 
             since = newCursor
@@ -371,6 +411,25 @@ class SyncOrchestrator @Inject constructor(
                     syncState = SyncState.SYNCED
                 )
             )
+        }
+    }
+
+    private suspend fun applyPulledMealPlan(dto: SyncMealPlanDto, userId: UUID, serverTimestamp: Long) {
+        val planUuid = UUID.fromString(dto.uuid)
+        val localPlan = mealPlanDao.getMealPlanById(planUuid)
+
+        // If local has unpushed changes and is newer, skip — push will send it next cycle
+        if (localPlan != null && localPlan.syncState == SyncState.PENDING && dto.updatedAt <= localPlan.updatedAt) {
+            return
+        }
+
+        val entity = dto.toMealPlanEntity(userId)
+        mealPlanDao.upsertMealPlan(entity)
+
+        // Always replace days — server is authoritative (especially after generation)
+        mealPlanDao.deleteDaysForMealPlan(planUuid)
+        if (dto.days.isNotEmpty()) {
+            mealPlanDao.upsertDays(dto.days.map { it.toMealPlanDayEntity(planUuid) })
         }
     }
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapper.kt
@@ -1,5 +1,7 @@
 package com.tenmilelabs.chefai.core.data.sync.mapper
 
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanDayEntity
+import com.tenmilelabs.chefai.core.data.local.room.MealPlanEntity
 import com.tenmilelabs.chefai.core.data.local.room.AllergenEntity
 import com.tenmilelabs.chefai.core.data.local.room.IngredientEntity
 import com.tenmilelabs.chefai.core.data.local.room.LabelEntity
@@ -22,6 +24,8 @@ import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncRecipeStepDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncSourceClassificationDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncTagDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncCreatorDto
+import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncMealPlanDayDto
+import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncMealPlanDto
 import java.util.UUID
 
 // --- Push direction: Room entities → DTO ---
@@ -183,4 +187,46 @@ fun SyncCreatorDto.toUserEntity(): UserEntity = UserEntity(
     updatedAt = updatedAt,
     deletedAt = deletedAt,
     syncState = SyncState.SYNCED
+)
+
+// --- Meal Plan: Push direction (Entity → DTO) ---
+
+fun MealPlanEntity.toSyncDto(days: List<MealPlanDayEntity>): SyncMealPlanDto = SyncMealPlanDto(
+    uuid = uuid.toString(),
+    name = name,
+    status = status,
+    preferencesJson = preferencesJson,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    deletedAt = deletedAt,
+    days = days.map { it.toSyncDto() }
+)
+
+fun MealPlanDayEntity.toSyncDto(): SyncMealPlanDayDto = SyncMealPlanDayDto(
+    uuid = uuid.toString(),
+    dayIndex = dayIndex,
+    dinnerRecipeId = dinnerRecipeId?.toString(),
+    lunchRecipeId = lunchRecipeId?.toString()
+)
+
+// --- Meal Plan: Pull direction (DTO → Entity) ---
+
+fun SyncMealPlanDto.toMealPlanEntity(userId: UUID): MealPlanEntity = MealPlanEntity(
+    uuid = UUID.fromString(uuid),
+    userId = userId,
+    name = name,
+    status = status,
+    preferencesJson = preferencesJson,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    deletedAt = deletedAt,
+    syncState = SyncState.SYNCED
+)
+
+fun SyncMealPlanDayDto.toMealPlanDayEntity(mealPlanId: UUID): MealPlanDayEntity = MealPlanDayEntity(
+    uuid = UUID.fromString(uuid),
+    mealPlanId = mealPlanId,
+    dayIndex = dayIndex,
+    dinnerRecipeId = dinnerRecipeId?.let { UUID.fromString(it) },
+    lunchRecipeId = lunchRecipeId?.let { UUID.fromString(it) }
 )

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/network/dto/SyncDtos.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/network/dto/SyncDtos.kt
@@ -5,7 +5,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class SyncPushRequest(
     val recipes: List<SyncRecipeDto>,
-    val bookmarkedRecipes: List<SyncBookmarkPushDto> = emptyList()
+    val bookmarkedRecipes: List<SyncBookmarkPushDto> = emptyList(),
+    val mealPlans: List<SyncMealPlanDto> = emptyList()
 )
 
 @Serializable
@@ -59,7 +60,8 @@ data class SyncPushResponse(
     val errors: List<SyncErrorDto>,
     val serverTimestamp: Long,
     val bookmarkedRecipes: List<BookmarkAcceptedDto> = emptyList(),
-    val bookmarkErrors: List<BookmarkErrorDto> = emptyList()
+    val bookmarkErrors: List<BookmarkErrorDto> = emptyList(),
+    val mealPlans: MealPlanPushResults = MealPlanPushResults()
 )
 
 @Serializable
@@ -160,7 +162,8 @@ data class SyncPullResponse(
     val ingredients: List<SyncIngredientDto> = emptyList(),
     val tags: List<SyncTagDto> = emptyList(),
     val labels: List<SyncLabelDto> = emptyList(),
-    val bookmarkedRecipes: List<SyncBookmarkPullDto> = emptyList()
+    val bookmarkedRecipes: List<SyncBookmarkPullDto> = emptyList(),
+    val mealPlans: List<SyncMealPlanDto> = emptyList()
 )
 
 @Serializable
@@ -169,4 +172,40 @@ data class SyncBookmarkPullDto(
     val recipeId: String,
     val updatedAt: Long,
     val deletedAt: Long?
+)
+
+// --- Meal Plan Sync DTOs ---
+
+@Serializable
+data class SyncMealPlanDto(
+    val uuid: String,
+    val name: String,
+    val status: String,
+    val preferencesJson: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val deletedAt: Long?,
+    val days: List<SyncMealPlanDayDto>
+)
+
+@Serializable
+data class SyncMealPlanDayDto(
+    val uuid: String,
+    val dayIndex: Int,
+    val dinnerRecipeId: String?,
+    val lunchRecipeId: String?
+)
+
+@Serializable
+data class MealPlanPushResults(
+    val accepted: List<AcceptedEntityDto> = emptyList(),
+    val conflicts: List<String> = emptyList(),
+    val errors: List<SyncErrorDto> = emptyList()
+)
+
+@Serializable
+data class GenerateMealPlanResponse(
+    val uuid: String,
+    val status: String,
+    val updatedAt: Long
 )

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -7,6 +7,8 @@ import com.tenmilelabs.chefai.auth.data.local.SecurePreferencesInterface
 import com.tenmilelabs.chefai.collections.data.repository.DefaultCollectionsRepository
 import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_5_6
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanApiService
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanNetworkDataSource
 import com.tenmilelabs.chefai.mealplans.data.repository.DefaultMealPlanRepository
 import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
 import com.tenmilelabs.chefai.core.data.local.room.RoomTransactionRunner
@@ -50,6 +52,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindMealPlanRepository(repository: DefaultMealPlanRepository): MealPlanRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindMealPlanNetworkDataSource(service: MealPlanApiService): MealPlanNetworkDataSource
 }
 
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/SyncModule.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/SyncModule.kt
@@ -2,7 +2,9 @@ package com.tenmilelabs.chefai.core.di
 
 import com.tenmilelabs.chefai.core.data.sync.ConnectivityObserver
 import com.tenmilelabs.chefai.core.data.sync.NetworkMonitor
+import com.tenmilelabs.chefai.core.data.sync.SyncExecutor
 import com.tenmilelabs.chefai.core.data.sync.SyncManager
+import com.tenmilelabs.chefai.core.data.sync.SyncOrchestrator
 import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
 import com.tenmilelabs.chefai.core.data.sync.network.SyncApiService
 import com.tenmilelabs.chefai.core.data.sync.network.SyncNetworkDataSource
@@ -27,6 +29,12 @@ abstract class SyncNetworkDataSourceModule {
     abstract fun bindSyncScheduler(
         syncManager: SyncManager
     ): SyncScheduler
+
+    @Binds
+    @Singleton
+    abstract fun bindSyncExecutor(
+        syncOrchestrator: SyncOrchestrator
+    ): SyncExecutor
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
@@ -3,6 +3,7 @@ package com.tenmilelabs.chefai.core.ui.navigation
 import androidx.annotation.StringRes
 import androidx.navigation.NavHostController
 import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.MEAL_PLAN_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.RECIPE_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.ScreenBaseRoutes.RECIPE_DETAILS
 import java.util.UUID
@@ -19,6 +20,8 @@ internal object ScreenBaseRoutes {
     const val SETTINGS = "settings_screen"
     const val LOGIN = "login_screen"
     const val REGISTER = "register_screen"
+    const val MEAL_PLAN_DETAIL = "meal_plan_detail"
+    const val MEAL_PLAN_RECIPE_DETAIL = "meal_plan_recipe_detail"
     const val MEAL_PLAN_WIZARD = "meal_plan_wizard"
     const val MEAL_PLAN_WIZARD_BASICS = "meal_plan_wizard_basics"
     const val MEAL_PLAN_WIZARD_PREFERENCES = "meal_plan_wizard_preferences"
@@ -30,6 +33,7 @@ internal object ScreenBaseRoutes {
  */
 object AppDestinationArgs {
     const val RECIPE_ID_ARG = "recipeUuid"
+    const val MEAL_PLAN_ID_ARG = "mealPlanId"
 }
 
 /**
@@ -47,6 +51,14 @@ enum class AppDestinations(
         "${ScreenBaseRoutes.RECIPE_DETAILS}/{$RECIPE_ID_ARG}"
     ),
     CREATE_RECIPE(R.string.app_dest_title_create_recipe, ScreenBaseRoutes.CREATE_RECIPE),
+    MEAL_PLAN_DETAIL(
+        R.string.app_dest_title_meal_plan_detail,
+        "${ScreenBaseRoutes.MEAL_PLAN_DETAIL}/{$MEAL_PLAN_ID_ARG}"
+    ),
+    MEAL_PLAN_RECIPE_DETAIL(
+        R.string.app_dest_title_recipe_details,
+        "${ScreenBaseRoutes.MEAL_PLAN_RECIPE_DETAIL}/{$RECIPE_ID_ARG}"
+    ),
     MEAL_PLAN_WIZARD(R.string.app_dest_title_meal_plan_wizard, ScreenBaseRoutes.MEAL_PLAN_WIZARD),
     SETTINGS(R.string.app_dest_title_settings, ScreenBaseRoutes.SETTINGS),
     LOGIN(R.string.app_dest_title_login, ScreenBaseRoutes.LOGIN),
@@ -74,6 +86,14 @@ class NavigationActions(private val navController: NavHostController) {
 
     fun navigateToRegister() {
         navController.navigate(ScreenBaseRoutes.REGISTER)
+    }
+
+    fun navigateToMealPlanDetail(mealPlanId: UUID) {
+        navController.navigate("${ScreenBaseRoutes.MEAL_PLAN_DETAIL}/$mealPlanId")
+    }
+
+    fun navigateToMealPlanRecipeDetail(recipeId: UUID) {
+        navController.navigate("${ScreenBaseRoutes.MEAL_PLAN_RECIPE_DETAIL}/$recipeId")
     }
 
     fun navigateToMealPlanWizard() {

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/BottomNavigationBar.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/BottomNavigationBar.kt
@@ -56,7 +56,7 @@ fun BottomNavigationBar(
     ) {
         TopLevelDestination.entries.forEachIndexed { index, item ->
             NavigationBarItem(
-                selected = currentRoute == item.appDestination.route,
+                selected = isRouteInSection(currentRoute, item),
                 onClick = {
                     navController.navigate(item.appDestination.route) {
                         popUpTo(navController.graph.startDestinationId) { saveState = true }
@@ -83,6 +83,22 @@ fun BottomNavigationBar(
                 )
             )
         }
+    }
+}
+
+/**
+ * Determines if the current route belongs to a given top-level section.
+ * This allows child routes (e.g., meal plan detail, recipe opened from meal plans)
+ * to keep the parent tab highlighted in the bottom navigation bar.
+ */
+private fun isRouteInSection(currentRoute: String?, item: TopLevelDestination): Boolean {
+    if (currentRoute == null) return false
+    if (currentRoute == item.appDestination.route) return true
+    return when (item) {
+        TopLevelDestination.MEAL_PLANS -> currentRoute.startsWith(ScreenBaseRoutes.MEAL_PLAN_DETAIL) ||
+            currentRoute.startsWith(ScreenBaseRoutes.MEAL_PLAN_RECIPE_DETAIL)
+        TopLevelDestination.RECIPES -> currentRoute.startsWith(ScreenBaseRoutes.RECIPE_DETAILS)
+        else -> false
     }
 }
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -34,6 +34,7 @@ import com.tenmilelabs.chefai.auth.ui.LoginScreen
 import com.tenmilelabs.chefai.auth.ui.RegisterScreen
 import com.tenmilelabs.chefai.home.ui.HomeScreen
 import com.tenmilelabs.chefai.mealplans.ui.MealPlansScreen
+import com.tenmilelabs.chefai.mealplans.ui.detail.MealPlanDetailScreen
 import com.tenmilelabs.chefai.mealplans.ui.create.CreateMealPlanEvent
 import com.tenmilelabs.chefai.mealplans.ui.create.CreateMealPlanViewModel
 import com.tenmilelabs.chefai.mealplans.ui.create.WizardAdvancedScreen
@@ -78,8 +79,18 @@ fun ChefAINavGraph(
         composable(route = AppDestinations.MEAL_PLANS.route) {
             MealPlansScreen(
                 onCreateMealPlan = { navActions.navigateToMealPlanWizard() },
+                onMealPlanClick = { mealPlanId -> navActions.navigateToMealPlanDetail(mealPlanId) },
                 snackbarHostState = snackbarHostState,
             )
+        }
+        composable(route = AppDestinations.MEAL_PLAN_DETAIL.route) {
+            MealPlanDetailScreen(
+                onRecipeClick = { recipeId -> navActions.navigateToMealPlanRecipeDetail(recipeId) },
+                snackbarHostState = snackbarHostState,
+            )
+        }
+        composable(route = AppDestinations.MEAL_PLAN_RECIPE_DETAIL.route) {
+            RecipeDetailsScreen(snackbarHostState = snackbarHostState)
         }
         navigation(
             startDestination = ScreenBaseRoutes.MEAL_PLAN_WIZARD_BASICS,
@@ -120,11 +131,21 @@ fun ChefAINavGraph(
                 LaunchedEffect(Unit) {
                     wizardViewModel.uiEvents.collect { event ->
                         when (event) {
-                            is CreateMealPlanEvent.MealPlanCreated -> {
+                            is CreateMealPlanEvent.MealPlanReady -> {
+                                // Generation succeeded — go straight to the detail screen
                                 navController.popBackStack(
                                     route = AppDestinations.MEAL_PLANS.route,
                                     inclusive = false,
                                 )
+                                navActions.navigateToMealPlanDetail(event.mealPlanId)
+                            }
+                            is CreateMealPlanEvent.MealPlanSavedAsDraft -> {
+                                // Offline / BE error — show detail as DRAFT with Generate button
+                                navController.popBackStack(
+                                    route = AppDestinations.MEAL_PLANS.route,
+                                    inclusive = false,
+                                )
+                                navActions.navigateToMealPlanDetail(event.mealPlanId)
                             }
                             is CreateMealPlanEvent.ShowError -> {
                                 snackbarHostState.showSnackbar("Failed to create meal plan")

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/network/MealPlanApiService.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/network/MealPlanApiService.kt
@@ -1,0 +1,43 @@
+package com.tenmilelabs.chefai.mealplans.data.network
+
+import com.tenmilelabs.chefai.core.data.sync.network.dto.GenerateMealPlanResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.request.post
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MealPlanApiService @Inject constructor(
+    private val client: HttpClient
+) : MealPlanNetworkDataSource {
+
+    companion object {
+        private const val BASE_URL = "http://10.0.2.2:8080"
+    }
+
+    override suspend fun generateMealPlan(mealPlanId: String): GenerateMealPlanResponse {
+        val httpResponse = client.post("$BASE_URL/meal-plans/$mealPlanId/generate") {
+            contentType(ContentType.Application.Json)
+            expectSuccess = false
+        }
+
+        if (!httpResponse.status.isSuccess()) {
+            throw MealPlanApiException(
+                message = "Generate meal plan failed: ${httpResponse.status}",
+                statusCode = httpResponse.status.value
+            )
+        }
+
+        return httpResponse.body()
+    }
+}
+
+data class MealPlanApiException(
+    override val message: String,
+    val statusCode: Int
+) : Exception(message)

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/network/MealPlanNetworkDataSource.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/network/MealPlanNetworkDataSource.kt
@@ -1,0 +1,7 @@
+package com.tenmilelabs.chefai.mealplans.data.network
+
+import com.tenmilelabs.chefai.core.data.sync.network.dto.GenerateMealPlanResponse
+
+interface MealPlanNetworkDataSource {
+    suspend fun generateMealPlan(mealPlanId: String): GenerateMealPlanResponse
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/repository/DefaultMealPlanRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/repository/DefaultMealPlanRepository.kt
@@ -1,12 +1,16 @@
 package com.tenmilelabs.chefai.mealplans.data.repository
 
 import com.tenmilelabs.chefai.core.data.local.room.dao.MealPlanDao
+import com.tenmilelabs.chefai.core.data.local.util.SyncState
+import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
 import com.tenmilelabs.chefai.mealplans.data.mapper.toDomain
 import com.tenmilelabs.chefai.mealplans.data.mapper.toEntity
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanNetworkDataSource
 import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
 import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -14,7 +18,17 @@ import javax.inject.Singleton
 @Singleton
 class DefaultMealPlanRepository @Inject constructor(
     private val mealPlanDao: MealPlanDao,
+    private val mealPlanNetworkDataSource: MealPlanNetworkDataSource,
+    private val syncScheduler: SyncScheduler,
 ) : MealPlanRepository {
+
+    override fun observeMealPlan(uuid: UUID): Flow<MealPlan?> =
+        mealPlanDao.observeMealPlanById(uuid).map { entity ->
+            entity?.let {
+                val days = mealPlanDao.getDaysForMealPlan(it.uuid)
+                it.toDomain(days)
+            }
+        }
 
     override fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlan>> =
         mealPlanDao.observeMealPlansForUser(userId).map { entities ->
@@ -29,9 +43,31 @@ class DefaultMealPlanRepository @Inject constructor(
         if (mealPlan.days.isNotEmpty()) {
             mealPlanDao.upsertDays(mealPlan.days.map { it.toEntity(mealPlan.uuid) })
         }
+        syncScheduler.requestMutationSync()
     }
 
     override suspend fun deleteMealPlan(uuid: UUID) {
         mealPlanDao.softDelete(uuid, System.currentTimeMillis())
+        syncScheduler.requestMutationSync()
+    }
+
+    override suspend fun requestGeneration(planId: UUID): Result<Unit> {
+        return try {
+            val response = mealPlanNetworkDataSource.generateMealPlan(planId.toString())
+            // Immediately update local status to GENERATING so UI reflects it
+            mealPlanDao.getMealPlanById(planId)?.let { existing ->
+                mealPlanDao.upsertMealPlan(
+                    existing.copy(
+                        status = response.status,
+                        syncState = SyncState.SYNCED
+                    )
+                )
+            }
+            Timber.d("requestGeneration: plan $planId accepted, status=${response.status}")
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Timber.e(e, "requestGeneration: failed for plan $planId")
+            Result.failure(e)
+        }
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/repository/MealPlanRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/domain/repository/MealPlanRepository.kt
@@ -8,7 +8,11 @@ interface MealPlanRepository {
 
     fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlan>>
 
+    fun observeMealPlan(uuid: UUID): Flow<MealPlan?>
+
     suspend fun createMealPlan(mealPlan: MealPlan)
 
     suspend fun deleteMealPlan(uuid: UUID)
+
+    suspend fun requestGeneration(planId: UUID): Result<Unit>
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/MealPlansScreen.kt
@@ -23,6 +23,7 @@ import java.util.UUID
 @Composable
 fun MealPlansScreen(
     onCreateMealPlan: () -> Unit = {},
+    onMealPlanClick: (UUID) -> Unit = {},
     snackbarHostState: SnackbarHostState = SnackbarHostState(),
     viewModel: MealPlansViewModel = hiltViewModel(),
     modifier: Modifier = Modifier,
@@ -42,6 +43,7 @@ fun MealPlansScreen(
 
     MealPlansContent(
         uiState = uiState,
+        onMealPlanClick = onMealPlanClick,
         onDeleteMealPlan = viewModel::onDeleteMealPlan,
         modifier = modifier,
     )
@@ -50,6 +52,7 @@ fun MealPlansScreen(
 @Composable
 private fun MealPlansContent(
     uiState: MealPlansUiState,
+    onMealPlanClick: (UUID) -> Unit,
     onDeleteMealPlan: (UUID) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -87,6 +90,7 @@ private fun MealPlansContent(
                     ) { mealPlan ->
                         MealPlanCard(
                             mealPlan = mealPlan,
+                            onClick = { onMealPlanClick(mealPlan.uuid) },
                             onDelete = { onDeleteMealPlan(mealPlan.uuid) },
                         )
                     }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/MealPlanCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/components/MealPlanCard.kt
@@ -34,10 +34,12 @@ import java.util.UUID
 @Composable
 fun MealPlanCard(
     mealPlan: MealPlan,
+    onClick: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.secondaryContainer,
@@ -125,6 +127,7 @@ private fun MealPlanCardDraftLightPreview() {
                 updatedAt = System.currentTimeMillis(),
                 days = emptyList(),
             ),
+            onClick = {},
             onDelete = {},
         )
     }
@@ -151,6 +154,7 @@ private fun MealPlanCardReadyDarkPreview() {
                 updatedAt = System.currentTimeMillis(),
                 days = emptyList(),
             ),
+            onClick = {},
             onDelete = {},
         )
     }
@@ -177,6 +181,7 @@ private fun MealPlanCardGeneratingLightPreview() {
                 updatedAt = System.currentTimeMillis(),
                 days = emptyList(),
             ),
+            onClick = {},
             onDelete = {},
         )
     }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanUiState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanUiState.kt
@@ -15,6 +15,8 @@ data class CreateMealPlanUiState(
     // Step 2: Preferences
     val dietaryRestrictions: Set<DietaryRestriction> = emptySet(),
     val recipeSource: RecipeSource = RecipeSource.COLLECTION_ONLY,
+    /** True when user has fewer than [MIN_COLLECTION_RECIPES] — COLLECTION_ONLY is disabled. */
+    val collectionTooSmall: Boolean = false,
     val maxPrepTimeMinutes: Int? = null,
     // Step 3: Advanced
     val batchCooking: Boolean = false,
@@ -38,6 +40,11 @@ sealed interface WizardAction {
 }
 
 sealed interface CreateMealPlanEvent {
-    data object MealPlanCreated : CreateMealPlanEvent
+    /** Plan created and generation completed — navigate to detail screen. */
+    data class MealPlanReady(val mealPlanId: java.util.UUID) : CreateMealPlanEvent
+
+    /** Plan saved locally but generation failed (offline/BE error) — navigate to detail as DRAFT. */
+    data class MealPlanSavedAsDraft(val mealPlanId: java.util.UUID) : CreateMealPlanEvent
+
     data class ShowError(val message: Int) : CreateMealPlanEvent
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModel.kt
@@ -5,12 +5,16 @@ import androidx.lifecycle.viewModelScope
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.auth.domain.SessionManager
 import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.sync.SyncExecutor
 import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
 import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
 import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanPreferences
 import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
 import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -19,6 +23,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.UUID
 import java.util.concurrent.CancellationException
 import javax.inject.Inject
 
@@ -26,6 +32,8 @@ import javax.inject.Inject
 class CreateMealPlanViewModel @Inject constructor(
     private val mealPlanRepository: MealPlanRepository,
     private val sessionManager: SessionManager,
+    private val syncExecutor: SyncExecutor,
+    private val recipesRepository: RecipesRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CreateMealPlanUiState())
@@ -34,13 +42,36 @@ class CreateMealPlanViewModel @Inject constructor(
     private val _uiEvent = MutableSharedFlow<CreateMealPlanEvent>()
     val uiEvents: SharedFlow<CreateMealPlanEvent> = _uiEvent.asSharedFlow()
 
+    init {
+        loadRecipeCount()
+    }
+
+    private fun loadRecipeCount() {
+        val userId = sessionManager.getCurrentUserId() ?: return
+        viewModelScope.launch {
+            val count = recipesRepository.getRecipeCountForUser(userId)
+            val tooSmall = count < MIN_COLLECTION_RECIPES
+            _uiState.update {
+                it.copy(
+                    collectionTooSmall = tooSmall,
+                    // Auto-switch to INCLUDE_PUBLIC when collection is too small
+                    recipeSource = if (tooSmall) RecipeSource.INCLUDE_PUBLIC else it.recipeSource,
+                )
+            }
+        }
+    }
+
     fun onAction(action: WizardAction) {
         when (action) {
             is WizardAction.SetPlanLength -> _uiState.update { it.copy(planLengthDays = action.days) }
             is WizardAction.SetMealType -> _uiState.update { it.copy(mealType = action.type) }
             is WizardAction.SetServings -> _uiState.update { it.copy(servingsPerMeal = action.count.coerceIn(1, 12)) }
             is WizardAction.ToggleDietaryRestriction -> toggleDietaryRestriction(action.restriction)
-            is WizardAction.SetRecipeSource -> _uiState.update { it.copy(recipeSource = action.source) }
+            is WizardAction.SetRecipeSource -> {
+                // Guard: don't allow COLLECTION_ONLY when collection is too small
+                if (action.source == RecipeSource.COLLECTION_ONLY && _uiState.value.collectionTooSmall) return
+                _uiState.update { it.copy(recipeSource = action.source) }
+            }
             is WizardAction.SetMaxPrepTime -> _uiState.update { it.copy(maxPrepTimeMinutes = action.minutes) }
             is WizardAction.SetBatchCooking -> _uiState.update { it.copy(batchCooking = action.enabled) }
             is WizardAction.SetLeftoverFriendly -> _uiState.update { it.copy(leftoverFriendly = action.enabled) }
@@ -72,10 +103,12 @@ class CreateMealPlanViewModel @Inject constructor(
         _uiState.update { it.copy(isSaving = true) }
 
         viewModelScope.launch {
+            val mealPlanId: UUID
             try {
                 val now = System.currentTimeMillis()
+                mealPlanId = UuidV7Generator.newId()
                 val mealPlan = MealPlan(
-                    uuid = UuidV7Generator.newId(),
+                    uuid = mealPlanId,
                     userId = userId,
                     name = "${state.planLengthDays}-day meal plan",
                     preferences = MealPlanPreferences(
@@ -95,13 +128,39 @@ class CreateMealPlanViewModel @Inject constructor(
                     days = emptyList(),
                 )
                 mealPlanRepository.createMealPlan(mealPlan)
-                _uiEvent.emit(CreateMealPlanEvent.MealPlanCreated)
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
-                _uiEvent.emit(CreateMealPlanEvent.ShowError(R.string.meal_plan_save_error))
-            } finally {
                 _uiState.update { it.copy(isSaving = false) }
+                _uiEvent.emit(CreateMealPlanEvent.ShowError(R.string.meal_plan_save_error))
+                return@launch
+            }
+
+            // Plan saved locally — now attempt immediate generation (sync → generate → pull).
+            // If any step fails, fall back to DRAFT so the user can retry from the detail screen.
+            try {
+                Timber.d("saveMealPlan: pushing plan $mealPlanId to server")
+                syncExecutor.sync()
+
+                Timber.d("saveMealPlan: calling generate API for $mealPlanId")
+                mealPlanRepository.requestGeneration(mealPlanId).getOrThrow()
+
+                delay(GENERATION_POLL_DELAY_MS)
+                Timber.d("saveMealPlan: pulling generated results for $mealPlanId")
+                syncExecutor.sync()
+
+                _uiState.update { it.copy(isSaving = false) }
+                _uiEvent.emit(CreateMealPlanEvent.MealPlanReady(mealPlanId))
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Timber.w(e, "saveMealPlan: generation failed for $mealPlanId, falling back to DRAFT")
+                _uiState.update { it.copy(isSaving = false) }
+                _uiEvent.emit(CreateMealPlanEvent.MealPlanSavedAsDraft(mealPlanId))
             }
         }
+    }
+
+    companion object {
+        private const val GENERATION_POLL_DELAY_MS = 2_000L
+        internal const val MIN_COLLECTION_RECIPES = 20
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardAdvancedScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardAdvancedScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
 import com.tenmilelabs.chefai.mealplans.ui.components.WizardProgressBar
+import com.tenmilelabs.chefai.mealplans.ui.create.components.PrepTimeSelector
 import com.tenmilelabs.chefai.mealplans.ui.create.components.ToggleOptionRow
 
 @Composable
@@ -87,6 +88,11 @@ private fun WizardAdvancedContent(
                 subtitle = stringResource(R.string.wizard_leftover_subtitle),
                 checked = uiState.leftoverFriendly,
                 onCheckedChange = { onAction(WizardAction.SetLeftoverFriendly(it)) },
+            )
+
+            PrepTimeSelector(
+                selectedMinutes = uiState.maxPrepTimeMinutes,
+                onMinutesSelected = { onAction(WizardAction.SetMaxPrepTime(it)) },
             )
 
             Column {

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardPreferencesScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardPreferencesScreen.kt
@@ -80,6 +80,7 @@ private fun WizardPreferencesContent(
             RecipeSourceSelector(
                 selectedSource = uiState.recipeSource,
                 onSourceSelected = { onAction(WizardAction.SetRecipeSource(it)) },
+                collectionTooSmall = uiState.collectionTooSmall,
             )
 
             PrepTimeSelector(

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardPreferencesScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/WizardPreferencesScreen.kt
@@ -22,7 +22,6 @@ import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
 import com.tenmilelabs.chefai.mealplans.ui.components.WizardProgressBar
 import com.tenmilelabs.chefai.mealplans.ui.create.components.DietaryChipGroup
-import com.tenmilelabs.chefai.mealplans.ui.create.components.PrepTimeSelector
 import com.tenmilelabs.chefai.mealplans.ui.create.components.RecipeSourceSelector
 
 @Composable
@@ -81,11 +80,6 @@ private fun WizardPreferencesContent(
                 selectedSource = uiState.recipeSource,
                 onSourceSelected = { onAction(WizardAction.SetRecipeSource(it)) },
                 collectionTooSmall = uiState.collectionTooSmall,
-            )
-
-            PrepTimeSelector(
-                selectedMinutes = uiState.maxPrepTimeMinutes,
-                onMinutesSelected = { onAction(WizardAction.SetMaxPrepTime(it)) },
             )
         }
 

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/RecipeSourceSelector.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/create/components/RecipeSourceSelector.kt
@@ -23,6 +23,7 @@ import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
 fun RecipeSourceSelector(
     selectedSource: RecipeSource,
     onSourceSelected: (RecipeSource) -> Unit,
+    collectionTooSmall: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -36,9 +37,11 @@ fun RecipeSourceSelector(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             RecipeSource.entries.forEach { source ->
+                val isDisabled = source == RecipeSource.COLLECTION_ONLY && collectionTooSmall
                 FilterChip(
                     selected = selectedSource == source,
                     onClick = { onSourceSelected(source) },
+                    enabled = !isDisabled,
                     label = { Text("${source.emoji} ${source.label}") },
                     colors = FilterChipDefaults.filterChipColors(
                         selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -46,6 +49,14 @@ fun RecipeSourceSelector(
                     ),
                 )
             }
+        }
+        if (collectionTooSmall) {
+            Text(
+                text = stringResource(R.string.wizard_recipe_source_collection_too_small),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/detail/MealPlanDetailScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/detail/MealPlanDetailScreen.kt
@@ -1,0 +1,310 @@
+package com.tenmilelabs.chefai.mealplans.ui.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.components.LargeCard
+import androidx.compose.runtime.LaunchedEffect
+import com.tenmilelabs.chefai.core.util.EmptyContent
+import com.tenmilelabs.chefai.core.util.LoadingContent
+import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanPreferences
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import java.util.UUID
+
+@Composable
+fun MealPlanDetailScreen(
+    onRecipeClick: (UUID) -> Unit,
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
+    viewModel: MealPlanDetailViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is MealPlanDetailEvent.ShowError -> {
+                    snackbarHostState.showSnackbar(event.message)
+                }
+            }
+        }
+    }
+
+    when (val state = uiState) {
+        is MealPlanDetailUiState.Loading -> LoadingContent(modifier = modifier)
+        is MealPlanDetailUiState.NotFound -> EmptyContent(
+            title = R.string.meal_plan_not_found,
+            subtitle = R.string.meal_plan_not_found_subtitle,
+            noRecipesIconRes = R.drawable.ic_skillet_cooktop_24dp,
+            modifier = modifier,
+        )
+        is MealPlanDetailUiState.Success -> MealPlanDetailContent(
+            mealPlan = state.mealPlan,
+            dayItems = state.dayItems,
+            onRecipeClick = onRecipeClick,
+            onGenerate = viewModel::onGenerate,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun MealPlanDetailContent(
+    mealPlan: MealPlan,
+    dayItems: List<DayItem>,
+    onRecipeClick: (UUID) -> Unit,
+    onGenerate: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Preferences summary card
+        item(key = "preferences") {
+            PreferencesSummaryCard(mealPlan = mealPlan)
+        }
+
+        // Day items: headers + recipe cards
+        itemsIndexed(
+            items = dayItems,
+            key = { index, item ->
+                when (item) {
+                    is DayItem.Header -> "header-$index-${item.label}"
+                    is DayItem.RecipeCard -> "recipe-$index-${item.recipeId}"
+                    is DayItem.MissingRecipe -> "missing-$index-${item.recipeId}"
+                }
+            }
+        ) { _, item ->
+            when (item) {
+                is DayItem.Header -> DayHeader(label = item.label)
+                is DayItem.RecipeCard -> LargeCard(
+                    recipe = item.recipe,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(220.dp),
+                    onClick = { onRecipeClick(item.recipeId) },
+                )
+                is DayItem.MissingRecipe -> MissingRecipeCard()
+            }
+        }
+
+        // Generate action for DRAFT plans
+        if (mealPlan.status == MealPlanStatus.DRAFT) {
+            item(key = "generate-action") {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "This meal plan hasn't been generated yet.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = onGenerate) {
+                        Icon(
+                            imageVector = Icons.Default.AutoAwesome,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.size(8.dp))
+                        Text("Generate Meal Plan")
+                    }
+                }
+            }
+        }
+
+        // Generating state — show spinner
+        if (mealPlan.status == MealPlanStatus.GENERATING) {
+            item(key = "generating") {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                ) {
+                    CircularProgressIndicator()
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Your meal plan is being generated...",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreferencesSummaryCard(
+    mealPlan: MealPlan,
+    modifier: Modifier = Modifier,
+) {
+    val prefs = mealPlan.preferences
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = mealPlan.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                StatusText(status = mealPlan.status)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            PreferenceRow(label = "Meals", value = "${prefs.mealType.emoji} ${prefs.mealType.label}")
+            PreferenceRow(label = "Duration", value = "${prefs.planLengthDays} days")
+            PreferenceRow(label = "Servings", value = "${prefs.servingsPerMeal} per meal")
+
+            val dietary = prefs.dietaryRestrictions.filter { it != DietaryRestriction.NONE }
+            if (dietary.isNotEmpty()) {
+                PreferenceRow(
+                    label = "Dietary",
+                    value = dietary.joinToString(", ") { "${it.emoji} ${it.label}" }
+                )
+            }
+
+            prefs.maxPrepTimeMinutes?.let {
+                PreferenceRow(label = "Max prep", value = "${it} min")
+            }
+            PreferenceRow(label = "Recipes from", value = "${prefs.recipeSource.emoji} ${prefs.recipeSource.label}")
+            PreferenceRow(label = "Variety", value = "${prefs.varietyPreference.emoji} ${prefs.varietyPreference.label}")
+
+            val extras = buildList {
+                if (prefs.batchCooking) add("Batch cooking")
+                if (prefs.leftoverFriendly) add("Leftover-friendly")
+            }
+            if (extras.isNotEmpty()) {
+                PreferenceRow(label = "Options", value = extras.joinToString(", "))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreferenceRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+private fun StatusText(
+    status: MealPlanStatus,
+    modifier: Modifier = Modifier,
+) {
+    val (text, color) = when (status) {
+        MealPlanStatus.DRAFT -> "Draft" to MaterialTheme.colorScheme.tertiary
+        MealPlanStatus.GENERATING -> "Generating..." to MaterialTheme.colorScheme.primary
+        MealPlanStatus.READY -> "Ready" to MaterialTheme.colorScheme.primary
+        MealPlanStatus.ARCHIVED -> "Archived" to MaterialTheme.colorScheme.outline
+    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = color,
+        fontWeight = FontWeight.SemiBold,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun DayHeader(
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier.padding(top = 8.dp),
+    )
+}
+
+@Composable
+private fun MissingRecipeCard(
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(80.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Text(
+            text = "Recipe not available",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/detail/MealPlanDetailViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/ui/detail/MealPlanDetailViewModel.kt
@@ -1,0 +1,184 @@
+package com.tenmilelabs.chefai.mealplans.ui.detail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tenmilelabs.chefai.core.data.sync.SyncExecutor
+import com.tenmilelabs.chefai.core.domain.model.RecipePreview
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlan
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanDay
+import com.tenmilelabs.chefai.mealplans.domain.model.MealPlanStatus
+import com.tenmilelabs.chefai.mealplans.domain.model.MealType
+import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+
+sealed interface MealPlanDetailUiState {
+    data object Loading : MealPlanDetailUiState
+    data object NotFound : MealPlanDetailUiState
+    data class Success(
+        val mealPlan: MealPlan,
+        val dayItems: List<DayItem>,
+        val isGenerating: Boolean = false,
+    ) : MealPlanDetailUiState
+}
+
+sealed interface MealPlanDetailEvent {
+    data class ShowError(val message: String) : MealPlanDetailEvent
+}
+
+/**
+ * A flattened item for the lazy list: either a day header or a recipe card.
+ */
+sealed interface DayItem {
+    data class Header(val label: String) : DayItem
+    data class RecipeCard(
+        val recipe: RecipePreview,
+        val recipeId: UUID,
+    ) : DayItem
+    data class MissingRecipe(val recipeId: UUID) : DayItem
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class MealPlanDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val mealPlanRepository: MealPlanRepository,
+    recipesRepository: RecipesRepository,
+    private val syncExecutor: SyncExecutor,
+) : ViewModel() {
+
+    private val mealPlanId: UUID = UUID.fromString(
+        savedStateHandle.get<String>(AppDestinationArgs.MEAL_PLAN_ID_ARG)
+            ?: error("Missing mealPlanId argument")
+    )
+
+    private val _events = MutableSharedFlow<MealPlanDetailEvent>()
+    val events: SharedFlow<MealPlanDetailEvent> = _events.asSharedFlow()
+
+    val uiState: StateFlow<MealPlanDetailUiState> = mealPlanRepository.observeMealPlan(mealPlanId)
+        .flatMapLatest { mealPlan ->
+            if (mealPlan == null) {
+                flowOf(MealPlanDetailUiState.NotFound)
+            } else {
+                val allRecipeIds = mealPlan.days.flatMap { day ->
+                    listOfNotNull(day.lunchRecipeId, day.dinnerRecipeId)
+                }.distinct()
+
+                if (allRecipeIds.isEmpty()) {
+                    flowOf(
+                        MealPlanDetailUiState.Success(
+                            mealPlan = mealPlan,
+                            dayItems = buildDayItems(mealPlan, emptyMap()),
+                        )
+                    )
+                } else {
+                    recipesRepository.getRecipePreviewsByIds(allRecipeIds)
+                        .map { previews ->
+                            val previewMap = previews.associateBy { it.uuid }
+                            MealPlanDetailUiState.Success(
+                                mealPlan = mealPlan,
+                                dayItems = buildDayItems(mealPlan, previewMap),
+                            )
+                        }
+                }
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = MealPlanDetailUiState.Loading,
+        )
+
+    fun onGenerate() {
+        viewModelScope.launch {
+            try {
+                // 1. Push so the server has the meal plan (suspends until complete)
+                Timber.d("onGenerate: pushing meal plan $mealPlanId to server")
+                syncExecutor.sync()
+
+                // 2. Call the generate endpoint
+                Timber.d("onGenerate: calling generate API for $mealPlanId")
+                mealPlanRepository.requestGeneration(mealPlanId)
+                    .getOrThrow()
+
+                // 3. Wait briefly for server-side generation to complete, then pull results.
+                //    Generation is fast (~100ms) but async on the server.
+                delay(GENERATION_POLL_DELAY_MS)
+                Timber.d("onGenerate: pulling generated results for $mealPlanId")
+                syncExecutor.sync()
+            } catch (e: Exception) {
+                Timber.e(e, "onGenerate: failed for plan $mealPlanId")
+                _events.emit(MealPlanDetailEvent.ShowError(e.message ?: "Generation failed"))
+            }
+        }
+    }
+
+    companion object {
+        /** Delay before pulling to let server-side generation finish. */
+        private const val GENERATION_POLL_DELAY_MS = 2_000L
+
+        internal fun buildDayItems(
+            mealPlan: MealPlan,
+            recipeMap: Map<UUID, RecipePreview>,
+        ): List<DayItem> {
+            val items = mutableListOf<DayItem>()
+            val isSingleMealType = mealPlan.preferences.mealType == MealType.DINNER
+
+            for (day in mealPlan.days.sortedBy { it.dayIndex }) {
+                val dayNumber = day.dayIndex + 1
+
+                if (isSingleMealType) {
+                    // Single meal type: "Day 1"
+                    items.add(DayItem.Header("Day $dayNumber"))
+                    val recipeId = day.dinnerRecipeId ?: day.lunchRecipeId
+                    if (recipeId != null) {
+                        val preview = recipeMap[recipeId]
+                        if (preview != null) {
+                            items.add(DayItem.RecipeCard(recipe = preview, recipeId = recipeId))
+                        } else {
+                            items.add(DayItem.MissingRecipe(recipeId))
+                        }
+                    }
+                } else {
+                    // Multiple meal types: separate headers per meal
+                    if (day.lunchRecipeId != null) {
+                        items.add(DayItem.Header("Day $dayNumber — Lunch"))
+                        val preview = recipeMap[day.lunchRecipeId]
+                        if (preview != null) {
+                            items.add(DayItem.RecipeCard(recipe = preview, recipeId = day.lunchRecipeId))
+                        } else {
+                            items.add(DayItem.MissingRecipe(day.lunchRecipeId))
+                        }
+                    }
+                    if (day.dinnerRecipeId != null) {
+                        items.add(DayItem.Header("Day $dayNumber — Dinner"))
+                        val preview = recipeMap[day.dinnerRecipeId]
+                        if (preview != null) {
+                            items.add(DayItem.RecipeCard(recipe = preview, recipeId = day.dinnerRecipeId))
+                        } else {
+                            items.add(DayItem.MissingRecipe(day.dinnerRecipeId))
+                        }
+                    }
+                }
+            }
+            return items
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepository.kt
@@ -266,6 +266,9 @@ class DefaultRecipeRepository @Inject constructor(
         syncManager.requestMutationSync()
     }
 
+    override suspend fun getRecipeCountForUser(userId: UUID): Int =
+        recipeDao.countRecipesForUser(userId)
+
     private suspend fun <T> FlowCollector<T>.logAndReThrow(
         e: Throwable,
         emptyObject: T? = null

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RecipesRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RecipesRepository.kt
@@ -34,4 +34,7 @@ interface RecipesRepository {
      * Returns an empty flow immediately if [ids] is empty.
      */
     fun getRecipePreviewsByIds(ids: List<UUID>): Flow<List<RecipePreview>>
+
+    /** Returns the number of recipes created by (or belonging to) the given user. */
+    suspend fun getRecipeCountForUser(userId: UUID): Int
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,9 @@
     <string name="meal_plan_created">Meal plan created! 🎉</string>
     <string name="meal_plan_save_error">Failed to save meal plan</string>
     <string name="meal_plan_default_name">Week plan</string>
+    <string name="meal_plan_not_found">Meal plan not found</string>
+    <string name="meal_plan_not_found_subtitle">This meal plan may have been deleted.</string>
+    <string name="app_dest_title_meal_plan_detail">Meal Plan</string>
 
     <!-- Meal Plan Wizard -->
     <string name="app_dest_title_meal_plan_wizard">Create Meal Plan</string>
@@ -138,6 +141,7 @@
     <string name="wizard_servings_title">👥 How many servings?</string>
     <string name="wizard_dietary_title">🥗 Any dietary preferences?</string>
     <string name="wizard_recipe_source_title">📖 Where should recipes come from?</string>
+    <string name="wizard_recipe_source_collection_too_small">Add at least 20 recipes to your collection to use only recipes in your collection</string>
     <string name="wizard_prep_time_title">⏱️ Max prep time per meal?</string>
     <string name="wizard_batch_cooking_title">❄️ Batch cook &amp; freeze?</string>
     <string name="wizard_batch_cooking_subtitle">Cook larger portions and freeze for later</string>

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncExecutor.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncExecutor.kt
@@ -1,0 +1,18 @@
+package com.tenmilelabs.chefai.core.data.sync
+
+class FakeSyncExecutor : SyncExecutor {
+
+    var syncCount = 0
+        private set
+
+    var shouldThrow: Boolean = false
+
+    override suspend fun sync(): SyncResult {
+        if (shouldThrow) throw RuntimeException("Fake sync error")
+        syncCount++
+        return SyncResult(
+            pushResult = PushResult(accepted = 0, conflicts = 0, errors = 0),
+            pullResult = PullResult(upserted = 0, deleted = 0, pages = 1),
+        )
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncE2ETest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncE2ETest.kt
@@ -13,6 +13,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeLabelDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeLabelCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeStepDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
@@ -123,6 +124,7 @@ class SyncE2ETest {
             recipeTagCrossRefDao = recipeTagCrossRefDao,
             recipeLabelCrossRefDao = recipeLabelCrossRefDao,
             bookmarkedRecipeDao = bookmarkedRecipeDao,
+            mealPlanDao = FakeMealPlanDao(),
             sessionManager = sessionManager,
             syncMetadataDao = syncMetadataDao,
             transactionRunner = fakeTransactionRunner,

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
@@ -11,6 +11,7 @@ import com.tenmilelabs.chefai.core.data.local.room.RecipeTagCrossRef
 import com.tenmilelabs.chefai.core.data.local.room.IngredientEntity
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeAllergenDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeBookmarkedRecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeIngredientDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeLabelDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDao
@@ -113,6 +114,7 @@ class SyncOrchestratorTest {
             recipeTagCrossRefDao = recipeTagCrossRefDao,
             recipeLabelCrossRefDao = recipeLabelCrossRefDao,
             bookmarkedRecipeDao = bookmarkedRecipeDao,
+            mealPlanDao = FakeMealPlanDao(),
             sessionManager = sessionManager,
             syncMetadataDao = syncMetadataDao,
             transactionRunner = fakeTransactionRunner,

--- a/app/src/test/java/com/tenmilelabs/chefai/home/data/repository/FakeRecipesRepository.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/home/data/repository/FakeRecipesRepository.kt
@@ -41,4 +41,5 @@ class FakeRecipesRepository : RecipesRepository {
     override suspend fun deleteAllRecipes() = error("Not used in home tests")
     override suspend fun deleteRecipe(recipeId: UUID) = error("Not used in home tests")
     override suspend fun softDeleteRecipe(recipeId: UUID) = error("Not used in home tests")
+    override suspend fun getRecipeCountForUser(userId: UUID): Int = error("Not used in home tests")
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/mealplans/data/repository/FakeMealPlanRepository.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/mealplans/data/repository/FakeMealPlanRepository.kt
@@ -14,6 +14,12 @@ class FakeMealPlanRepository : MealPlanRepository {
     var shouldThrowOnCreate: Boolean = false
     var shouldThrowOnDelete: Boolean = false
     var shouldThrowOnObserve: Boolean = false
+    var shouldFailGeneration: Boolean = false
+    var generationRequestedIds: MutableList<UUID> = mutableListOf()
+
+    override fun observeMealPlan(uuid: UUID): Flow<MealPlan?> {
+        return plans.map { list -> list.find { it.uuid == uuid } }
+    }
 
     override fun observeMealPlansForUser(userId: UUID): Flow<List<MealPlan>> {
         if (shouldThrowOnObserve) throw RuntimeException("Fake observe error")
@@ -28,6 +34,15 @@ class FakeMealPlanRepository : MealPlanRepository {
     override suspend fun deleteMealPlan(uuid: UUID) {
         if (shouldThrowOnDelete) throw RuntimeException("Fake delete error")
         plans.value = plans.value.filter { it.uuid != uuid }
+    }
+
+    override suspend fun requestGeneration(planId: UUID): Result<Unit> {
+        generationRequestedIds.add(planId)
+        return if (shouldFailGeneration) {
+            Result.failure(RuntimeException("Fake generation error"))
+        } else {
+            Result.success(Unit)
+        }
     }
 
     fun emitPlans(vararg mealPlans: MealPlan) {

--- a/app/src/test/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/mealplans/ui/create/CreateMealPlanViewModelTest.kt
@@ -4,10 +4,12 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.core.data.sync.FakeSyncExecutor
 import com.tenmilelabs.chefai.core.testutil.createTestSessionManager
 import com.tenmilelabs.chefai.core.util.MainCoroutineRule
 import com.tenmilelabs.chefai.mealplans.data.repository.FakeMealPlanRepository
 import com.tenmilelabs.chefai.mealplans.domain.model.DietaryRestriction
+import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipesRepository
 import com.tenmilelabs.chefai.mealplans.domain.model.MealType
 import com.tenmilelabs.chefai.mealplans.domain.model.RecipeSource
 import com.tenmilelabs.chefai.mealplans.domain.model.VarietyPreference
@@ -26,16 +28,30 @@ class CreateMealPlanViewModelTest {
     val mainCoroutineRule = MainCoroutineRule()
 
     private lateinit var repository: FakeMealPlanRepository
+    private lateinit var recipesRepository: FakeRecipesRepository
     private lateinit var sessionManager: SessionManager
+    private lateinit var syncExecutor: FakeSyncExecutor
     private lateinit var viewModel: CreateMealPlanViewModel
 
     @Before
     fun setup() {
         repository = FakeMealPlanRepository()
+        recipesRepository = FakeRecipesRepository()
+        recipesRepository.fakeRecipeCount = 50 // enough to allow COLLECTION_ONLY
         sessionManager = createTestSessionManager(CoroutineScope(mainCoroutineRule.testDispatcher))
-        viewModel = CreateMealPlanViewModel(
+        syncExecutor = FakeSyncExecutor()
+        viewModel = createViewModel()
+    }
+
+    private fun createViewModel(
+        recipeCount: Int = recipesRepository.fakeRecipeCount,
+    ): CreateMealPlanViewModel {
+        recipesRepository.fakeRecipeCount = recipeCount
+        return CreateMealPlanViewModel(
             mealPlanRepository = repository,
             sessionManager = sessionManager,
+            syncExecutor = syncExecutor,
+            recipesRepository = recipesRepository,
         )
     }
 
@@ -167,10 +183,31 @@ class CreateMealPlanViewModelTest {
     // --- Save ---
 
     @Test
-    fun `SaveMealPlan emits MealPlanCreated on success`() = runTest {
+    fun `SaveMealPlan emits MealPlanReady when sync and generation succeed`() = runTest {
         viewModel.uiEvents.test {
             viewModel.onAction(WizardAction.SaveMealPlan)
-            assertThat(awaitItem()).isEqualTo(CreateMealPlanEvent.MealPlanCreated)
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(CreateMealPlanEvent.MealPlanReady::class.java)
+        }
+    }
+
+    @Test
+    fun `SaveMealPlan emits MealPlanSavedAsDraft when sync fails`() = runTest {
+        syncExecutor.shouldThrow = true
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(CreateMealPlanEvent.MealPlanSavedAsDraft::class.java)
+        }
+    }
+
+    @Test
+    fun `SaveMealPlan emits MealPlanSavedAsDraft when generation fails`() = runTest {
+        repository.shouldFailGeneration = true
+        viewModel.uiEvents.test {
+            viewModel.onAction(WizardAction.SaveMealPlan)
+            val event = awaitItem()
+            assertThat(event).isInstanceOf(CreateMealPlanEvent.MealPlanSavedAsDraft::class.java)
         }
     }
 
@@ -228,5 +265,30 @@ class CreateMealPlanViewModelTest {
             awaitItem()
         }
         assertThat(viewModel.uiState.value.isSaving).isFalse()
+    }
+
+    // --- Collection too small ---
+
+    @Test
+    fun `collectionTooSmall is true and recipeSource defaults to INCLUDE_PUBLIC when under 20 recipes`() = runTest {
+        val vm = createViewModel(recipeCount = 5)
+        val state = vm.uiState.value
+        assertThat(state.collectionTooSmall).isTrue()
+        assertThat(state.recipeSource).isEqualTo(RecipeSource.INCLUDE_PUBLIC)
+    }
+
+    @Test
+    fun `collectionTooSmall is false when user has 20 or more recipes`() = runTest {
+        val vm = createViewModel(recipeCount = 20)
+        val state = vm.uiState.value
+        assertThat(state.collectionTooSmall).isFalse()
+        assertThat(state.recipeSource).isEqualTo(RecipeSource.COLLECTION_ONLY)
+    }
+
+    @Test
+    fun `SetRecipeSource to COLLECTION_ONLY is ignored when collection is too small`() = runTest {
+        val vm = createViewModel(recipeCount = 5)
+        vm.onAction(WizardAction.SetRecipeSource(RecipeSource.COLLECTION_ONLY))
+        assertThat(vm.uiState.value.recipeSource).isEqualTo(RecipeSource.INCLUDE_PUBLIC)
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipesRepository.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipesRepository.kt
@@ -161,4 +161,8 @@ class FakeRecipesRepository : RecipesRepository {
         val idSet = ids.toHashSet()
         return recipesPreviewListFlow.map { all -> all.filter { it.uuid in idSet } }
     }
+
+    var fakeRecipeCount: Int = 0
+
+    override suspend fun getRecipeCountForUser(userId: UUID): Int = fakeRecipeCount
 }


### PR DESCRIPTION
## Summary

- **Meal plan sync integration**: Wired meal plans into the existing push/pull sync infrastructure — added `SyncMealPlanDto`/`SyncMealPlanDayDto`, extended `SyncOrchestrator` for meal plan push/pull, and added sync mappers in both directions.
- **Generate API**: Added `MealPlanNetworkDataSource` interface + `MealPlanApiService` (Ktor) hitting `POST /meal-plans/{id}/generate`, wired into `DefaultMealPlanRepository.requestGeneration()`.
- **Meal plan detail screen**: New `MealPlanDetailScreen` + `MealPlanDetailViewModel` showing preferences summary, day headers (e.g. "Day 1", "Day 1 — Lunch"), and large recipe cards. Clickable cards open recipe detail while keeping bottom nav on the Meal Plans tab.
- **One-step generation flow**: Wizard now creates → pushes → generates → pulls in a single action. User lands directly on the detail screen with populated recipes. Falls back to DRAFT with a manual Generate button only on sync/BE failure.
- **`SyncExecutor` interface**: Extracted from `SyncOrchestrator` to provide an awaitable `suspend fun sync()` for callers that need to block until sync completes (vs fire-and-forget `SyncScheduler`).
- **Fixed generation race condition**: Previous flow used fire-and-forget `SyncScheduler.requestImmediateSync()`, causing the pull to run before server-side generation completed. Now uses `SyncExecutor.sync()` with a brief delay to ensure results are ready.
- **Fixed duplicate LazyColumn key crash**: Same recipe appearing on multiple days caused `IllegalArgumentException`. Keys now include list index for uniqueness.
- **Collection size guard**: "My collection only" recipe source is disabled when user has < 20 recipes, auto-defaulting to "Include public recipes" with an explanatory message.
- **Moved Max Prep Time to step 3**: Relocated `PrepTimeSelector` from the Preferences step to the Advanced step to prevent content being cropped on smaller screens.
- **Clickable meal plan cards**: `MealPlanCard` is now tappable, navigating to the detail screen.
- **Section-aware bottom nav**: Refactored selection logic so Meal Plans tab stays highlighted when viewing recipes opened from within a meal plan.

## Test plan

- [x]  All 330+ unit tests pass (0 failures)
- [ ]  Create a meal plan via wizard → verify it generates immediately and navigates to detail with recipes
- [ ]  Kill network, create a meal plan → verify it saves as DRAFT with Generate button available
- [ ]  Tap Generate on a DRAFT plan → verify spinner appears then recipes load
- [ ]  Verify same recipe on multiple days doesn't crash the detail screen
- [ ]  With < 20 recipes: verify "My collection only" chip is disabled and defaults to "Include public"
- [ ]  With ≥ 20 recipes: verify both options are selectable
- [ ]  Verify Max Prep Time appears on step 3 and is not cropped
- [ ]  Tap a recipe card from meal plan detail → verify recipe opens with Meal Plans tab still highlighted