### PR TITLE
Recipe URL import: scraper module, text parsers, editor draft hand-off

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,9 @@ hilt {
 
 dependencies {
 
+    // Recipe URL scraping (pure Kotlin, no Android deps)
+    implementation(project(":recipe-scraper"))
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.core)
     implementation(libs.material)

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
@@ -3,6 +3,7 @@ package com.tenmilelabs.chefai.core.ui.navigation
 import androidx.annotation.StringRes
 import androidx.navigation.NavHostController
 import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.DRAFT_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.MEAL_PLAN_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.RECIPE_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.ScreenBaseRoutes.RECIPE_DETAILS
@@ -18,6 +19,7 @@ internal object ScreenBaseRoutes {
     const val RECIPE_DETAILS = "recipe_details_screen"
     const val CREATE_RECIPE = "create_recipe_screen"
     const val RECIPE_EDITOR = "recipe_editor_screen"
+    const val IMPORT_RECIPE = "import_recipe_screen"
     const val SETTINGS = "settings_screen"
     const val LOGIN = "login_screen"
     const val REGISTER = "register_screen"
@@ -35,6 +37,13 @@ internal object ScreenBaseRoutes {
 object AppDestinationArgs {
     const val RECIPE_ID_ARG = "recipeUuid"
     const val MEAL_PLAN_ID_ARG = "mealPlanId"
+
+    /**
+     * Id of a pre-seeded [com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity] the editor
+     * should open in **create** mode, used by recipe URL import. Distinct from [RECIPE_ID_ARG],
+     * which puts the editor in edit mode against an already-saved recipe.
+     */
+    const val DRAFT_ID_ARG = "draftUuid"
 }
 
 /**
@@ -54,8 +63,11 @@ enum class AppDestinations(
     CREATE_RECIPE(R.string.app_dest_title_create_recipe, ScreenBaseRoutes.CREATE_RECIPE),
     RECIPE_EDITOR(
         R.string.app_dest_title_recipe_editor,
-        "${ScreenBaseRoutes.RECIPE_EDITOR}?${RECIPE_ID_ARG}={${RECIPE_ID_ARG}}"
+        "${ScreenBaseRoutes.RECIPE_EDITOR}" +
+            "?${RECIPE_ID_ARG}={${RECIPE_ID_ARG}}" +
+            "&${DRAFT_ID_ARG}={${DRAFT_ID_ARG}}"
     ),
+    IMPORT_RECIPE(R.string.app_dest_title_import_recipe, ScreenBaseRoutes.IMPORT_RECIPE),
     MEAL_PLAN_DETAIL(
         R.string.app_dest_title_meal_plan_detail,
         "${ScreenBaseRoutes.MEAL_PLAN_DETAIL}/{$MEAL_PLAN_ID_ARG}"
@@ -85,6 +97,21 @@ class NavigationActions(private val navController: NavHostController) {
 
     fun navigateToEditRecipe(recipeId: UUID) {
         navController.navigate("${ScreenBaseRoutes.RECIPE_EDITOR}?${RECIPE_ID_ARG}=$recipeId")
+    }
+
+    fun navigateToImportRecipe() {
+        navController.navigate(ScreenBaseRoutes.IMPORT_RECIPE)
+    }
+
+    /**
+     * Opens the editor in **create** mode against an already-persisted draft — the hand-off after a
+     * recipe has been scraped from a URL. The import screen is popped so that backing out of the
+     * editor returns to the recipe list rather than to a stale URL field.
+     */
+    fun navigateToEditorWithDraft(draftId: UUID) {
+        navController.navigate("${ScreenBaseRoutes.RECIPE_EDITOR}?${DRAFT_ID_ARG}=$draftId") {
+            popUpTo(ScreenBaseRoutes.IMPORT_RECIPE) { inclusive = true }
+        }
     }
 
     fun navigateToLogin() {

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -182,7 +182,12 @@ fun ChefAINavGraph(
                     type = NavType.StringType
                     nullable = true
                     defaultValue = null
-                }
+                },
+                navArgument(AppDestinationArgs.DRAFT_ID_ARG) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
             ),
         ) {
             RecipeEditorScreen(

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModel.kt
@@ -51,16 +51,24 @@ class RecipeEditorViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val recipeIdArg: String? = savedStateHandle[AppDestinationArgs.RECIPE_ID_ARG]
-    val mode: EditorMode = if (recipeIdArg != null) {
-        EditorMode.Edit(UUID.fromString(recipeIdArg))
-    } else {
-        EditorMode.Create
-    }
+
+    /**
+     * Id of a draft seeded by another screen (recipe URL import) for this editor to adopt.
+     * Stays in **create** mode: [restoreDraftIfExists] picks the draft up on init, and saving takes
+     * the create path rather than updating an existing recipe.
+     */
+    private val draftIdArg: String? = savedStateHandle[AppDestinationArgs.DRAFT_ID_ARG]
+
+    val mode: EditorMode = recipeIdArg?.toUuidOrNull()
+        ?.let { EditorMode.Edit(it) }
+        ?: EditorMode.Create
 
     private val _state = MutableStateFlow(
         RecipeEditorState(
             mode = mode,
-            recipeId = (mode as? EditorMode.Edit)?.recipeId ?: UuidV7Generator.newId(),
+            recipeId = (mode as? EditorMode.Edit)?.recipeId
+                ?: draftIdArg?.toUuidOrNull()
+                ?: UuidV7Generator.newId(),
             isLoading = mode is EditorMode.Edit,
         )
     )
@@ -405,4 +413,16 @@ class RecipeEditorViewModel @Inject constructor(
     companion object {
         const val AUTO_SAVE_INTERVAL_MS = 10_000L
     }
+}
+
+/**
+ * Parses a nav-argument string as a UUID, returning `null` rather than throwing on malformed input.
+ * Nav args arrive as untrusted strings (deep links included), and a bad one should degrade to a
+ * blank new recipe instead of crashing the ViewModel during construction.
+ */
+private fun String.toUuidOrNull(): UUID? = try {
+    UUID.fromString(this)
+} catch (e: IllegalArgumentException) {
+    Timber.w(e, "Malformed UUID nav argument: %s", this)
+    null
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="app_dest_title_recipes">Recipes</string>
     <string name="app_dest_title_register">Register</string>
     <string name="app_dest_title_recipe_editor">Recipe Editor</string>
+    <string name="app_dest_title_import_recipe">Import Recipe</string>
     <string name="app_dest_title_settings">Settings</string>
     <string name="app_name">ChefAI</string>
     <string name="button_select_photo">Select Photo from Gallery</string>

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModelTest.kt
@@ -3,7 +3,10 @@ package com.tenmilelabs.chefai.recipes.ui.editor
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.tenmilelabs.chefai.collections.data.repository.FakeCollectionsRepository
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDraftDao
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
 import com.tenmilelabs.chefai.core.data.repository.FakeMetadataRepository
 import com.tenmilelabs.chefai.core.testutil.createTestSessionManager
@@ -48,9 +51,11 @@ class RecipeEditorViewModelTest {
 
     private fun createViewModel(
         recipeId: String? = null,
+        draftId: String? = null,
     ): RecipeEditorViewModel {
         val savedStateHandle = SavedStateHandle().apply {
             if (recipeId != null) set(AppDestinationArgs.RECIPE_ID_ARG, recipeId)
+            if (draftId != null) set(AppDestinationArgs.DRAFT_ID_ARG, draftId)
         }
         return RecipeEditorViewModel(
             recipesRepository = recipesRepository,
@@ -85,6 +90,109 @@ class RecipeEditorViewModelTest {
         assertEquals(recipe1.uuid, (vm.mode as EditorMode.Edit).recipeId)
         vm.viewModelScope.cancel()
     }
+
+    // --- Seeded Draft (recipe URL import hand-off) ---
+
+    @Test
+    fun `draftId arg stays in create mode and adopts the draft id`() = runTest {
+        val draftId = UuidV7Generator.newId()
+
+        val vm = createViewModel(draftId = draftId.toString())
+
+        assertEquals(EditorMode.Create, vm.mode)
+        assertEquals(draftId, vm.state.value.recipeId)
+        assertFalse(vm.state.value.isLoading)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
+    fun `seeded draft populates editor state and is immediately valid`() = runTest {
+        val draftId = UuidV7Generator.newId()
+        recipeDraftDao.saveDraft(completeImportedDraft(draftId).toRecipeDraftEntity())
+
+        val vm = createViewModel(draftId = draftId.toString())
+
+        val state = vm.state.value
+        assertEquals("Scraped Pancakes", state.recipeFields.title)
+        assertEquals("From a food blog", state.recipeFields.description)
+        assertEquals("5", state.recipeFields.prepTimeMinutes)
+        assertEquals("15", state.recipeFields.cookTimeMinutes)
+        assertEquals("4", state.recipeFields.servings)
+        assertEquals("https://example.com/pancakes", state.recipeFields.externalUrl)
+        assertEquals(1, state.ingredients.selectedIngredients.size)
+        assertEquals(1, state.steps.steps.size)
+        // The whole point of the import hand-off: the user can save without touching anything.
+        assertTrue(state.isFormValid)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
+    fun `saving a seeded draft takes the create path not update`() = runTest {
+        val draftId = UuidV7Generator.newId()
+        recipeDraftDao.saveDraft(completeImportedDraft(draftId).toRecipeDraftEntity())
+
+        val vm = createViewModel(draftId = draftId.toString())
+        vm.dispatch(EditorAction.Save)
+
+        assertEquals("Scraped Pancakes", recipesRepository.lastCreatedRecipe?.title)
+        assertNull(recipesRepository.lastUpdatedRecipe)
+        // Source URL survives the round trip into the saved recipe.
+        assertEquals(
+            "https://example.com/pancakes",
+            recipesRepository.lastCreatedRecipe?.recipeExternalUrl,
+        )
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
+    fun `malformed recipeId arg falls back to create mode instead of crashing`() = runTest {
+        val vm = createViewModel(recipeId = "not-a-uuid")
+
+        assertEquals(EditorMode.Create, vm.mode)
+        assertFalse(vm.state.value.isLoading)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
+    fun `malformed draftId arg falls back to a fresh recipe id`() = runTest {
+        val vm = createViewModel(draftId = "not-a-uuid")
+
+        assertEquals(EditorMode.Create, vm.mode)
+        assertNotNull(vm.state.value.recipeId)
+        assertTrue(vm.state.value.recipeFields.title.isEmpty())
+        vm.viewModelScope.cancel()
+    }
+
+    /** Mirrors what the recipe URL importer persists before handing off to the editor. */
+    private fun completeImportedDraft(draftId: java.util.UUID) = RecipeDraft(
+        recipeId = draftId,
+        isNewRecipe = true,
+        title = "Scraped Pancakes",
+        description = "From a food blog",
+        prepTimeMinutes = "5",
+        cookTimeMinutes = "15",
+        servings = "4",
+        externalUrl = "https://example.com/pancakes",
+        ingredients = listOf(
+            RecipeIngredient(
+                ingredientId = UuidV7Generator.newId(),
+                ingredientDisplayName = "flour",
+                quantity = 2.0,
+                unit = "cup",
+                allergenName = null,
+                srcCategory = null,
+                srcSubcategory = null,
+            )
+        ),
+        steps = listOf(
+            RecipeStep(
+                uuid = UuidV7Generator.newId(),
+                orderIndex = 0,
+                instruction = "Mix everything together.",
+            )
+        ),
+        updatedAt = 1L,
+    )
 
     // --- Edit Mode Loading ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.ksp) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.room) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlin = "2.3.0"
 kotlinxCoroutines = "1.10.2"
 kotlinxSerializationJson = "1.9.0"
 kspVersion = "2.3.2"
+ksoup = "0.2.6"
 ktorClientCio = "3.3.3"
 ktorVersion = "3.3.3"
 lifecycleViewmodel = "2.10.0"
@@ -75,6 +76,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktorClientCio" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktorVersion" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVersion" }
@@ -98,5 +100,6 @@ hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = {id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 room = { id = "androidx.room", version.ref = "roomRuntime" }

--- a/recipe-scraper/build.gradle.kts
+++ b/recipe-scraper/build.gradle.kts
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+// Pure Kotlin recipe extraction library. Deliberately free of Android, Hilt, Room and Ktor
+// dependencies: it takes an HTML string and returns a structured recipe, doing no network I/O.
+// Only a jvm() target is declared today; the code all lives in commonMain so additional KMP
+// targets (iOS, JS) can be added without moving files.
+kotlin {
+    // Targets JVM 11 bytecode to match :app, without requiring a JDK 11 toolchain be installed.
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.ksoup)
+            // Used for its untyped JsonElement API only — schema.org shapes are too
+            // polymorphic to model with @Serializable classes, so no plugin is needed.
+            implementation(libs.kotlinx.serialization.json)
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
+}

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParser.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParser.kt
@@ -1,0 +1,201 @@
+package com.tenmilelabs.recipescraper.ingredient
+
+import com.tenmilelabs.recipescraper.model.ScrapedIngredient
+import com.tenmilelabs.recipescraper.util.collapseWhitespace
+
+/**
+ * Splits a free-text ingredient line into an amount, a unit and a name.
+ *
+ * schema.org publishes `recipeIngredient` as prose ("2 cups all-purpose flour, sifted"), so this is
+ * necessarily heuristic. It is built to degrade rather than guess: anything it cannot confidently
+ * split comes back with a null quantity and unit and the whole line as the name, which a UI can
+ * still display correctly. It never throws.
+ */
+internal fun parseIngredient(raw: String): ScrapedIngredient {
+    val text = raw.trim().collapseWhitespace()
+    if (text.isEmpty()) return ScrapedIngredient(raw = raw, quantity = null, unit = null, name = "")
+
+    val tokens = text.split(' ').filter { it.isNotEmpty() }
+    var index = 0
+    var quantity: Double? = null
+
+    parseNumber(tokens[0])?.let { leading ->
+        quantity = leading
+        index = 1
+
+        // A mixed number arrives as two tokens: "1 1/2 cups".
+        if (index < tokens.size) {
+            parseFractionOnly(tokens[index])?.let { fraction ->
+                quantity = leading + fraction
+                index++
+            }
+        }
+
+        // A spelled-out range ("2 to 3 tablespoons") — keep the lower bound, drop the rest.
+        if (index + 1 < tokens.size &&
+            tokens[index].lowercase() in RANGE_WORDS &&
+            parseNumber(tokens[index + 1]) != null
+        ) {
+            index += 2
+        }
+
+        // A parenthetical size qualifier often sits between amount and unit: "1 (14 oz) can".
+        index = skipParenthetical(tokens, index)
+    }
+
+    var unit: String? = null
+    // Only look for a unit behind an amount; without one, a leading word is far more likely to be
+    // part of the name ("Salt to taste") than a unit.
+    if (quantity != null && index < tokens.size) {
+        normalizeUnit(tokens[index])?.let { matched ->
+            unit = matched
+            index = skipParenthetical(tokens, index + 1)
+        }
+    }
+
+    val name = tokens.drop(index)
+        .joinToString(" ")
+        .removePrefix("of ")
+        .removePrefix("Of ")
+        .trim()
+        // A line that was nothing but an amount still needs a usable label.
+        .ifEmpty { text }
+
+    return ScrapedIngredient(raw = raw, quantity = quantity, unit = unit, name = name)
+}
+
+/** Advances past a `( … )` group starting at [index], leaving [index] untouched if none is there. */
+private fun skipParenthetical(tokens: List<String>, index: Int): Int {
+    if (index >= tokens.size || !tokens[index].startsWith("(")) return index
+    var cursor = index
+    while (cursor < tokens.size) {
+        val closes = tokens[cursor].endsWith(")")
+        cursor++
+        if (closes) return cursor
+    }
+    // Unbalanced parenthesis — leave the tokens in the name rather than swallowing the whole line.
+    return index
+}
+
+/** Parses a leading amount, resolving a numeric range such as `"2-3"` to its lower bound. */
+private fun parseNumber(token: String): Double? {
+    for (dash in DASHES) {
+        if (!token.contains(dash)) continue
+        val parts = token.split(dash).filter { it.isNotBlank() }
+        if (parts.size == 2) {
+            val lower = parseSingleNumber(parts[0])
+            // Require both sides to be numeric, so hyphenated words ("all-purpose") aren't split.
+            if (lower != null && parseSingleNumber(parts[1]) != null) return lower
+        }
+    }
+    return parseSingleNumber(token)
+}
+
+/** Parses a token only if it is purely a fraction, used to attach the tail of a mixed number. */
+private fun parseFractionOnly(token: String): Double? {
+    val isFraction = token.contains('/') || token.any { it in VULGAR_FRACTIONS }
+    return if (isFraction) parseSingleNumber(token) else null
+}
+
+private fun parseSingleNumber(text: String): Double? {
+    if (text.isEmpty()) return null
+
+    // Vulgar fractions, alone ("½") or fused to a whole number ("1½").
+    val vulgarAt = text.indexOfFirst { it in VULGAR_FRACTIONS }
+    if (vulgarAt >= 0) {
+        // Anything trailing the glyph means this isn't a bare amount.
+        if (vulgarAt != text.length - 1) return null
+        val fraction = VULGAR_FRACTIONS[text[vulgarAt]] ?: return null
+        val whole = text.substring(0, vulgarAt)
+        if (whole.isEmpty()) return fraction
+        return whole.toDoubleOrNull()?.plus(fraction)
+    }
+
+    if (text.contains('/')) {
+        val parts = text.split('/')
+        if (parts.size != 2) return null
+        val numerator = parts[0].toDoubleOrNull() ?: return null
+        val denominator = parts[1].toDoubleOrNull() ?: return null
+        return if (denominator == 0.0) null else numerator / denominator
+    }
+
+    // Accept a comma decimal separator, as used across most of Europe.
+    return text.replace(',', '.').toDoubleOrNull()
+}
+
+/**
+ * Maps a unit token onto a canonical short form, or `null` if it isn't a recognised unit.
+ *
+ * Single-letter forms are matched case-sensitively first, because `T` (tablespoon) and `t`
+ * (teaspoon) are distinguished only by case in recipe shorthand.
+ */
+private fun normalizeUnit(token: String): String? {
+    val bare = token.trim().trimEnd('.', ',')
+    if (bare.isEmpty()) return null
+    CASE_SENSITIVE_UNITS[bare]?.let { return it }
+    return UNITS[bare.lowercase()]
+}
+
+private val DASHES = listOf('-', '–', '—')
+
+private val RANGE_WORDS = setOf("to", "or")
+
+private val VULGAR_FRACTIONS: Map<Char, Double> = mapOf(
+    '½' to 0.5,          // ½
+    '¼' to 0.25,         // ¼
+    '¾' to 0.75,         // ¾
+    '⅓' to 1.0 / 3.0,    // ⅓
+    '⅔' to 2.0 / 3.0,    // ⅔
+    '⅕' to 0.2,          // ⅕
+    '⅖' to 0.4,          // ⅖
+    '⅗' to 0.6,          // ⅗
+    '⅘' to 0.8,          // ⅘
+    '⅙' to 1.0 / 6.0,    // ⅙
+    '⅚' to 5.0 / 6.0,    // ⅚
+    '⅐' to 1.0 / 7.0,    // ⅐
+    '⅛' to 0.125,        // ⅛
+    '⅜' to 0.375,        // ⅜
+    '⅝' to 0.625,        // ⅝
+    '⅞' to 0.875,        // ⅞
+    '⅑' to 1.0 / 9.0,    // ⅑
+    '⅒' to 0.1,          // ⅒
+)
+
+private val CASE_SENSITIVE_UNITS: Map<String, String> = mapOf(
+    "T" to "tbsp",
+    "t" to "tsp",
+)
+
+private val UNITS: Map<String, String> = buildMap {
+    fun unit(canonical: String, vararg synonyms: String) {
+        put(canonical, canonical)
+        synonyms.forEach { put(it, canonical) }
+    }
+    unit("cup", "cups", "c")
+    unit("tbsp", "tbsps", "tablespoon", "tablespoons", "tbs", "tbl", "tblsp")
+    unit("tsp", "tsps", "teaspoon", "teaspoons")
+    unit("oz", "ounce", "ounces")
+    unit("lb", "lbs", "pound", "pounds")
+    unit("g", "gr", "gram", "grams", "gramme", "grammes")
+    unit("kg", "kilo", "kilos", "kilogram", "kilograms")
+    unit("mg", "milligram", "milligrams")
+    unit("ml", "milliliter", "milliliters", "millilitre", "millilitres")
+    unit("l", "liter", "liters", "litre", "litres")
+    unit("pinch", "pinches")
+    unit("dash", "dashes")
+    unit("clove", "cloves")
+    unit("slice", "slices")
+    unit("can", "cans")
+    unit("jar", "jars")
+    unit("package", "packages", "pkg", "pkgs", "pack", "packs")
+    unit("quart", "quarts", "qt", "qts")
+    unit("pint", "pints", "pt", "pts")
+    unit("gallon", "gallons", "gal")
+    unit("stick", "sticks")
+    unit("sprig", "sprigs")
+    unit("bunch", "bunches")
+    unit("head", "heads")
+    unit("handful", "handfuls")
+    unit("piece", "pieces")
+    unit("sheet", "sheets")
+}

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapeResult.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapeResult.kt
@@ -1,0 +1,34 @@
+package com.tenmilelabs.recipescraper.model
+
+/**
+ * The outcome of attempting to extract a recipe from an HTML document.
+ *
+ * Extraction failure is an expected result, not an exception: plenty of URLs are simply not recipe
+ * pages.
+ */
+sealed interface ScrapeResult {
+
+    /** A recipe was found. [source] records which extraction strategy produced it. */
+    data class Success(val recipe: ScrapedRecipe, val source: ExtractionSource) : ScrapeResult
+
+    /**
+     * The document parsed cleanly but carried no usable recipe — either no recipe markup at all,
+     * or markup too incomplete to use (no title, or neither ingredients nor instructions).
+     */
+    data object NoRecipeFound : ScrapeResult
+
+    /** The document could not be parsed. [message] describes the failure for logging. */
+    data class ParseError(val message: String) : ScrapeResult
+}
+
+/**
+ * Which markup format a recipe was extracted from. Both encode schema.org's `Recipe` type; JSON-LD
+ * is tried first because it is by far the more common and the more reliably structured.
+ */
+enum class ExtractionSource {
+    /** A `<script type="application/ld+json">` block. */
+    JSON_LD,
+
+    /** Inline `itemscope`/`itemprop` microdata attributes. */
+    MICRODATA,
+}

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapedIngredient.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapedIngredient.kt
@@ -1,0 +1,22 @@
+package com.tenmilelabs.recipescraper.model
+
+/**
+ * A single ingredient line, as found on a recipe page and split into its parts.
+ *
+ * Recipe sites publish ingredients as free text ("2 cups all-purpose flour, sifted"), so
+ * [quantity] and [unit] are best-effort: both are `null` when the line carries no recognisable
+ * amount ("Salt to taste"). Callers decide what to substitute — this library does not invent values.
+ *
+ * @property raw the untouched source line, always populated, so callers can display or re-parse it.
+ * @property quantity the parsed amount, or `null` if the line had none.
+ * @property unit the unit normalised to a canonical short form (e.g. `"cup"`, `"tbsp"`), or `null`
+ *   if the line had no recognisable unit.
+ * @property name the ingredient text with the quantity and unit removed. Never blank — falls back
+ *   to the whole of [raw] when the line could not be split.
+ */
+data class ScrapedIngredient(
+    val raw: String,
+    val quantity: Double?,
+    val unit: String?,
+    val name: String,
+)

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapedRecipe.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapedRecipe.kt
@@ -1,0 +1,39 @@
+package com.tenmilelabs.recipescraper.model
+
+/**
+ * A recipe extracted from a web page.
+ *
+ * Every field that a page may legitimately omit is nullable or empty rather than defaulted: this
+ * library reports what the page actually published and never fabricates data. Choosing fallbacks
+ * (for example, treating a missing prep time as zero) is the caller's decision.
+ *
+ * @property title the recipe name. Always non-blank — extraction fails rather than returning a
+ *   recipe without one.
+ * @property description the page's own summary, with any embedded HTML stripped.
+ * @property imageUrl the first usable image URL found, which may be relative to [sourceUrl].
+ * @property prepTimeMinutes preparation time in whole minutes.
+ * @property cookTimeMinutes cooking time in whole minutes.
+ * @property totalTimeMinutes total time in whole minutes. Frequently present when the prep/cook
+ *   split is not, so callers can derive one from the other.
+ * @property servings the yield as a whole number of servings.
+ * @property ingredients ingredient lines in source order; may be empty.
+ * @property instructions instruction steps in order, flattened across any sections, with HTML
+ *   stripped and blanks dropped; may be empty.
+ * @property keywords tags, cuisines and categories the page declared, deduplicated.
+ * @property author the recipe author's name.
+ * @property sourceUrl the URL this recipe was extracted from, as supplied by the caller.
+ */
+data class ScrapedRecipe(
+    val title: String,
+    val description: String?,
+    val imageUrl: String?,
+    val prepTimeMinutes: Int?,
+    val cookTimeMinutes: Int?,
+    val totalTimeMinutes: Int?,
+    val servings: Int?,
+    val ingredients: List<ScrapedIngredient>,
+    val instructions: List<String>,
+    val keywords: List<String>,
+    val author: String?,
+    val sourceUrl: String,
+)

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/util/HtmlText.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/util/HtmlText.kt
@@ -1,0 +1,42 @@
+package com.tenmilelabs.recipescraper.util
+
+import com.fleeksoft.ksoup.Ksoup
+
+/**
+ * Reduces a string that may contain HTML to plain text: tags removed, entities decoded, whitespace
+ * collapsed to single spaces. Recipe sites routinely embed `<p>`, `<a>` and `<br>` inside JSON-LD
+ * string values, so this runs over every extracted text field.
+ *
+ * Returns `null` for input that is null, or that is blank once cleaned.
+ */
+internal fun cleanHtmlText(raw: String?): String? {
+    if (raw.isNullOrBlank()) return null
+    // Only pay for a parse when the text actually looks like markup; the common case is plain text.
+    val text = if (raw.containsMarkup()) Ksoup.parse(raw).text() else raw
+    return text.collapseWhitespace().takeIf { it.isNotBlank() }
+}
+
+private fun String.containsMarkup(): Boolean = contains('<') || contains('&')
+
+/** Collapses all whitespace runs — including non-breaking spaces, which food blogs love — to one space. */
+internal fun String.collapseWhitespace(): String =
+    replace(' ', ' ').split(WHITESPACE_RUN).filter { it.isNotEmpty() }.joinToString(" ")
+
+private val WHITESPACE_RUN = Regex("\\s+")
+
+/**
+ * Extracts the first whole number in a string, used for yields such as `"4 servings"`, `"Serves 4"`
+ * or `"4-6"` (which takes the lower bound). Returns `null` when there is no number, or when the
+ * number is not a plausible serving count.
+ */
+internal fun firstIntOrNull(raw: String?): Int? {
+    if (raw.isNullOrBlank()) return null
+    val digits = FIRST_INT.find(raw)?.value ?: return null
+    return digits.toIntOrNull()?.takeIf { it in 1..MAX_PLAUSIBLE_SERVINGS }
+}
+
+private val FIRST_INT = Regex("\\d+")
+
+// Guards against picking up a stray number from prose ("Makes 24 cookies" is fine; a 4-digit
+// value is far more likely to be a year or an ID than a serving count).
+private const val MAX_PLAUSIBLE_SERVINGS = 999

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/util/IsoDuration.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/util/IsoDuration.kt
@@ -1,0 +1,73 @@
+package com.tenmilelabs.recipescraper.util
+
+import kotlin.math.floor
+
+/**
+ * Parses a schema.org duration into whole minutes.
+ *
+ * Durations arrive as ISO-8601 (`"PT1H30M"`), which is what the spec asks for, but a fair number of
+ * sites emit a bare minute count instead (`"45"`), so both are accepted. Hand-rolled rather than
+ * using `java.time.Duration` because this module is `commonMain`.
+ *
+ * Fractional components are honoured (`"PT1.5H"` is 90 minutes) and the result is rounded to the
+ * nearest minute. Date-scale components (years, months, weeks) are ignored rather than treated as
+ * failures — a recipe measured in weeks is a data error on the page, not something worth rejecting
+ * the whole parse for. Days are honoured, since slow-fermented doughs legitimately use them.
+ *
+ * Returns `null` for null, blank, or unparseable input, and for a duration of zero.
+ */
+internal fun parseDurationToMinutes(raw: String?): Int? {
+    val text = raw?.trim()?.uppercase() ?: return null
+    if (text.isEmpty()) return null
+
+    // Some sites skip ISO-8601 entirely and publish a plain minute count.
+    text.toIntOrNull()?.let { return it.takeIf { minutes -> minutes > 0 } }
+
+    if (!text.startsWith("P")) return null
+
+    var totalMinutes = 0.0
+    var sawComponent = false
+    // The T separator splits date-scale components from time-scale ones. It matters: "PT5M" is five
+    // minutes, "P5M" is five months.
+    var inTimePart = false
+    val number = StringBuilder()
+
+    for (char in text.drop(1)) {
+        when {
+            char.isDigit() -> number.append(char)
+
+            // ISO-8601 permits either separator for decimal fractions.
+            char == '.' || char == ',' -> number.append('.')
+
+            char == 'T' -> {
+                inTimePart = true
+                number.clear()
+            }
+
+            else -> {
+                val value = number.toString().toDoubleOrNull()
+                number.clear()
+                if (value == null) continue
+                sawComponent = true
+                totalMinutes += when (char) {
+                    'D' -> value * MINUTES_PER_DAY
+                    'H' -> if (inTimePart) value * MINUTES_PER_HOUR else 0.0
+                    'M' -> if (inTimePart) value else 0.0 // outside the time part this is months
+                    'S' -> if (inTimePart) value / SECONDS_PER_MINUTE else 0.0
+                    else -> 0.0 // 'W'/'Y' and unknown designators: counted as seen, not accumulated
+                }
+            }
+        }
+    }
+
+    if (!sawComponent) return null
+
+    // Half-up, so "PT30S" reads as 1 minute. kotlin.math.round breaks ties towards even, which
+    // would round that to 0.
+    val minutes = floor(totalMinutes + 0.5).toLong()
+    return minutes.takeIf { it > 0 }?.coerceAtMost(Int.MAX_VALUE.toLong())?.toInt()
+}
+
+private const val MINUTES_PER_DAY = 24 * 60.0
+private const val MINUTES_PER_HOUR = 60.0
+private const val SECONDS_PER_MINUTE = 60.0

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParserTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParserTest.kt
@@ -1,0 +1,163 @@
+package com.tenmilelabs.recipescraper.ingredient
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class IngredientTextParserTest {
+
+    private fun assertParsed(
+        raw: String,
+        quantity: Double?,
+        unit: String?,
+        name: String,
+    ) {
+        val result = parseIngredient(raw)
+        assertEquals(quantity, result.quantity, "quantity for \"$raw\"")
+        assertEquals(unit, result.unit, "unit for \"$raw\"")
+        assertEquals(name, result.name, "name for \"$raw\"")
+        assertEquals(raw, result.raw, "raw must be preserved verbatim")
+    }
+
+    // --- Whole numbers and units ---
+
+    @Test
+    fun `parses whole number with plural unit`() {
+        assertParsed("2 cups all-purpose flour, sifted", 2.0, "cup", "all-purpose flour, sifted")
+    }
+
+    @Test
+    fun `normalizes unit synonyms to a canonical form`() {
+        assertParsed("3 tablespoons butter", 3.0, "tbsp", "butter")
+        assertParsed("3 tbsps butter", 3.0, "tbsp", "butter")
+        assertParsed("2 teaspoons vanilla", 2.0, "tsp", "vanilla")
+        assertParsed("500 grams beef", 500.0, "g", "beef")
+        assertParsed("2 lbs potatoes", 2.0, "lb", "potatoes")
+    }
+
+    @Test
+    fun `tolerates a trailing period on an abbreviation`() {
+        assertParsed("2 tbsp. olive oil", 2.0, "tbsp", "olive oil")
+    }
+
+    @Test
+    fun `distinguishes tablespoon and teaspoon by case`() {
+        assertParsed("1 T sugar", 1.0, "tbsp", "sugar")
+        assertParsed("1 t sugar", 1.0, "tsp", "sugar")
+    }
+
+    // --- Fractions ---
+
+    @Test
+    fun `parses unicode vulgar fraction fused to a whole number`() {
+        assertParsed("1½ tbsp olive oil", 1.5, "tbsp", "olive oil")
+    }
+
+    @Test
+    fun `parses a bare unicode vulgar fraction`() {
+        assertParsed("½ tsp salt", 0.5, "tsp", "salt")
+        assertParsed("¾ cup milk", 0.75, "cup", "milk")
+    }
+
+    @Test
+    fun `parses an ascii mixed number across two tokens`() {
+        assertParsed("1 1/2 cups sugar", 1.5, "cup", "sugar")
+    }
+
+    @Test
+    fun `parses a bare ascii fraction`() {
+        assertParsed("1/4 cup water", 0.25, "cup", "water")
+    }
+
+    @Test
+    fun `parses a decimal amount`() {
+        assertParsed("0.5 cup cream", 0.5, "cup", "cream")
+    }
+
+    @Test
+    fun `accepts a comma decimal separator`() {
+        assertParsed("0,5 l milk", 0.5, "l", "milk")
+    }
+
+    // --- Ranges ---
+
+    @Test
+    fun `takes the lower bound of a hyphenated range`() {
+        assertParsed("2-3 cloves garlic, minced", 2.0, "clove", "garlic, minced")
+    }
+
+    @Test
+    fun `takes the lower bound of an en dash range`() {
+        assertParsed("2–3 tbsp honey", 2.0, "tbsp", "honey")
+    }
+
+    @Test
+    fun `takes the lower bound of a spelled out range`() {
+        assertParsed("2 to 3 tablespoons butter", 2.0, "tbsp", "butter")
+        assertParsed("1 or 2 cloves garlic", 1.0, "clove", "garlic")
+    }
+
+    @Test
+    fun `does not split a hyphenated word as a range`() {
+        // "all-purpose" must not be read as a numeric range.
+        assertParsed("all-purpose flour", null, null, "all-purpose flour")
+    }
+
+    // --- Parentheticals ---
+
+    @Test
+    fun `skips a parenthetical size qualifier between amount and unit`() {
+        assertParsed("1 (14 oz) can diced tomatoes", 1.0, "can", "diced tomatoes")
+    }
+
+    @Test
+    fun `keeps an unbalanced parenthesis in the name rather than swallowing the line`() {
+        val result = parseIngredient("1 (14 oz can diced tomatoes")
+        assertEquals(1.0, result.quantity)
+        assertTrue(result.name.contains("diced tomatoes"), "got: ${result.name}")
+    }
+
+    // --- Name handling ---
+
+    @Test
+    fun `strips a leading of after the unit`() {
+        assertParsed("2 cups of flour", 2.0, "cup", "flour")
+    }
+
+    @Test
+    fun `leaves an unrecognised word as part of the name`() {
+        // "large" is a descriptor, not a unit — quantity still parses.
+        assertParsed("3 large eggs", 3.0, null, "large eggs")
+    }
+
+    @Test
+    fun `collapses internal whitespace`() {
+        assertParsed("2   cups    flour", 2.0, "cup", "flour")
+    }
+
+    // --- Fallbacks ---
+
+    @Test
+    fun `falls back to the whole line when there is no amount`() {
+        assertParsed("Salt to taste", null, null, "Salt to taste")
+        assertParsed("olive oil", null, null, "olive oil")
+    }
+
+    @Test
+    fun `falls back to the amount text when the line is only an amount`() {
+        // Never returns a blank name, so a UI always has something to show.
+        val result = parseIngredient("2 cups")
+        assertEquals(2.0, result.quantity)
+        assertEquals("cup", result.unit)
+        assertEquals("2 cups", result.name)
+    }
+
+    @Test
+    fun `handles empty and blank input without throwing`() {
+        assertParsed("", null, null, "")
+        val blank = parseIngredient("   ")
+        assertNull(blank.quantity)
+        assertEquals("", blank.name)
+    }
+}

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/util/IsoDurationTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/util/IsoDurationTest.kt
@@ -1,0 +1,93 @@
+package com.tenmilelabs.recipescraper.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class IsoDurationTest {
+
+    @Test
+    fun `parses hours and minutes`() {
+        assertEquals(90, parseDurationToMinutes("PT1H30M"))
+    }
+
+    @Test
+    fun `parses minutes only`() {
+        assertEquals(30, parseDurationToMinutes("PT30M"))
+    }
+
+    @Test
+    fun `parses hours only`() {
+        assertEquals(120, parseDurationToMinutes("PT2H"))
+    }
+
+    @Test
+    fun `parses full form with zero components`() {
+        assertEquals(45, parseDurationToMinutes("P0DT0H45M"))
+    }
+
+    @Test
+    fun `parses trailing zero seconds`() {
+        assertEquals(90, parseDurationToMinutes("PT1H30M0S"))
+    }
+
+    @Test
+    fun `rounds seconds to nearest minute`() {
+        assertEquals(2, parseDurationToMinutes("PT90S"))
+        assertEquals(1, parseDurationToMinutes("PT40S"))
+        assertEquals(1, parseDurationToMinutes("PT30S"))
+    }
+
+    @Test
+    fun `honours days for long ferments`() {
+        assertEquals(1500, parseDurationToMinutes("P1DT1H"))
+    }
+
+    @Test
+    fun `accepts lowercase and surrounding whitespace`() {
+        assertEquals(90, parseDurationToMinutes("  pt1h30m  "))
+    }
+
+    @Test
+    fun `accepts a bare minute count`() {
+        assertEquals(45, parseDurationToMinutes("45"))
+    }
+
+    @Test
+    fun `honours fractional components`() {
+        assertEquals(90, parseDurationToMinutes("PT1.5H"))
+        // ISO-8601 allows a comma as the decimal separator too.
+        assertEquals(90, parseDurationToMinutes("PT1,5H"))
+        assertEquals(30, parseDurationToMinutes("PT0.5H"))
+    }
+
+    @Test
+    fun `ignores date-scale components without failing`() {
+        // P1M is one month, not one minute — must not be read as time.
+        assertNull(parseDurationToMinutes("P1M"))
+        // Weeks are ignored, so only the time part counts.
+        assertEquals(30, parseDurationToMinutes("P1WT30M"))
+    }
+
+    @Test
+    fun `distinguishes months from minutes by the T separator`() {
+        assertEquals(5, parseDurationToMinutes("PT5M"))
+        assertNull(parseDurationToMinutes("P5M"))
+    }
+
+    @Test
+    fun `returns null for zero durations`() {
+        assertNull(parseDurationToMinutes("PT0M"))
+        assertNull(parseDurationToMinutes("0"))
+    }
+
+    @Test
+    fun `returns null for null blank and garbage`() {
+        assertNull(parseDurationToMinutes(null))
+        assertNull(parseDurationToMinutes(""))
+        assertNull(parseDurationToMinutes("   "))
+        assertNull(parseDurationToMinutes("about an hour"))
+        assertNull(parseDurationToMinutes("PT"))
+        assertNull(parseDurationToMinutes("P"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "ChefAI"
 include(":app")
+include(":recipe-scraper")
  


### PR DESCRIPTION
## Context

Foundation for **client-side recipe URL import** — the feature behind the already-stubbed "Import recipe" FAB item on the Recipes tab, which until now hit a bare `// TODO: Navigate to import recipe screen` in `ChefAINavGraph.kt`.

Recipe sites are SEO-driven and so almost universally embed schema.org `Recipe` structured data in static HTML for Google rich snippets. No headless browser is needed — an HTTP GET plus an HTML parse is enough, which is what makes doing this on-device viable: zero server compute, and requests spread across users' own IPs rather than concentrated on one easily-rate-limited server IP. If volume ever justifies it, a cache-by-normalized-URL layer on the existing Ktor backend is a later optimization, not a capability being given up.

**No behaviour change yet.** Nothing calls into the new module and the import screen doesn't exist, so this is additive and cannot regress the app.

## What's here

### New `:recipe-scraper` module

The project's first multi-module split. Pure Kotlin, deliberately free of Android/Hilt/Room/Ktor so the boundary is compiler-enforced, tests run on plain JVM, and publishing it as a library later is a `maven-publish` block rather than a refactor. There is no comparable Kotlin/JVM recipe scraper published today — the mature options ([recipe-scrapers](https://github.com/hhursev/recipe-scrapers)) are Python, and the JS ones lean on headless Chromium.

- **Public API**: `ScrapedRecipe`, `ScrapedIngredient`, `ScrapeResult`, `ExtractionSource`. Every optional field is nullable — the library reports what the page actually published and never fabricates data; choosing fallbacks is the caller's job.
- **`parseDurationToMinutes`** — schema.org durations. ISO-8601 is what the spec asks for, but plenty of sites publish a bare minute count, so both are accepted.
- **`parseIngredient`** — splits prose like `"2 cups all-purpose flour, sifted"` into amount, unit and name. Decimals (including comma separators), ASCII and unicode vulgar fractions, mixed numbers, numeric and spelled-out ranges, parenthetical size qualifiers, and a unit synonym table.
- Shared `cleanHtmlText` / `firstIntOrNull` helpers for the extractors to come.

### Editor draft hand-off (`:app`)

The integration seam turned out unusually clean. The editor's existing `restoreDraftIfExists` → `populateFromDraft` path already loads a persisted draft in create mode, so all that was missing was a way to name which draft to adopt:

- New optional **`draftUuid`** nav arg on the editor route, deliberately distinct from `recipeUuid` (which means *edit* mode against a saved recipe). With `draftUuid` the editor stays in **create** mode, so saving takes the `createRecipe` + `addBookmark` path — what an import wants. **No reducer change and no new `EditorAction` needed.**
- `navigateToEditorWithDraft` pops the import screen, so backing out of the editor returns to the recipe list rather than a stale URL field.
- `IMPORT_RECIPE` route and nav actions added ahead of the screen itself.

## Design decisions worth reviewing

- **Ksoup over Jsoup.** Jsoup is more battle-tested but JVM-only. Ksoup is a KMP port with a near-identical API, keeping the door open to publishing for iOS/JS later. Accepted tradeoff: younger project, smaller community.
- **Parsing is separated from fetching.** `RecipeHtmlParser` will take an HTML string and do no network I/O — the same split `recipe-scrapers` uses. Keeps the library dependency-light and testable from HTML fixtures rather than live sites.
- **No `@Serializable` models for schema.org.** Real-world JSON-LD is too polymorphic (`@type` is a string *or* an array; `image` is a string *or* object *or* array; instructions nest via `HowToSection`). The extractor will walk `JsonElement` untyped, so the serialization plugin isn't needed — only the runtime.
- **Both nav args are now hardened.** Only `draftUuid` strictly needed it, but `recipeUuid` had the same latent bug: a malformed value from a deep link would throw `IllegalArgumentException` during ViewModel construction. Both now degrade to a blank new recipe.

## Two bugs worth calling out

- **Fraction handling was wrong and a test caught it.** `"PT1.5H"` parsed as **300 minutes instead of 90** — hitting `.` reset the digit buffer and discarded the integer part. This also reversed an earlier decision to *truncate* fractions, which would have read `PT1.5H` as 60 minutes. Fractions are now honoured properly.
- **`kotlin.math.round` is a trap here.** It breaks ties toward even, so `"PT30S"` (0.5 min) would round to **0** and be dropped as a zero duration. Uses `floor(x + 0.5)` instead.

## Gradle notes for anyone building this

- The multiplatform plugin must be pinned in the **root** build file with `apply false`. Applying it only in the module fails with *"plugin is already on the classpath with an unknown version"*.
- The `jvm` target sets `compilerOptions.jvmTarget` rather than `jvmToolchain(11)`, matching how `:app` handles it, so no JDK 11 install is required.
- **Worktrees need their own `local.properties`** (`sdk.dir=...`). It's gitignored, so it doesn't come across, and every `:app` Gradle task fails without it.

## Verification

| Gate | Result |
|---|---|
| `./gradlew :recipe-scraper:jvmTest` | ✅ 36 tests, 0 failures |
| `./gradlew :app:testDebugUnitTest` | ✅ 338 tests / 23 classes, 0 failures |
| `./gradlew :app:assembleDebug` | ✅ confirms `:app` consumes the KMP `jvm()` target with no variant-resolution issues |

## Follow-ups (not in this PR)

JSON-LD + microdata extraction and the parser tiering · unauthenticated `@ScraperHttpClient` (the existing `HttpClient` installs `AuthInterceptor`, so third-party fetches must not reuse it) · `ScrapedRecipe` → `RecipeDraft` mapper · importer with URL validation and body-size cap · import screen · FAB wiring · ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)