### PR TITLE
Recipe URL import: JSON-LD/microdata extraction, importer, UI, wiring (T5-T13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,14 @@ Rule: start in feature package, move to `core/` only when a second feature needs
 
 See [ADR-005](docs/adrs/adr-0005-feature-based-package-structure.md) for full guidelines.
 
+### Modules
+Besides `:app`, the project has `:recipe-scraper` — a pure-Kotlin (KMP, `jvm()`-only target today)
+module with no Android/Hilt/Room/Ktor dependencies. It parses HTML into a structured recipe
+(`RecipeHtmlParser`, JSON-LD + microdata) and does no network I/O; `:app` fetches pages and maps the
+result into a `RecipeDraft`. See [ADR-010](docs/adrs/adr-010-client-side-recipe-scraping.md) and
+`recipe-scraper/README.md`. **Never name a package/class after a Kotlin reserved word** (`import`,
+`object`, `when`, …) — see `docs/claude/gotchas.md` for why.
+
 ---
 
 ## Coding Rules
@@ -156,7 +164,7 @@ After completing any code change (bug fix, feature, refactor), always run the un
 
 ---
 
-## Current Gaps (Mar 2026)
+## Current Gaps (Aug 2026)
 | Area | Status                                                                              |
 |------|-------------------------------------------------------------------------------------|
 | HomeScreen | Static placeholder data, explore server driven UI                             |
@@ -166,6 +174,7 @@ After completing any code change (bug fix, feature, refactor), always run the un
 | Meal Plans — Android sync wiring | Not started — extend `SyncOrchestrator` + `SyncDtos`         |
 | Conflict resolution | SyncState.CONFLICT defined but unused                                     |
 | RecipesViewModel user wiring | Hardcoded test UUID, needs real user from SessionManager           |
+| Recipe URL import | Done — paste a URL, scrape via `:recipe-scraper` (JSON-LD/microdata), pre-fill the editor. No per-site scrapers, no nutrition data, no image download. Share-target intent (T14) not started — optional follow-up. |
 
 **Next milestone**: Complete all tasks to prepare for Monstro Demo
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -15,7 +15,9 @@ import com.tenmilelabs.chefai.core.data.local.room.TransactionRunner
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
+import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.Binds
 import dagger.Module
@@ -51,6 +53,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindMealPlanNetworkDataSource(service: MealPlanApiService): MealPlanNetworkDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindRecipeImporter(importer: DefaultRecipeImporter): RecipeImporter
 }
 
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import com.tenmilelabs.chefai.auth.data.network.AuthInterceptor
 import com.tenmilelabs.chefai.auth.domain.TokenProvider
 import com.tenmilelabs.chefai.recipes.data.network.ChefAIApiService
 import com.tenmilelabs.chefai.recipes.data.network.RecipeNetworkDataSource
+import com.tenmilelabs.recipescraper.RecipeHtmlParser
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -103,4 +104,9 @@ object NetworkModule {
             header(HttpHeaders.Accept, "text/html,application/xhtml+xml")
         }
     }
+
+    /** Stateless — [RecipeHtmlParser] lives in the dependency-free `:recipe-scraper` module. */
+    @Provides
+    @Singleton
+    fun provideRecipeHtmlParser(): RecipeHtmlParser = RecipeHtmlParser()
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -49,6 +49,7 @@ import com.tenmilelabs.chefai.mealplans.ui.create.WizardPreferencesScreen
 import com.tenmilelabs.chefai.recipes.ui.RecipesScreen
 import com.tenmilelabs.chefai.recipes.ui.details.RecipeDetailsScreen
 import com.tenmilelabs.chefai.recipes.ui.editor.RecipeEditorScreen
+import com.tenmilelabs.chefai.recipes.ui.urlimport.ImportRecipeRoute
 import timber.log.Timber
 
 @Composable
@@ -198,6 +199,13 @@ fun ChefAINavGraph(
                 snackbarHostState = snackbarHostState,
             )
         }
+        composable(route = AppDestinations.IMPORT_RECIPE.route) {
+            ImportRecipeRoute(
+                onNavigateToEditorWithDraft = { draftId -> navActions.navigateToEditorWithDraft(draftId) },
+                onNavigateToManualEditor = { navActions.navigateToCreateRecipe() },
+                onNavigateBack = { navController.popBackStack() },
+            )
+        }
         composable(route = AppDestinations.LOGIN.route) {
             LoginScreen(
                 snackbarHostState = snackbarHostState,
@@ -301,6 +309,7 @@ fun ChefAINavGraph(
             )
             val hideNav = currentRoute == AppDestinations.LOGIN.route ||
                 currentRoute == AppDestinations.REGISTER.route ||
+                currentRoute == AppDestinations.IMPORT_RECIPE.route ||
                 currentRoute in wizardRoutes
             if (!hideNav && !isExpanded) {
                 BottomNavigationBar(navController)
@@ -320,8 +329,7 @@ fun ChefAINavGraph(
                         },
                         onImportRecipeClick = {
                             isFabMenuExpanded = false
-                            // TODO: Navigate to import recipe screen
-                            // navActions.navigateToImportRecipe()
+                            navActions.navigateToImportRecipe()
                         }
                     )
                 }
@@ -346,6 +354,7 @@ fun ChefAINavGraph(
         )
         val hideNav = currentRoute == AppDestinations.LOGIN.route ||
             currentRoute == AppDestinations.REGISTER.route ||
+            currentRoute == AppDestinations.IMPORT_RECIPE.route ||
             currentRoute in wizardRoutes
 
         Row(modifier = Modifier.padding(innerPadding)) {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapper.kt
@@ -1,0 +1,85 @@
+package com.tenmilelabs.chefai.recipes.data.mapper
+
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.domain.model.Ingredient
+import com.tenmilelabs.chefai.core.domain.model.RecipeStep
+import com.tenmilelabs.chefai.core.domain.model.Tag
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
+import com.tenmilelabs.recipescraper.model.ScrapedIngredient
+import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+import java.util.UUID
+
+private const val MAX_KEYWORDS = 8
+private const val MAX_KEYWORD_LENGTH = 30
+private const val DEFAULT_QUANTITY = 1.0
+private const val DEFAULT_UNIT = "unit"
+
+/**
+ * Converts a scraped recipe into a [RecipeDraft] ready to seed the editor.
+ *
+ * Times and servings are never left blank — [RecipeDraft.toRecipe] throws on a blank numeric
+ * string, so every value the page didn't publish becomes `"0"` here rather than `""`; Save simply
+ * stays disabled until the user fills in what's missing. Ingredients and tags are matched by name
+ * (case-insensitively) against the app's existing catalogs before minting a new id, mirroring
+ * [com.tenmilelabs.chefai.recipes.ui.editor.RecipeEditorViewModel.selectIngredient] and
+ * `addTagByName` — otherwise every import would duplicate catalog rows.
+ */
+fun ScrapedRecipe.toRecipeDraft(
+    recipeId: UUID,
+    knownIngredients: List<Ingredient>,
+    knownTags: List<Tag>,
+): RecipeDraft = RecipeDraft(
+    recipeId = recipeId,
+    isNewRecipe = true,
+    title = title,
+    description = description.orEmpty(),
+    imageUrl = imageUrl.orEmpty(),
+    prepTimeMinutes = prepTimeMinutes?.toString() ?: "0",
+    cookTimeMinutes = cookTimeMinutesOrFallback(),
+    servings = servings?.toString() ?: "0",
+    externalUrl = sourceUrl,
+    ingredients = ingredients.toRecipeIngredients(knownIngredients),
+    steps = instructions.toRecipeSteps(),
+    tags = keywords.toTags(knownTags),
+    labels = emptyList(),
+    version = 1,
+)
+
+/** Prefers [ScrapedRecipe.cookTimeMinutes]; falls back to total-minus-prep, then to `"0"`. */
+private fun ScrapedRecipe.cookTimeMinutesOrFallback(): String {
+    cookTimeMinutes?.let { return it.toString() }
+    val total = totalTimeMinutes ?: return "0"
+    return (total - (prepTimeMinutes ?: 0)).coerceAtLeast(0).toString()
+}
+
+private fun List<ScrapedIngredient>.toRecipeIngredients(
+    knownIngredients: List<Ingredient>,
+): List<RecipeIngredient> {
+    val seenNames = HashSet<String>()
+    return mapNotNull { ingredient ->
+        val name = ingredient.name.trim()
+        if (name.isBlank() || !seenNames.add(name.lowercase())) return@mapNotNull null
+        val known = knownIngredients.find { it.displayName.equals(name, ignoreCase = true) }
+        RecipeIngredient(
+            ingredientId = known?.uuid ?: UuidV7Generator.newId(),
+            ingredientDisplayName = name,
+            quantity = ingredient.quantity ?: DEFAULT_QUANTITY,
+            unit = ingredient.unit ?: DEFAULT_UNIT,
+            allergenName = null,
+            srcCategory = null,
+            srcSubcategory = null,
+        )
+    }
+}
+
+private fun List<String>.toRecipeSteps(): List<RecipeStep> = mapIndexed { index, instruction ->
+    RecipeStep(uuid = UuidV7Generator.newId(), orderIndex = index, instruction = instruction)
+}
+
+private fun List<String>.toTags(knownTags: List<Tag>): List<Tag> = filter { it.length <= MAX_KEYWORD_LENGTH }
+    .take(MAX_KEYWORDS)
+    .map { keyword ->
+        knownTags.find { it.displayName.equals(keyword, ignoreCase = true) }
+            ?: Tag(uuid = UuidV7Generator.newId(), displayName = keyword)
+    }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
@@ -1,0 +1,105 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.di.IoDispatcher
+import com.tenmilelabs.chefai.core.di.ScraperHttpClient
+import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
+import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraft
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import com.tenmilelabs.recipescraper.RecipeHtmlParser
+import com.tenmilelabs.recipescraper.model.ScrapeResult
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.io.IOException
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+
+/** Caps how much of a fetched page is read into memory — well past any real recipe page. */
+private const val MAX_BODY_BYTES = 3 * 1024 * 1024
+
+@Singleton
+class DefaultRecipeImporter @Inject constructor(
+    @ScraperHttpClient private val httpClient: HttpClient,
+    private val recipeHtmlParser: RecipeHtmlParser,
+    private val metadataRepository: MetadataRepository,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : RecipeImporter {
+
+    override suspend fun import(url: String): RecipeImportResult = withContext(ioDispatcher) {
+        val normalizedUrl = normalizeAndValidateUrl(url) ?: return@withContext RecipeImportResult.InvalidUrl
+
+        val html = fetchHtml(normalizedUrl).let { result ->
+            if (result is FetchOutcome.Failure) return@withContext result.error
+            (result as FetchOutcome.Html).body
+        }
+
+        when (val scrapeResult = recipeHtmlParser.parse(html, normalizedUrl)) {
+            is ScrapeResult.Success -> {
+                val knownIngredients = metadataRepository.observeAllIngredients().first()
+                val knownTags = metadataRepository.observeAllTags().first()
+                val draft = scrapeResult.recipe.toRecipeDraft(
+                    recipeId = UuidV7Generator.newId(),
+                    knownIngredients = knownIngredients,
+                    knownTags = knownTags,
+                )
+                RecipeImportResult.Success(draft)
+            }
+
+            ScrapeResult.NoRecipeFound -> RecipeImportResult.NoRecipeFound
+            is ScrapeResult.ParseError -> RecipeImportResult.ParseError(scrapeResult.message)
+        }
+    }
+
+    private sealed interface FetchOutcome {
+        data class Html(val body: String) : FetchOutcome
+        data class Failure(val error: RecipeImportResult.NetworkError) : FetchOutcome
+    }
+
+    private suspend fun fetchHtml(url: String): FetchOutcome = try {
+        val response = httpClient.get(url)
+        val contentType = response.headers[HttpHeaders.ContentType].orEmpty()
+        if (!contentType.contains("text/html", ignoreCase = true) &&
+            !contentType.contains("application/xhtml+xml", ignoreCase = true)
+        ) {
+            FetchOutcome.Failure(RecipeImportResult.NetworkError("Not an HTML page"))
+        } else {
+            FetchOutcome.Html(response.readBodyCapped())
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: HttpRequestTimeoutException) {
+        Timber.w(e, "Recipe import request timed out")
+        FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Request timed out"))
+    } catch (e: ResponseException) {
+        Timber.w(e, "Recipe import received an error response")
+        FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Request failed"))
+    } catch (e: IOException) {
+        Timber.w(e, "Recipe import network error")
+        FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Network error"))
+    }
+
+    /** Reads at most [MAX_BODY_BYTES] of the response body, protecting against a hostile/huge page. */
+    private suspend fun HttpResponse.readBodyCapped(): String {
+        val channel = bodyAsChannel()
+        val buffer = ByteArray(MAX_BODY_BYTES)
+        var offset = 0
+        while (offset < buffer.size) {
+            val read = channel.readAvailable(buffer, offset, buffer.size - offset)
+            if (read == -1) break
+            offset += read
+        }
+        return buffer.decodeToString(0, offset)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/RecipeUrlValidation.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/RecipeUrlValidation.kt
@@ -1,0 +1,50 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import java.net.URI
+import java.net.URISyntaxException
+
+private val SCHEME_PREFIX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*://")
+
+/**
+ * Trims and, if absent, adds an `https://` scheme, then validates the result is a plausible
+ * public web URL: `http`/`https` only, a host present, and not a loopback or private-network
+ * address. The URL comes from user paste, so there's no reason for the app to fetch those.
+ *
+ * Returns `null` when the input is not a usable URL.
+ */
+internal fun normalizeAndValidateUrl(input: String): String? {
+    val trimmed = input.trim()
+    if (trimmed.isEmpty()) return null
+    val withScheme = if (SCHEME_PREFIX.containsMatchIn(trimmed)) trimmed else "https://$trimmed"
+
+    val uri = try {
+        URI(withScheme)
+    } catch (e: URISyntaxException) {
+        return null
+    }
+
+    val scheme = uri.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") return null
+    val host = uri.host ?: return null
+    if (host.isBlockedHost()) return null
+
+    return uri.toString()
+}
+
+private fun String.isBlockedHost(): Boolean {
+    val host = lowercase()
+    if (host == "localhost") return true
+
+    val octets = host.split(".")
+    if (octets.size != 4) return false
+    val values = octets.map { it.toIntOrNull() ?: return false }
+    val (a, b) = values[0] to values[1]
+    return when {
+        a == 127 -> true // 127.0.0.0/8
+        a == 10 -> true // 10.0.0.0/8
+        a == 192 && b == 168 -> true // 192.168.0.0/16
+        a == 172 && b in 16..31 -> true // 172.16.0.0/12
+        a == 169 && b == 254 -> true // 169.254.0.0/16
+        else -> false
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/model/RecipeImportResult.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/model/RecipeImportResult.kt
@@ -1,0 +1,10 @@
+package com.tenmilelabs.chefai.recipes.domain.model
+
+/** The outcome of importing a recipe from a URL — explicit and sealed rather than thrown. */
+sealed interface RecipeImportResult {
+    data class Success(val draft: RecipeDraft) : RecipeImportResult
+    data object InvalidUrl : RecipeImportResult
+    data object NoRecipeFound : RecipeImportResult
+    data class NetworkError(val message: String) : RecipeImportResult
+    data class ParseError(val message: String) : RecipeImportResult
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RecipeImporter.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RecipeImporter.kt
@@ -1,0 +1,8 @@
+package com.tenmilelabs.chefai.recipes.domain.repository
+
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+
+/** Fetches a third-party recipe page and extracts a [RecipeImportResult.Success] draft from it. */
+interface RecipeImporter {
+    suspend fun import(url: String): RecipeImportResult
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/import/ImportRecipeScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/import/ImportRecipeScreen.kt
@@ -1,0 +1,170 @@
+package com.tenmilelabs.chefai.recipes.ui.import
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+import java.util.UUID
+
+@Composable
+fun ImportRecipeRoute(
+    onNavigateToEditorWithDraft: (UUID) -> Unit,
+    onNavigateToManualEditor: () -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: ImportRecipeViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is ImportEffect.NavigateToEditorWithDraft -> onNavigateToEditorWithDraft(effect.draftId)
+                ImportEffect.NavigateToManualEditor -> onNavigateToManualEditor()
+                ImportEffect.NavigateBack -> onNavigateBack()
+            }
+        }
+    }
+
+    ImportRecipeScreen(state = state, onAction = viewModel::dispatch)
+}
+
+@Composable
+fun ImportRecipeScreen(
+    state: ImportRecipeState,
+    onAction: (ImportAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val clipboard = LocalClipboard.current
+    LaunchedEffect(Unit) {
+        if (state.url.isNotBlank()) return@LaunchedEffect
+        val clipboardText = runCatching {
+            clipboard.getClipEntry()?.clipData?.let { data ->
+                if (data.itemCount > 0) data.getItemAt(0).text?.toString() else null
+            }
+        }.getOrNull()
+        if (clipboardText != null && (clipboardText.startsWith("http://") || clipboardText.startsWith("https://"))) {
+            onAction(ImportAction.UrlChanged(clipboardText))
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize().padding(dimensionResource(R.dimen.padding_medium))) {
+        Text(stringResource(R.string.import_recipe_title), style = MaterialTheme.typography.headlineSmall)
+
+        Spacer(Modifier.height(dimensionResource(R.dimen.padding_large)))
+
+        OutlinedTextField(
+            value = state.url,
+            onValueChange = { onAction(ImportAction.UrlChanged(it)) },
+            label = { Text(stringResource(R.string.import_recipe_url_label)) },
+            placeholder = { Text(stringResource(R.string.import_recipe_url_placeholder)) },
+            singleLine = true,
+            enabled = !state.isImporting,
+            isError = state.errorRes != null,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Go),
+            keyboardActions = KeyboardActions(onGo = { if (state.canImport) onAction(ImportAction.Import) }),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(Modifier.height(dimensionResource(R.dimen.padding_medium)))
+
+        Button(
+            onClick = { onAction(ImportAction.Import) },
+            enabled = state.canImport,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (state.isImporting) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            } else {
+                Text(stringResource(R.string.import_recipe_button))
+            }
+        }
+
+        state.errorRes?.let { errorRes ->
+            Spacer(Modifier.height(dimensionResource(R.dimen.padding_medium)))
+            Text(stringResource(errorRes), color = MaterialTheme.colorScheme.error)
+
+            if (state.showManualEntryOption) {
+                TextButton(onClick = { onAction(ImportAction.EnterManually) }) {
+                    Text(stringResource(R.string.import_recipe_enter_manually))
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Empty — Light", showBackground = true)
+@Composable
+private fun ImportRecipeScreenEmptyLightPreview() {
+    ChefAITheme(darkTheme = false) {
+        ImportRecipeScreen(state = ImportRecipeState(), onAction = {})
+    }
+}
+
+@Preview(name = "Loading — Dark", showBackground = true)
+@Composable
+private fun ImportRecipeScreenLoadingDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        ImportRecipeScreen(
+            state = ImportRecipeState(url = "https://example.com/recipe", isImporting = true),
+            onAction = {},
+        )
+    }
+}
+
+@Preview(name = "Error — Light", showBackground = true)
+@Composable
+private fun ImportRecipeScreenErrorLightPreview() {
+    ChefAITheme(darkTheme = false) {
+        ImportRecipeScreen(
+            state = ImportRecipeState(
+                url = "https://example.com/not-a-recipe",
+                errorRes = R.string.import_recipe_no_recipe_found,
+                showManualEntryOption = true,
+            ),
+            onAction = {},
+        )
+    }
+}
+
+@Preview(name = "Error — Dark", showBackground = true)
+@Composable
+private fun ImportRecipeScreenErrorDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        ImportRecipeScreen(
+            state = ImportRecipeState(
+                url = "not a url",
+                errorRes = R.string.import_recipe_invalid_url,
+            ),
+            onAction = {},
+        )
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/import/ImportRecipeState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/import/ImportRecipeState.kt
@@ -1,0 +1,26 @@
+package com.tenmilelabs.chefai.recipes.ui.import
+
+import androidx.annotation.StringRes
+import java.util.UUID
+
+sealed interface ImportAction {
+    data class UrlChanged(val url: String) : ImportAction
+    data object Import : ImportAction
+    data object ClearError : ImportAction
+    data object EnterManually : ImportAction
+}
+
+sealed interface ImportEffect {
+    data class NavigateToEditorWithDraft(val draftId: UUID) : ImportEffect
+    data object NavigateToManualEditor : ImportEffect
+    data object NavigateBack : ImportEffect
+}
+
+data class ImportRecipeState(
+    val url: String = "",
+    val isImporting: Boolean = false,
+    @param:StringRes val errorRes: Int? = null,
+    val showManualEntryOption: Boolean = false,
+) {
+    val canImport: Boolean = url.isNotBlank() && !isImporting
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/import/ImportRecipeViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/import/ImportRecipeViewModel.kt
@@ -1,0 +1,85 @@
+package com.tenmilelabs.chefai.recipes.ui.import
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDraftDao
+import com.tenmilelabs.chefai.core.di.IoDispatcher
+import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraftEntity
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+class ImportRecipeViewModel @Inject constructor(
+    private val recipeImporter: RecipeImporter,
+    private val recipeDraftDao: RecipeDraftDao,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ImportRecipeState())
+    val state: StateFlow<ImportRecipeState> = _state.asStateFlow()
+
+    private val _effects = Channel<ImportEffect>(Channel.BUFFERED)
+    val effects: Flow<ImportEffect> = _effects.receiveAsFlow()
+
+    fun dispatch(action: ImportAction) {
+        when (action) {
+            is ImportAction.UrlChanged -> _state.update {
+                it.copy(url = action.url, errorRes = null, showManualEntryOption = false)
+            }
+
+            ImportAction.Import -> import()
+            ImportAction.ClearError -> _state.update { it.copy(errorRes = null, showManualEntryOption = false) }
+            ImportAction.EnterManually -> viewModelScope.launch { _effects.send(ImportEffect.NavigateToManualEditor) }
+        }
+    }
+
+    private fun import() {
+        if (!_state.value.canImport) return
+        val url = _state.value.url
+
+        viewModelScope.launch {
+            _state.update { it.copy(isImporting = true, errorRes = null, showManualEntryOption = false) }
+
+            when (val result = recipeImporter.import(url)) {
+                is RecipeImportResult.Success -> {
+                    withContext(ioDispatcher) {
+                        recipeDraftDao.saveDraft(result.draft.toRecipeDraftEntity())
+                    }
+                    _state.update { it.copy(isImporting = false) }
+                    _effects.send(ImportEffect.NavigateToEditorWithDraft(result.draft.recipeId))
+                }
+
+                RecipeImportResult.InvalidUrl -> failWith(R.string.import_recipe_invalid_url)
+
+                RecipeImportResult.NoRecipeFound -> _state.update {
+                    it.copy(
+                        isImporting = false,
+                        errorRes = R.string.import_recipe_no_recipe_found,
+                        showManualEntryOption = true,
+                    )
+                }
+
+                is RecipeImportResult.NetworkError -> failWith(R.string.import_recipe_network_error)
+                is RecipeImportResult.ParseError -> failWith(R.string.import_recipe_parse_error)
+            }
+        }
+    }
+
+    private fun failWith(@StringRes messageRes: Int) {
+        _state.update { it.copy(isImporting = false, errorRes = messageRes, showManualEntryOption = false) }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeScreen.kt
@@ -1,4 +1,4 @@
-package com.tenmilelabs.chefai.recipes.ui.import
+package com.tenmilelabs.chefai.recipes.ui.urlimport
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.res.dimensionResource

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeState.kt
@@ -1,4 +1,4 @@
-package com.tenmilelabs.chefai.recipes.ui.import
+package com.tenmilelabs.chefai.recipes.ui.urlimport
 
 import androidx.annotation.StringRes
 import java.util.UUID

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModel.kt
@@ -1,4 +1,4 @@
-package com.tenmilelabs.chefai.recipes.ui.import
+package com.tenmilelabs.chefai.recipes.ui.urlimport
 
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,4 +170,14 @@
     <string name="wizard_days_format">%1$d days</string>
     <string name="wizard_day_format">%1$d day</string>
 
+    <string name="import_recipe_title">Import Recipe</string>
+    <string name="import_recipe_url_label">Recipe URL</string>
+    <string name="import_recipe_url_placeholder">Paste a recipe link…</string>
+    <string name="import_recipe_button">Import</string>
+    <string name="import_recipe_enter_manually">Enter it manually</string>
+    <string name="import_recipe_invalid_url">That doesn\'t look like a valid link</string>
+    <string name="import_recipe_no_recipe_found">We couldn\'t find a recipe on that page</string>
+    <string name="import_recipe_network_error">Couldn\'t reach that site — check your connection</string>
+    <string name="import_recipe_parse_error">Something went wrong reading that page</string>
+
 </resources>

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapperTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapperTest.kt
@@ -1,0 +1,230 @@
+package com.tenmilelabs.chefai.recipes.data.mapper
+
+import com.tenmilelabs.chefai.core.domain.model.Ingredient
+import com.tenmilelabs.chefai.core.domain.model.Tag
+import com.tenmilelabs.chefai.core.domain.model.User
+import com.tenmilelabs.recipescraper.model.ScrapedIngredient
+import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+class ScrapedRecipeMapperTest {
+
+    private val testUser = User(uuid = UUID.randomUUID(), displayName = "Test", email = "test@test.com", avatarUrl = "")
+
+    private fun scrapedIngredient(name: String, quantity: Double? = 1.0, unit: String? = "cup") =
+        ScrapedIngredient(raw = "$quantity $unit $name", quantity = quantity, unit = unit, name = name)
+
+    private fun minimalScrapedRecipe(
+        title: String = "Test Recipe",
+        description: String? = "A description",
+        imageUrl: String? = "https://example.com/img.jpg",
+        prepTimeMinutes: Int? = 10,
+        cookTimeMinutes: Int? = 20,
+        totalTimeMinutes: Int? = null,
+        servings: Int? = 4,
+        ingredients: List<ScrapedIngredient> = emptyList(),
+        instructions: List<String> = emptyList(),
+        keywords: List<String> = emptyList(),
+        author: String? = "A Cook",
+        sourceUrl: String = "https://example.com/recipe",
+    ) = ScrapedRecipe(
+        title = title,
+        description = description,
+        imageUrl = imageUrl,
+        prepTimeMinutes = prepTimeMinutes,
+        cookTimeMinutes = cookTimeMinutes,
+        totalTimeMinutes = totalTimeMinutes,
+        servings = servings,
+        ingredients = ingredients,
+        instructions = instructions,
+        keywords = keywords,
+        author = author,
+        sourceUrl = sourceUrl,
+    )
+
+    @Test
+    fun `maps scalar fields straight across`() {
+        val recipeId = UUID.randomUUID()
+        val draft = minimalScrapedRecipe().toRecipeDraft(recipeId, emptyList(), emptyList())
+
+        assertEquals(recipeId, draft.recipeId)
+        assertEquals(true, draft.isNewRecipe)
+        assertEquals("Test Recipe", draft.title)
+        assertEquals("A description", draft.description)
+        assertEquals("https://example.com/img.jpg", draft.imageUrl)
+        assertEquals("10", draft.prepTimeMinutes)
+        assertEquals("20", draft.cookTimeMinutes)
+        assertEquals("4", draft.servings)
+        assertEquals("https://example.com/recipe", draft.externalUrl)
+        assertEquals(1, draft.version)
+        assertEquals(emptyList<Any>(), draft.labels)
+    }
+
+    @Test
+    fun `null description and imageUrl become blank, not omitted`() {
+        val draft = minimalScrapedRecipe(description = null, imageUrl = null)
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("", draft.description)
+        assertEquals("", draft.imageUrl)
+    }
+
+    @Test
+    fun `absent prep time and servings become the string zero, never blank`() {
+        val draft = minimalScrapedRecipe(prepTimeMinutes = null, servings = null)
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("0", draft.prepTimeMinutes)
+        assertEquals("0", draft.servings)
+    }
+
+    @Test
+    fun `cook time falls back to total minus prep when cook time is absent`() {
+        val draft = minimalScrapedRecipe(prepTimeMinutes = 10, cookTimeMinutes = null, totalTimeMinutes = 45)
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("35", draft.cookTimeMinutes)
+    }
+
+    @Test
+    fun `cook time fallback never goes negative`() {
+        val draft = minimalScrapedRecipe(prepTimeMinutes = 50, cookTimeMinutes = null, totalTimeMinutes = 45)
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("0", draft.cookTimeMinutes)
+    }
+
+    @Test
+    fun `cook time is zero when neither cook nor total time is present`() {
+        val draft = minimalScrapedRecipe(cookTimeMinutes = null, totalTimeMinutes = null)
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("0", draft.cookTimeMinutes)
+    }
+
+    @Test
+    fun `ingredients reuse a known catalog id, matched case-insensitively`() {
+        val flourId = UUID.randomUUID()
+        val known = listOf(Ingredient(uuid = flourId, displayName = "Flour", allergen = null, sourcePrimary = null))
+        val scraped = minimalScrapedRecipe(ingredients = listOf(scrapedIngredient("flour")))
+
+        val draft = scraped.toRecipeDraft(UUID.randomUUID(), known, emptyList())
+
+        assertEquals(flourId, draft.ingredients.single().ingredientId)
+    }
+
+    @Test
+    fun `an unrecognised ingredient mints a new id rather than reusing an unrelated known one`() {
+        val flourId = UUID.randomUUID()
+        val known = listOf(Ingredient(uuid = flourId, displayName = "Flour", allergen = null, sourcePrimary = null))
+        val draft = minimalScrapedRecipe(ingredients = listOf(scrapedIngredient("Dragon Fruit")))
+            .toRecipeDraft(UUID.randomUUID(), known, emptyList())
+
+        assertTrue(draft.ingredients.single().ingredientId != flourId)
+        assertEquals("Dragon Fruit", draft.ingredients.single().ingredientDisplayName)
+    }
+
+    @Test
+    fun `ingredients missing quantity or unit fall back to 1 and unit`() {
+        val scraped = minimalScrapedRecipe(
+            ingredients = listOf(ScrapedIngredient(raw = "salt to taste", quantity = null, unit = null, name = "salt")),
+        )
+
+        val draft = scraped.toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(1.0, draft.ingredients.single().quantity, 0.0)
+        assertEquals("unit", draft.ingredients.single().unit)
+    }
+
+    @Test
+    fun `blank-name ingredients are dropped`() {
+        val scraped = minimalScrapedRecipe(
+            ingredients = listOf(scrapedIngredient("flour"), ScrapedIngredient(raw = "  ", quantity = null, unit = null, name = "  ")),
+        )
+
+        val draft = scraped.toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(1, draft.ingredients.size)
+    }
+
+    @Test
+    fun `duplicate ingredient names are deduped, keeping the first`() {
+        val scraped = minimalScrapedRecipe(
+            ingredients = listOf(
+                scrapedIngredient("Flour", quantity = 2.0),
+                scrapedIngredient("flour", quantity = 5.0),
+            ),
+        )
+
+        val draft = scraped.toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(1, draft.ingredients.size)
+        assertEquals(2.0, draft.ingredients.single().quantity, 0.0)
+    }
+
+    @Test
+    fun `instructions become ordered steps`() {
+        val draft = minimalScrapedRecipe(instructions = listOf("Step one", "Step two", "Step three"))
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(listOf(0, 1, 2), draft.steps.map { it.orderIndex })
+        assertEquals(listOf("Step one", "Step two", "Step three"), draft.steps.map { it.instruction })
+    }
+
+    @Test
+    fun `keywords reuse a known tag id, matched case-insensitively`() {
+        val dessertId = UUID.randomUUID()
+        val known = listOf(Tag(uuid = dessertId, displayName = "Dessert"))
+        val draft = minimalScrapedRecipe(keywords = listOf("dessert"))
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), known)
+
+        assertEquals(dessertId, draft.tags.single().uuid)
+    }
+
+    @Test
+    fun `keywords are capped at 8`() {
+        val keywords = (1..12).map { "keyword$it" }
+        val draft = minimalScrapedRecipe(keywords = keywords).toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(8, draft.tags.size)
+    }
+
+    @Test
+    fun `keywords longer than 30 characters are dropped`() {
+        val longKeyword = "a".repeat(31)
+        val draft = minimalScrapedRecipe(keywords = listOf(longKeyword, "short"))
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(listOf("short"), draft.tags.map { it.displayName })
+    }
+
+    @Test
+    fun `a fully-null-optional recipe still produces a draft that does not throw on toRecipe`() {
+        val scraped = ScrapedRecipe(
+            title = "Bare Recipe",
+            description = null,
+            imageUrl = null,
+            prepTimeMinutes = null,
+            cookTimeMinutes = null,
+            totalTimeMinutes = null,
+            servings = null,
+            ingredients = emptyList(),
+            instructions = emptyList(),
+            keywords = emptyList(),
+            author = null,
+            sourceUrl = "https://example.com/bare",
+        )
+
+        val draft = scraped.toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("0", draft.prepTimeMinutes)
+        assertEquals("0", draft.cookTimeMinutes)
+        assertEquals("0", draft.servings)
+
+        // Regression guard for the constraint that RecipeDraft.toRecipe() throws on blank numerics.
+        draft.toRecipe(testUser)
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporterTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporterTest.kt
@@ -1,0 +1,108 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.core.data.repository.FakeMetadataRepository
+import com.tenmilelabs.chefai.core.testutil.testIngredients
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.recipescraper.RecipeHtmlParser
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+private const val JSON_LD_RECIPE_HTML = """
+    <html><head>
+    <script type="application/ld+json">
+    {
+      "@type": "Recipe",
+      "name": "Mock Recipe",
+      "recipeIngredient": ["2 cups flour", "1 cup sugar"],
+      "recipeInstructions": ["Mix.", "Bake."]
+    }
+    </script>
+    </head><body></body></html>
+"""
+
+private const val NO_RECIPE_HTML = "<html><body><h1>Just a blog post</h1></body></html>"
+
+class DefaultRecipeImporterTest {
+
+    private fun importer(engine: MockEngine): DefaultRecipeImporter = DefaultRecipeImporter(
+        httpClient = HttpClient(engine) { expectSuccess = true },
+        recipeHtmlParser = RecipeHtmlParser(),
+        metadataRepository = FakeMetadataRepository(),
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    private fun htmlEngine(html: String, contentType: String = "text/html") = MockEngine { _ ->
+        respond(
+            content = ByteReadChannel(html),
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, contentType),
+        )
+    }
+
+    @Test
+    fun `imports a JSON-LD recipe and maps ingredients against the known catalog`() = runTest {
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML)).import("https://example.com/recipe")
+
+        val success = result as? RecipeImportResult.Success
+        assertThat(success).isNotNull()
+        assertThat(success!!.draft.title).isEqualTo("Mock Recipe")
+        val flourIngredient = success.draft.ingredients.find { it.ingredientDisplayName.equals("flour", ignoreCase = true) }
+        assertThat(flourIngredient).isNotNull()
+        assertThat(flourIngredient!!.ingredientId).isEqualTo(testIngredients.first { it.displayName == "Flour" }.uuid)
+    }
+
+    @Test
+    fun `returns NoRecipeFound when the page has no recipe markup`() = runTest {
+        val result = importer(htmlEngine(NO_RECIPE_HTML)).import("https://example.com/blog")
+
+        assertThat(result).isEqualTo(RecipeImportResult.NoRecipeFound)
+    }
+
+    @Test
+    fun `returns NetworkError on a 404`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.NotFound) }
+
+        val result = importer(engine).import("https://example.com/missing")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.NetworkError::class.java)
+    }
+
+    @Test
+    fun `returns NetworkError when the content type is not html`() = runTest {
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML, contentType = "application/pdf"))
+            .import("https://example.com/file.pdf")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.NetworkError::class.java)
+    }
+
+    @Test
+    fun `returns InvalidUrl for text that isn't a url`() = runTest {
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML)).import("not a url")
+
+        assertThat(result).isEqualTo(RecipeImportResult.InvalidUrl)
+    }
+
+    @Test
+    fun `returns InvalidUrl for a localhost address`() = runTest {
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML)).import("http://localhost:8080/x")
+
+        assertThat(result).isEqualTo(RecipeImportResult.InvalidUrl)
+    }
+
+    @Test
+    fun `returns InvalidUrl for a private-network address`() = runTest {
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML)).import("http://192.168.1.5/x")
+
+        assertThat(result).isEqualTo(RecipeImportResult.InvalidUrl)
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
@@ -1,0 +1,24 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import kotlinx.coroutines.CompletableDeferred
+
+class FakeRecipeImporter : RecipeImporter {
+
+    var result: RecipeImportResult = RecipeImportResult.InvalidUrl
+    var callCount: Int = 0
+        private set
+    var lastImportedUrl: String? = null
+        private set
+
+    /** When set, [import] suspends until this completes — lets tests assert in-flight behaviour. */
+    var gate: CompletableDeferred<Unit>? = null
+
+    override suspend fun import(url: String): RecipeImportResult {
+        callCount++
+        lastImportedUrl = url
+        gate?.await()
+        return result
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
@@ -1,0 +1,127 @@
+package com.tenmilelabs.chefai.recipes.ui.urlimport
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDraftDao
+import com.tenmilelabs.chefai.core.util.MainCoroutineRule
+import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.UUID
+
+@ExperimentalCoroutinesApi
+class ImportRecipeViewModelTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private lateinit var recipeImporter: FakeRecipeImporter
+    private lateinit var recipeDraftDao: FakeRecipeDraftDao
+    private lateinit var viewModel: ImportRecipeViewModel
+
+    @Before
+    fun setup() {
+        recipeImporter = FakeRecipeImporter()
+        recipeDraftDao = FakeRecipeDraftDao()
+        viewModel = ImportRecipeViewModel(recipeImporter, recipeDraftDao, mainCoroutineRule.testDispatcher)
+    }
+
+    @Test
+    fun `success persists a draft and emits the nav effect with the matching id`() = runTest {
+        val draftId = UUID.randomUUID()
+        recipeImporter.result = RecipeImportResult.Success(
+            RecipeDraft(recipeId = draftId, isNewRecipe = true, title = "Mock Recipe"),
+        )
+
+        viewModel.effects.test {
+            viewModel.dispatch(ImportAction.UrlChanged("https://example.com/recipe"))
+            viewModel.dispatch(ImportAction.Import)
+
+            val effect = awaitItem()
+            assertThat(effect).isEqualTo(ImportEffect.NavigateToEditorWithDraft(draftId))
+        }
+
+        assertThat(recipeDraftDao.getDraft(draftId)).isNotNull()
+        assertThat(viewModel.state.value.isImporting).isFalse()
+    }
+
+    @Test
+    fun `invalid url sets an error and emits no nav effect`() = runTest {
+        recipeImporter.result = RecipeImportResult.InvalidUrl
+
+        viewModel.dispatch(ImportAction.UrlChanged("not a url"))
+        viewModel.dispatch(ImportAction.Import)
+
+        assertThat(viewModel.state.value.errorRes).isEqualTo(R.string.import_recipe_invalid_url)
+        assertThat(viewModel.state.value.isImporting).isFalse()
+    }
+
+    @Test
+    fun `no recipe found sets an error and offers manual entry`() = runTest {
+        recipeImporter.result = RecipeImportResult.NoRecipeFound
+
+        viewModel.dispatch(ImportAction.UrlChanged("https://example.com/blog"))
+        viewModel.dispatch(ImportAction.Import)
+
+        assertThat(viewModel.state.value.errorRes).isEqualTo(R.string.import_recipe_no_recipe_found)
+        assertThat(viewModel.state.value.showManualEntryOption).isTrue()
+    }
+
+    @Test
+    fun `network error sets an error message`() = runTest {
+        recipeImporter.result = RecipeImportResult.NetworkError("timeout")
+
+        viewModel.dispatch(ImportAction.UrlChanged("https://example.com/recipe"))
+        viewModel.dispatch(ImportAction.Import)
+
+        assertThat(viewModel.state.value.errorRes).isEqualTo(R.string.import_recipe_network_error)
+    }
+
+    @Test
+    fun `parse error sets an error message`() = runTest {
+        recipeImporter.result = RecipeImportResult.ParseError("boom")
+
+        viewModel.dispatch(ImportAction.UrlChanged("https://example.com/recipe"))
+        viewModel.dispatch(ImportAction.Import)
+
+        assertThat(viewModel.state.value.errorRes).isEqualTo(R.string.import_recipe_parse_error)
+    }
+
+    @Test
+    fun `EnterManually emits the manual editor nav effect`() = runTest {
+        viewModel.effects.test {
+            viewModel.dispatch(ImportAction.EnterManually)
+            assertThat(awaitItem()).isEqualTo(ImportEffect.NavigateToManualEditor)
+        }
+    }
+
+    @Test
+    fun `Import is a no-op while a previous import is still in flight`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        recipeImporter.gate = gate
+        recipeImporter.result = RecipeImportResult.InvalidUrl
+
+        viewModel.dispatch(ImportAction.UrlChanged("https://example.com/recipe"))
+        viewModel.dispatch(ImportAction.Import)
+        assertThat(viewModel.state.value.isImporting).isTrue()
+
+        viewModel.dispatch(ImportAction.Import)
+        assertThat(recipeImporter.callCount).isEqualTo(1)
+
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun `Import does nothing when the url is blank`() = runTest {
+        viewModel.dispatch(ImportAction.Import)
+
+        assertThat(recipeImporter.callCount).isEqualTo(0)
+    }
+}

--- a/docs/adrs/adr-010-client-side-recipe-scraping.md
+++ b/docs/adrs/adr-010-client-side-recipe-scraping.md
@@ -1,0 +1,135 @@
+# ADR 010 – Client-Side Recipe URL Scraping
+
+**Date:** August 2026
+**Status:** Accepted
+**Author:** Claude (Sonnet 5), on behalf of Jose Mucientes
+
+---
+
+## Context
+
+The only way into Pocket Chef's recipe library was typing a recipe by hand into the unified editor.
+The FAB menu on the Recipes tab shipped an "Import recipe" item that did nothing. This ADR covers
+the design behind filling that gap: paste a recipe URL, get a pre-filled editor.
+
+Recipe sites are SEO-driven, so they almost universally embed schema.org `Recipe` structured data
+(JSON-LD or microdata) in static HTML for Google's rich-snippet search results. That means no
+headless browser or JS execution is needed — an HTTP GET plus an HTML parse is enough to extract a
+usable recipe from the large majority of sites.
+
+---
+
+## Decision 1: Client-side scraping, not a backend endpoint
+
+The scrape (fetch + parse) happens **on-device**, inside the Android app, rather than as a backend
+endpoint the app calls.
+
+**Why:**
+- Zero server compute cost, and zero new backend surface to build, deploy, and operate.
+- Requests to third-party sites are spread across users' own IPs rather than concentrated on one
+  backend IP that's trivially rate-limited or blocked by recipe sites.
+- No backend release is needed to ship the feature.
+
+**Tradeoff accepted:** a broken parser (a recipe site changes its markup) requires an app release to
+fix, not a backend deploy. There is also no cross-user cache — if 1,000 users import the same URL,
+it's fetched and parsed 1,000 times. If scraping volume ever justifies it, a cache-by-normalized-URL
+layer on the existing Ktor backend is a **later, additive** optimization — not a capability given up
+by this decision, since the client-side extraction logic would be reused as-is server-side too (see
+Decision 2).
+
+---
+
+## Decision 2: A separate `:recipe-scraper` Gradle module, pure Kotlin
+
+HTML-string-in, structured-recipe-out is a genuinely self-contained problem with no need for
+Android, Room, Hilt, or Ktor. It lives in its own module rather than a package inside `:app`:
+
+- The "no Android dependencies" boundary is **compiler-enforced**, not just a convention respected
+  by discipline.
+- Its tests run on plain JVM — no Robolectric, no instrumented tests, no emulator needed for the
+  extraction logic itself.
+- "Publish this as a library" becomes a `maven-publish` block, not a refactor. There is no comparable
+  Kotlin/JVM recipe scraper published today — the mature options
+  ([recipe-scrapers](https://github.com/hhursev/recipe-scrapers)) are Python; the JS ecosystem's
+  options lean on headless Chromium.
+- It's built as Kotlin Multiplatform (`jvm()`-only target for now, all code in `commonMain`) so
+  iOS/JS targets can be added later without moving files, even though only JVM is used today.
+
+The module does **no network I/O** — `RecipeHtmlParser.parse(html, sourceUrl)` takes a string and
+returns a `ScrapeResult`. `:app` owns fetching (see Decision 4), mirroring how the Python
+`recipe-scrapers` library separates fetching from parsing: it keeps the library dependency-light,
+testable purely from HTML fixtures, and reusable from a future backend cache layer without dragging
+Ktor client internals into it.
+
+---
+
+## Decision 3: JSON-LD first, microdata fallback, no per-site scrapers in v1
+
+Two generic extraction tiers, tried in order:
+
+1. **JSON-LD** (`<script type="application/ld+json">`) — the more common format and the more
+   reliably structured one (typed fields, less markup-mixed-with-data than microdata).
+2. **Microdata** (`itemscope`/`itemprop` attributes) — second-tier fallback for older or
+   differently-built sites.
+
+A tier only counts as a hit when it produces a non-blank title **and** at least one ingredient or
+instruction — a schema.org block with only a name is not a usable recipe, and falls through to the
+next tier or to `ScrapeResult.NoRecipeFound`.
+
+**No per-site selectors in v1.** Both tiers are schema.org-generic; nothing is hardcoded to a
+specific site's HTML structure. If misses turn out to be common in real usage, the extensible next
+step is a `SiteScraper` registry keyed by hostname as a third tier — the tiered design in
+`RecipeHtmlParser` leaves room for this without a redesign.
+
+**Ksoup, not Jsoup**, for HTML parsing (`com.fleeksoft.ksoup:ksoup`) — a Kotlin Multiplatform port of
+Jsoup's API, chosen specifically so the module's only non-Kotlin-stdlib dependency stays
+KMP-compatible, keeping the door open for non-JVM targets.
+
+---
+
+## Decision 4: Fetch/DI split — a second, unauthenticated Ktor `HttpClient`
+
+The single existing `HttpClient` (`core/di/NetworkModule.kt`) installs `AuthInterceptor` and runs
+responses through `ContentNegotiation`. Pointing that client at a third-party site would leak ChefAI
+auth tokens to whatever host the user pasted, and run untrusted third-party HTML through JSON content
+negotiation. A second client, qualified `@ScraperHttpClient`, was added instead:
+
+- No `AuthInterceptor` — the entire point.
+- No `ContentNegotiation` — the raw HTML body is wanted as text, not deserialized.
+- `HttpTimeout` (15s request / 10s connect / 10s socket) and `HttpRequestRetry` (2 retries,
+  exponential backoff on server errors) — a user-facing paste-a-URL action needs to fail fast and
+  predictably, unlike background sync.
+- A normal desktop `User-Agent` — many sites serve degraded or no HTML to unrecognized clients.
+- `Logging` at `INFO`, not `HEADERS` — scraped-page response headers are noise and may carry
+  third-party cookies worth not logging.
+
+`DefaultRecipeImporter` (the fetch → parse → map orchestrator) additionally: rejects non-`http(s)`
+schemes and loopback/private-network hosts before ever making a request (the URL is arbitrary user
+paste — there's no reason the app should fetch `localhost` or RFC1918 addresses); caps the read body
+at ~3MB via a bounded channel read, which is robust to a missing or wrong `Content-Length` header
+rather than trusting the header outright; and rejects non-HTML `Content-Type` responses before
+handing the body to the parser.
+
+---
+
+## Consequences
+
+**Positive:**
+- The integration into the existing editor is minimal: a scraped recipe becomes a `RecipeDraftEntity`
+  seeded under a new UUID, and the editor's existing `restoreDraftIfExists` / `populateFromDraft`
+  path (already built for auto-save/process-death recovery) picks it up with **no new
+  `EditorAction`, no reducer change**. Save takes the normal `createRecipe` + `addBookmark` path.
+- `:recipe-scraper` is independently testable and, per Decision 2, potentially independently
+  publishable later with no rearchitecting.
+- The auth-leak risk (Decision 4) is structurally prevented at the DI level, not just by code review
+  discipline — there is no code path where the scraper flow can obtain the authenticated client.
+
+**Negative / accepted tradeoffs:**
+- Per-user, per-request scraping cost (no shared cache) — see Decision 1.
+- No per-site scrapers — some sites with non-schema.org markup will simply fail to import in v1 and
+  fall back to `NoRecipeFound` with a manual-entry offramp.
+- `RecipeDraft.toRecipe()` still throws `NumberFormatException` on a blank numeric string, a
+  pre-existing contract the mapper works around by emitting `"0"` rather than `""` for absent
+  numerics — see `docs/claude/gotchas.md`. Hardening that contract (`toIntOrNull() ?: 0`) is a good
+  separate change, kept out of this diff since it touches a documented, tested path used by the
+  editor's save flow.

--- a/docs/claude/decisions.md
+++ b/docs/claude/decisions.md
@@ -13,6 +13,7 @@ All ADRs live in [`docs/adrs/`](../adrs/). This file is a quick-reference index.
 | 005 | [Feature-Based Packages](../adrs/adr-0005-feature-based-package-structure.md) | Nov 2025 | Feature packages over layer packages. Start in feature, move to core/ when shared. |
 | 006 | [Anonymous-First Sync](../adrs/adr-006-sync-protocol.md) | Feb 2026 | App works without login. Anonymous → Authenticated upgrade merges data. |
 | 009 | [Navigation-Scoped ViewModel for Wizards](../adrs/adr-009-navigation-scoped-viewmodel-for-wizards.md) | Mar 2026 | Multi-screen wizard flows use a nested NavGraph-scoped ViewModel; state lives exactly as long as the flow. |
+| 010 | [Client-Side Recipe URL Scraping](../adrs/adr-010-client-side-recipe-scraping.md) | Aug 2026 | Paste-a-URL import scrapes JSON-LD/microdata on-device via a new pure-Kotlin `:recipe-scraper` module; no backend endpoint, no per-site scrapers, unauthenticated `@ScraperHttpClient` prevents auth-token leakage to third-party hosts. |
 
 ## RFCs
 

--- a/docs/claude/gotchas.md
+++ b/docs/claude/gotchas.md
@@ -99,3 +99,48 @@ Hilt uses KSP. Don't add `kapt` dependencies — they'll slow the build and may 
 
 ### 16. Ktor MockEngine for network tests
 Always use `MockEngine` for testing network calls. Don't mock the repository when you can test the actual Ktor client with a fake server response.
+
+---
+
+## Recipe Import / Scraping (`:recipe-scraper`)
+
+### 17. `RecipeDraft.toRecipe()` throws on blank numeric strings
+`prepTimeMinutes`, `cookTimeMinutes`, and `servings` are `String` on `RecipeDraft` (so partial or
+invalid form input survives auto-save), but `toRecipe()` (`DraftMapper.kt`) calls bare `.toInt()` on
+them — a blank string throws `NumberFormatException`. Any code that builds a `RecipeDraft` from a
+source other than the editor's own form (e.g. `ScrapedRecipeMapper`) **must emit `"0"`, never `""`,
+for an absent numeric value**. `RecipeEditorReducer.revalidate()` also requires these three fields
+plus `description` to be non-blank for `isFormValid`, so a draft seeded with `"0"` correctly leaves
+Save disabled until the user confirms real values — it doesn't silently save a zero.
+
+### 18. The unqualified `HttpClient` carries ChefAI auth headers
+`NetworkModule.provideHttpClient()` installs `AuthInterceptor` and is injected by five API services.
+**Never point it at a third-party host** — a scraper, webhook receiver, or any code fetching a
+user-supplied URL must use the separate `@ScraperHttpClient`-qualified client (no auth interceptor,
+no content negotiation, its own timeout/retry/logging config). Don't add a qualifier to the existing
+`provideHttpClient` to "fix" this — it would break all five services that inject it unqualified; add
+a new provider alongside it instead, as `ScraperHttpClient.kt` does.
+
+### 19. Never name a package or class after a Kotlin reserved word
+`import` is a reserved keyword. A package literally named `...ui.import` (as originally planned for
+the recipe-import screens) compiles fine with plain `kotlinc`, but crashes **KSP2's
+Analysis-API-based FIR resolver** with a deeply-nested, misleading `NoClassDefFoundError:
+kotlin/reflect/full/KClasses` — thrown while KSP tries to render a debug attachment for an *earlier*
+internal failure resolving a symbol's containing declaration. It's a real toolchain bug (reproduced
+on Kotlin 2.3.0 / KSP 2.3.2), not a code-correctness issue, and it's deterministic: an **empty**
+`@HiltViewModel class Foo @Inject constructor() : ViewModel()` alone, in that package, is enough to
+trigger it. Renamed to `recipes/ui/urlimport/` and the build succeeded immediately with no other
+changes. If this exact `NoClassDefFoundError` shows up again, check package/class names against
+Kotlin's reserved-word list (`import`, `object`, `when`, `is`, `as`, `package`, …) before chasing
+Gradle daemon / cache / heap theories — those were all dead ends here.
+
+### 20. Building `:recipe-scraper` in a new worktree
+1. `local.properties` is gitignored, so a fresh `git worktree add` doesn't carry it over — every
+   `:app` Gradle task fails with "SDK location not found" until it's recreated with
+   `sdk.dir=<path to your Android SDK>`.
+2. The root `build.gradle.kts` needs `alias(libs.plugins.kotlin.multiplatform) apply false` in its
+   `plugins {}` block (already on `main`) — without it, `:recipe-scraper` applying
+   `kotlin("multiplatform")` fails with "plugin is already on the classpath with an unknown version."
+3. `recipe-scraper/build.gradle.kts` targets JVM 11 bytecode via
+   `jvm { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }`, not `jvmToolchain(11)` — the latter
+   requires an actual JDK 11 installation, which isn't guaranteed on every machine building this.

--- a/recipe-scraper/README.md
+++ b/recipe-scraper/README.md
@@ -1,0 +1,75 @@
+# :recipe-scraper
+
+A pure-Kotlin library that extracts a structured recipe from a web page's HTML.
+
+No Android, Hilt, Room, or Ktor dependencies — it takes an HTML string and returns a structured
+recipe, doing **no network I/O**. The host app (or any other JVM/Kotlin consumer) owns fetching the
+page; this module owns parsing it. See [ADR-010](../docs/adrs/adr-010-client-side-recipe-scraping.md)
+for the reasoning behind the module boundary and the client-side-vs-backend decision.
+
+## Why this exists
+
+Recipe sites are SEO-driven, so they almost universally embed
+[schema.org `Recipe`](https://schema.org/Recipe) structured data — JSON-LD or microdata — in static
+HTML for Google's rich-snippet search results. That's enough to extract a usable recipe from most
+sites without a headless browser or JS execution.
+
+## Public API
+
+```kotlin
+class RecipeHtmlParser {
+    fun parse(html: String, sourceUrl: String): ScrapeResult
+}
+
+sealed interface ScrapeResult {
+    data class Success(val recipe: ScrapedRecipe, val source: ExtractionSource) : ScrapeResult
+    data object NoRecipeFound : ScrapeResult
+    data class ParseError(val message: String) : ScrapeResult
+}
+```
+
+`parse` never throws — any unexpected failure inside the HTML or JSON parsers is caught and reported
+as `ScrapeResult.ParseError` instead. `sourceUrl` is recorded on the result as-is; it is never read
+from the page itself.
+
+`ScrapedRecipe` fields are nullable or empty wherever a page may legitimately omit them — this
+library reports what the page actually published and never fabricates or defaults a value. Choosing
+fallbacks (e.g. treating a missing prep time as zero) is the caller's job.
+
+## Extraction tiers
+
+Two generic tiers, tried in order — no per-site selectors:
+
+1. **JSON-LD** (`<script type="application/ld+json">`) — the more common format and the more
+   reliably structured one.
+2. **Microdata** (`itemscope`/`itemprop` attributes) — fallback for sites that don't publish JSON-LD.
+
+A tier counts as a hit only when it produces a non-blank title *and* at least one ingredient or
+instruction; otherwise the next tier is tried, and if both miss, the result is
+`ScrapeResult.NoRecipeFound`.
+
+## Using it
+
+```kotlin
+val parser = RecipeHtmlParser()
+when (val result = parser.parse(html, "https://example.com/recipe")) {
+    is ScrapeResult.Success -> result.recipe // title, ingredients, instructions, ...
+    ScrapeResult.NoRecipeFound -> // no usable schema.org Recipe markup on the page
+    is ScrapeResult.ParseError -> // unexpected failure; result.message describes it
+}
+```
+
+Fetching the HTML (an `HttpClient` GET, URL validation, response size caps, etc.) is the caller's
+responsibility — in this repo, that's `com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter`
+in `:app`.
+
+## Testing
+
+All tests run on plain JVM (`kotlin.test`, no Robolectric or instrumentation). Fixtures are
+hand-authored minimal HTML as Kotlin `const val` strings in `commonTest` — not saved copies of real
+sites, and not loaded from `commonTest/resources` (resource loading is awkward in KMP; inline strings
+are simpler and just as effective for these small fixtures).
+
+```bash
+./gradlew :recipe-scraper:jvmTest
+```

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParser.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParser.kt
@@ -1,0 +1,50 @@
+package com.tenmilelabs.recipescraper
+
+import com.fleeksoft.ksoup.Ksoup
+import com.tenmilelabs.recipescraper.jsonld.extractJsonLdRecipe
+import com.tenmilelabs.recipescraper.microdata.extractMicrodataRecipe
+import com.tenmilelabs.recipescraper.model.ExtractionSource
+import com.tenmilelabs.recipescraper.model.ScrapeResult
+import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+
+/**
+ * Extracts a structured recipe from an HTML document.
+ *
+ * This is the library's single entry point. It does parsing only — no network I/O — so callers
+ * fetch the HTML themselves and hand it in along with the URL it came from.
+ *
+ * [parse] never throws: any unexpected failure inside the HTML or JSON parsers is caught and
+ * reported as [ScrapeResult.ParseError] instead.
+ *
+ * Two extraction tiers are tried in order, JSON-LD then microdata, since JSON-LD is both the more
+ * common format on recipe sites and the more reliably structured one. A tier only counts as a hit
+ * when it produces a recipe with a non-blank title *and* at least one ingredient or instruction —
+ * a schema.org block that carries only a name is not a usable recipe, so the next tier is tried.
+ */
+class RecipeHtmlParser {
+
+    /**
+     * Extracts a recipe from [html]. [sourceUrl] is recorded on the result as-is; it is never read
+     * from the page itself.
+     */
+    fun parse(html: String, sourceUrl: String): ScrapeResult = try {
+        val document = Ksoup.parse(html)
+
+        val jsonLd = extractJsonLdRecipe(document, sourceUrl)
+        if (jsonLd != null && jsonLd.isUsable()) {
+            ScrapeResult.Success(jsonLd, ExtractionSource.JSON_LD)
+        } else {
+            val microdata = extractMicrodataRecipe(document, sourceUrl)
+            if (microdata != null && microdata.isUsable()) {
+                ScrapeResult.Success(microdata, ExtractionSource.MICRODATA)
+            } else {
+                ScrapeResult.NoRecipeFound
+            }
+        }
+    } catch (e: Exception) {
+        ScrapeResult.ParseError(e.message ?: "Unknown parse error")
+    }
+}
+
+private fun ScrapedRecipe.isUsable(): Boolean =
+    title.isNotBlank() && (ingredients.isNotEmpty() || instructions.isNotEmpty())

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdExtractor.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdExtractor.kt
@@ -1,0 +1,58 @@
+package com.tenmilelabs.recipescraper.jsonld
+
+import com.fleeksoft.ksoup.nodes.Document
+import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Finds and maps the first usable schema.org `Recipe` in a document's `application/ld+json`
+ * blocks.
+ *
+ * A "candidate miss" — a `Recipe`-typed object with no usable `name` — does not abort the search;
+ * the next candidate (in the same block's `@graph`, or a later script block) is tried instead.
+ * A malformed block is skipped rather than failing the whole extraction.
+ */
+internal fun extractJsonLdRecipe(document: Document, sourceUrl: String): ScrapedRecipe? {
+    for (script in document.select("script[type=application/ld+json]")) {
+        val root = runCatching { LENIENT_JSON.parseToJsonElement(script.data()) }.getOrNull() ?: continue
+        for (candidate in findRecipeCandidates(root)) {
+            val recipe = mapJsonLdRecipe(candidate, sourceUrl)
+            if (recipe != null) return recipe
+        }
+    }
+    return null
+}
+
+private val LENIENT_JSON = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+/**
+ * Walks a parsed JSON-LD document looking for `Recipe`-typed objects, in document order. Handles a
+ * bare object, a top-level array, an `@graph` wrapper, and an `@graph` nested inside an array
+ * element.
+ */
+private fun findRecipeCandidates(element: JsonElement): List<JsonObject> = when (element) {
+    is JsonObject -> buildList {
+        if (element.isRecipeType()) add(element)
+        (element["@graph"] as? JsonArray)?.let { addAll(findRecipeCandidates(it)) }
+    }
+
+    is JsonArray -> element.flatMap { findRecipeCandidates(it) }
+    else -> emptyList()
+}
+
+private fun JsonObject.isRecipeType(): Boolean = typeNames().any { it.equals("Recipe", ignoreCase = true) }
+
+/** `@type` as either a bare string or an array of strings. */
+internal fun JsonObject.typeNames(): List<String> = when (val type = this["@type"]) {
+    is JsonPrimitive -> listOfNotNull(type.contentOrNull)
+    is JsonArray -> type.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+    else -> emptyList()
+}

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdRecipeMapper.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdRecipeMapper.kt
@@ -1,0 +1,108 @@
+package com.tenmilelabs.recipescraper.jsonld
+
+import com.tenmilelabs.recipescraper.ingredient.parseIngredient
+import com.tenmilelabs.recipescraper.model.ScrapedIngredient
+import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+import com.tenmilelabs.recipescraper.util.cleanHtmlText
+import com.tenmilelabs.recipescraper.util.firstIntOrNull
+import com.tenmilelabs.recipescraper.util.parseDurationToMinutes
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Maps one `Recipe`-typed JSON-LD object to a [ScrapedRecipe].
+ *
+ * Returns `null` when the object has no usable `name` — per schema.org's own spec `name` is
+ * required, so an object without one is not a real recipe listing, just a malformed or partial one.
+ */
+internal fun mapJsonLdRecipe(obj: JsonObject, sourceUrl: String): ScrapedRecipe? {
+    val title = cleanHtmlText(obj.stringOrNull("name")) ?: return null
+
+    return ScrapedRecipe(
+        title = title,
+        description = cleanHtmlText(obj.stringOrNull("description")),
+        imageUrl = obj["image"]?.firstImageUrlOrNull(),
+        prepTimeMinutes = parseDurationToMinutes(obj.stringOrNull("prepTime")),
+        cookTimeMinutes = parseDurationToMinutes(obj.stringOrNull("cookTime")),
+        totalTimeMinutes = parseDurationToMinutes(obj.stringOrNull("totalTime")),
+        servings = obj["recipeYield"]?.yieldStrings()?.firstNotNullOfOrNull(::firstIntOrNull),
+        ingredients = (obj["recipeIngredient"] ?: obj["ingredients"])?.toIngredients().orEmpty(),
+        instructions = obj["recipeInstructions"]?.toInstructionSteps().orEmpty(),
+        keywords = obj.keywords(),
+        author = obj["author"]?.firstAuthorNameOrNull(),
+        sourceUrl = sourceUrl,
+    )
+}
+
+internal fun JsonObject.stringOrNull(key: String): String? = (this[key] as? JsonPrimitive)?.contentOrNull
+
+private fun JsonElement.firstImageUrlOrNull(): String? = when (this) {
+    is JsonArray -> firstNotNullOfOrNull { it.firstImageUrlOrNull() }
+    is JsonObject -> stringOrNull("url")
+    is JsonPrimitive -> contentOrNull
+}
+
+private fun JsonElement.yieldStrings(): List<String> = when (this) {
+    is JsonArray -> flatMap { it.yieldStrings() }
+    is JsonPrimitive -> listOfNotNull(contentOrNull)
+    is JsonObject -> emptyList()
+}
+
+private fun JsonElement.toIngredients(): List<ScrapedIngredient> =
+    when (this) {
+        is JsonArray -> mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            .mapNotNull(::cleanHtmlText)
+            .map(::parseIngredient)
+
+        else -> emptyList()
+    }
+
+private fun JsonElement.toInstructionSteps(): List<String> = when (this) {
+    is JsonArray -> flatMap { it.toInstructionSteps() }
+
+    is JsonObject -> {
+        if (typeNames().any { it.equals("HowToSection", ignoreCase = true) }) {
+            this["itemListElement"]?.toInstructionSteps().orEmpty()
+        } else {
+            listOfNotNull(cleanHtmlText(stringOrNull("text") ?: stringOrNull("name")))
+        }
+    }
+
+    is JsonPrimitive -> contentOrNull?.let(::splitInstructionText).orEmpty()
+}
+
+/** A single string blob, split on newlines or — failing that — numbered-list markers ("1. "). */
+private fun splitInstructionText(text: String): List<String> {
+    val byLine = text.split(Regex("\r?\n+")).map { it.trim() }.filter { it.isNotBlank() }
+    val pieces = when {
+        byLine.size > 1 -> byLine
+        NUMBERED_MARKER.containsMatchIn(text) -> text.split(NUMBERED_MARKER).map { it.trim() }.filter { it.isNotBlank() }
+        else -> listOf(text)
+    }
+    return pieces.mapNotNull(::cleanHtmlText)
+}
+
+private val NUMBERED_MARKER = Regex("(?:^|\\s)\\d{1,2}[.)]\\s+")
+
+private fun JsonObject.keywords(): List<String> {
+    val all = this["keywords"]?.commaOrArraySeparated().orEmpty() +
+        this["recipeCategory"]?.commaOrArraySeparated().orEmpty() +
+        this["recipeCuisine"]?.commaOrArraySeparated().orEmpty()
+    val seen = HashSet<String>()
+    return all.filter { it.isNotBlank() && seen.add(it.lowercase()) }
+}
+
+private fun JsonElement.commaOrArraySeparated(): List<String> = when (this) {
+    is JsonArray -> flatMap { it.commaOrArraySeparated() }
+    is JsonPrimitive -> contentOrNull?.split(",")?.map { it.trim() }.orEmpty()
+    is JsonObject -> emptyList()
+}
+
+private fun JsonElement.firstAuthorNameOrNull(): String? = when (this) {
+    is JsonArray -> firstNotNullOfOrNull { it.firstAuthorNameOrNull() }
+    is JsonObject -> stringOrNull("name")
+    is JsonPrimitive -> contentOrNull
+}

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/microdata/MicrodataExtractor.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/microdata/MicrodataExtractor.kt
@@ -1,0 +1,63 @@
+package com.tenmilelabs.recipescraper.microdata
+
+import com.fleeksoft.ksoup.nodes.Document
+import com.fleeksoft.ksoup.nodes.Element
+import com.tenmilelabs.recipescraper.ingredient.parseIngredient
+import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+import com.tenmilelabs.recipescraper.util.cleanHtmlText
+import com.tenmilelabs.recipescraper.util.firstIntOrNull
+import com.tenmilelabs.recipescraper.util.parseDurationToMinutes
+
+/**
+ * Extracts a recipe from schema.org microdata (`itemscope`/`itemprop` attributes) — the second-tier
+ * fallback for sites that don't publish JSON-LD. Reuses the same HTML-stripping and yield-integer
+ * helpers as the JSON-LD tier ([cleanHtmlText], [firstIntOrNull]) rather than duplicating them.
+ *
+ * Returns `null` when the document has no `Recipe`-typed microdata scope, or that scope has no
+ * usable `name`.
+ */
+internal fun extractMicrodataRecipe(document: Document, sourceUrl: String): ScrapedRecipe? {
+    val scope = document.select("[itemscope][itemtype~=(?i)schema\\.org/Recipe]").firstOrNull() ?: return null
+    val title = cleanHtmlText(scope.propertyValue("name")) ?: return null
+
+    return ScrapedRecipe(
+        title = title,
+        description = cleanHtmlText(scope.propertyValue("description")),
+        imageUrl = scope.propertyValue("image"),
+        prepTimeMinutes = parseDurationToMinutes(scope.propertyValue("prepTime")),
+        cookTimeMinutes = parseDurationToMinutes(scope.propertyValue("cookTime")),
+        totalTimeMinutes = parseDurationToMinutes(scope.propertyValue("totalTime")),
+        servings = firstIntOrNull(scope.propertyValue("recipeYield")),
+        ingredients = scope.propertyValues("recipeIngredient")
+            .mapNotNull(::cleanHtmlText)
+            .map(::parseIngredient),
+        instructions = scope.propertyValues("recipeInstructions").mapNotNull(::cleanHtmlText),
+        keywords = scope.keywords(),
+        author = cleanHtmlText(scope.propertyValue("author")),
+        sourceUrl = sourceUrl,
+    )
+}
+
+private fun Element.keywords(): List<String> {
+    val all = propertyValues("keywords") + propertyValues("recipeCategory") + propertyValues("recipeCuisine")
+    val split = all.flatMap { it.split(",") }.map { it.trim() }
+    val seen = HashSet<String>()
+    return split.filter { it.isNotBlank() && seen.add(it.lowercase()) }
+}
+
+/** The first `[itemprop=<name>]` value scoped to this element. */
+private fun Element.propertyValue(name: String): String? = propertyValues(name).firstOrNull()
+
+/** Every `[itemprop=<name>]` value scoped to this element, in document order. */
+private fun Element.propertyValues(name: String): List<String> =
+    select("[itemprop=$name]").mapNotNull { it.microdataValue() }
+
+/**
+ * `content` (for `<meta>`) → `datetime` (for `<time>`, where an ISO duration lives) → `src` (for
+ * `<img>`) → `href` (for `<a>`/`<link>`) → else the element's own text.
+ */
+private fun Element.microdataValue(): String? =
+    attrOrNull("content") ?: attrOrNull("datetime") ?: attrOrNull("src") ?: attrOrNull("href")
+        ?: text().takeIf { it.isNotBlank() }
+
+private fun Element.attrOrNull(key: String): String? = attr(key).takeIf { it.isNotBlank() }

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParserTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParserTest.kt
@@ -1,0 +1,75 @@
+package com.tenmilelabs.recipescraper
+
+import com.tenmilelabs.recipescraper.jsonld.JsonLdFixtures
+import com.tenmilelabs.recipescraper.microdata.MicrodataFixtures
+import com.tenmilelabs.recipescraper.model.ExtractionSource
+import com.tenmilelabs.recipescraper.model.ScrapeResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class RecipeHtmlParserTest {
+
+    private val parser = RecipeHtmlParser()
+
+    @Test
+    fun `extracts from JSON-LD when present`() {
+        val result = parser.parse(JsonLdFixtures.PLAIN_OBJECT, "https://example.com/r")
+
+        val success = assertIs<ScrapeResult.Success>(result)
+        assertEquals(ExtractionSource.JSON_LD, success.source)
+        assertEquals("Simple Pancakes", success.recipe.title)
+    }
+
+    @Test
+    fun `falls back to microdata when there is no JSON-LD`() {
+        val result = parser.parse(MicrodataFixtures.FULL_RECIPE, "https://example.com/r")
+
+        val success = assertIs<ScrapeResult.Success>(result)
+        assertEquals(ExtractionSource.MICRODATA, success.source)
+        assertEquals("Chocolate Chip Cookies", success.recipe.title)
+    }
+
+    @Test
+    fun `prefers JSON-LD over microdata when both are present`() {
+        val html = JsonLdFixtures.PLAIN_OBJECT.replace("</body></html>", "") +
+            MicrodataFixtures.FULL_RECIPE.substringAfter("<body>")
+
+        val result = parser.parse(html, "https://example.com/r")
+
+        val success = assertIs<ScrapeResult.Success>(result)
+        assertEquals(ExtractionSource.JSON_LD, success.source)
+        assertEquals("Simple Pancakes", success.recipe.title)
+    }
+
+    @Test
+    fun `falls through to NoRecipeFound when the only JSON-LD candidate has no ingredients or instructions`() {
+        assertEquals(ScrapeResult.NoRecipeFound, parser.parse(JsonLdFixtures.NAME_ONLY, "https://example.com/r"))
+    }
+
+    @Test
+    fun `falls through to NoRecipeFound when the only microdata scope has no ingredients or instructions`() {
+        assertEquals(ScrapeResult.NoRecipeFound, parser.parse(MicrodataFixtures.NAME_ONLY, "https://example.com/r"))
+    }
+
+    @Test
+    fun `returns NoRecipeFound for a page with no recipe markup`() {
+        assertEquals(
+            ScrapeResult.NoRecipeFound,
+            parser.parse("<html><body>hello</body></html>", "https://example.com/r"),
+        )
+    }
+
+    @Test
+    fun `returns NoRecipeFound for an empty document`() {
+        assertEquals(ScrapeResult.NoRecipeFound, parser.parse("", "https://example.com/r"))
+    }
+
+    @Test
+    fun `records the caller-supplied sourceUrl, not anything read from the page`() {
+        val result = parser.parse(JsonLdFixtures.PLAIN_OBJECT, "https://mysite.example/recipe/42")
+
+        val success = assertIs<ScrapeResult.Success>(result)
+        assertEquals("https://mysite.example/recipe/42", success.recipe.sourceUrl)
+    }
+}

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdExtractorTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdExtractorTest.kt
@@ -1,0 +1,96 @@
+package com.tenmilelabs.recipescraper.jsonld
+
+import com.fleeksoft.ksoup.Ksoup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class JsonLdExtractorTest {
+
+    private fun extract(html: String) = extractJsonLdRecipe(Ksoup.parse(html), sourceUrl = "https://example.com/r")
+
+    @Test
+    fun `maps a plain Recipe object`() {
+        val recipe = extract(JsonLdFixtures.PLAIN_OBJECT)
+
+        assertEquals("Simple Pancakes", recipe?.title)
+        assertEquals("Fluffy pancakes for breakfast.", recipe?.description)
+        assertEquals("https://example.com/pancakes.jpg", recipe?.imageUrl)
+        assertEquals(10, recipe?.prepTimeMinutes)
+        assertEquals(15, recipe?.cookTimeMinutes)
+        assertEquals(4, recipe?.servings)
+        assertEquals(listOf("2 cups all-purpose flour", "1 cup milk", "2 eggs"), recipe?.ingredients?.map { it.raw })
+        assertEquals(
+            listOf("Mix dry ingredients.", "Whisk in milk and eggs.", "Cook on a griddle."),
+            recipe?.instructions,
+        )
+        assertEquals(listOf("breakfast", "easy"), recipe?.keywords)
+        assertEquals("Jane Doe", recipe?.author)
+        assertEquals("https://example.com/r", recipe?.sourceUrl)
+    }
+
+    @Test
+    fun `finds a Recipe nested inside an @graph wrapper, skipping non-Recipe siblings`() {
+        val recipe = extract(JsonLdFixtures.GRAPH_WRAPPER)
+
+        assertEquals("Graph Recipe", recipe?.title)
+        assertEquals(listOf("Cream the sugar.", "Bake it."), recipe?.instructions)
+    }
+
+    @Test
+    fun `matches a Recipe when @type is an array`() {
+        val recipe = extract(JsonLdFixtures.TYPE_ARRAY)
+
+        assertEquals("Multi-Typed Recipe", recipe?.title)
+    }
+
+    @Test
+    fun `flattens HowToSection instructions in order`() {
+        val recipe = extract(JsonLdFixtures.HOW_TO_SECTIONS)
+
+        assertEquals(
+            listOf("Rinse the rice.", "Soak for 10 minutes.", "Boil until tender."),
+            recipe?.instructions,
+        )
+    }
+
+    @Test
+    fun `splits a single instructions string on newlines`() {
+        val recipe = extract(JsonLdFixtures.STRING_INSTRUCTIONS)
+
+        assertEquals(listOf("Peel the potato.", "Boil it.", "Mash it."), recipe?.instructions)
+    }
+
+    @Test
+    fun `resolves an ImageObject to its url`() {
+        val recipe = extract(JsonLdFixtures.IMAGE_OBJECT)
+
+        assertEquals("https://example.com/dish.jpg", recipe?.imageUrl)
+    }
+
+    @Test
+    fun `skips a malformed script block and recovers the valid one`() {
+        val recipe = extract(JsonLdFixtures.MULTIPLE_BLOCKS_ONE_MALFORMED)
+
+        assertEquals("Recovered Recipe", recipe?.title)
+    }
+
+    @Test
+    fun `treats a nameless Recipe candidate as a miss`() {
+        assertNull(extract("""<script type="application/ld+json">{"@type":"Recipe"}</script>"""))
+    }
+
+    @Test
+    fun `returns null when no Recipe markup is present`() {
+        assertNull(extract("<html><body>hello</body></html>"))
+    }
+
+    @Test
+    fun `a name-only Recipe still maps — ingredient-instruction sufficiency is the caller's job`() {
+        val recipe = extract(JsonLdFixtures.NAME_ONLY)
+
+        assertEquals("Just A Name", recipe?.title)
+        assertEquals(emptyList(), recipe?.ingredients)
+        assertEquals(emptyList(), recipe?.instructions)
+    }
+}

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdFixtures.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdFixtures.kt
@@ -1,0 +1,141 @@
+package com.tenmilelabs.recipescraper.jsonld
+
+/**
+ * Minimal, hand-authored HTML fixtures exercising the JSON-LD extraction shapes seen in the wild.
+ * Deliberately not copies of real sites — see the plan this module was built from.
+ */
+internal object JsonLdFixtures {
+
+    val PLAIN_OBJECT = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org/",
+          "@type": "Recipe",
+          "name": "Simple Pancakes",
+          "description": "Fluffy <b>pancakes</b> for breakfast.",
+          "image": "https://example.com/pancakes.jpg",
+          "prepTime": "PT10M",
+          "cookTime": "PT15M",
+          "recipeYield": "4 servings",
+          "recipeIngredient": ["2 cups all-purpose flour", "1 cup milk", "2 eggs"],
+          "recipeInstructions": ["Mix dry ingredients.", "Whisk in milk and eggs.", "Cook on a griddle."],
+          "keywords": "breakfast, easy",
+          "author": {"@type": "Person", "name": "Jane Doe"}
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val GRAPH_WRAPPER = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {"@type": "WebPage", "name": "Some Page"},
+            {
+              "@type": "Recipe",
+              "name": "Graph Recipe",
+              "recipeIngredient": ["1 cup sugar"],
+              "recipeInstructions": ["Cream the sugar.", "Bake it."]
+            }
+          ]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val TYPE_ARRAY = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": ["NewsArticle", "Recipe"],
+          "name": "Multi-Typed Recipe",
+          "recipeIngredient": ["1 lemon"],
+          "recipeInstructions": ["Squeeze the lemon."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val HOW_TO_SECTIONS = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Sectioned Recipe",
+          "recipeIngredient": ["1 cup rice"],
+          "recipeInstructions": [
+            {
+              "@type": "HowToSection",
+              "name": "Prep",
+              "itemListElement": [
+                {"@type": "HowToStep", "text": "Rinse the rice."},
+                {"@type": "HowToStep", "text": "Soak for 10 minutes."}
+              ]
+            },
+            {
+              "@type": "HowToSection",
+              "name": "Cook",
+              "itemListElement": [
+                {"@type": "HowToStep", "text": "Boil until tender."}
+              ]
+            }
+          ]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val STRING_INSTRUCTIONS = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Blob Instructions Recipe",
+          "recipeIngredient": ["1 potato"],
+          "recipeInstructions": "Peel the potato.\nBoil it.\nMash it."
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val IMAGE_OBJECT = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Image Object Recipe",
+          "image": {"@type": "ImageObject", "url": "https://example.com/dish.jpg"},
+          "recipeIngredient": ["1 cup broth"],
+          "recipeInstructions": ["Heat the broth."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val MULTIPLE_BLOCKS_ONE_MALFORMED = """
+        <html><head>
+        <script type="application/ld+json">
+        { this is not valid json at all
+        </script>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Recovered Recipe",
+          "recipeIngredient": ["1 cup water"],
+          "recipeInstructions": ["Boil the water."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val NAME_ONLY = """
+        <html><head>
+        <script type="application/ld+json">
+        {"@type": "Recipe", "name": "Just A Name"}
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+}

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/microdata/MicrodataExtractorTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/microdata/MicrodataExtractorTest.kt
@@ -1,0 +1,60 @@
+package com.tenmilelabs.recipescraper.microdata
+
+import com.fleeksoft.ksoup.Ksoup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MicrodataExtractorTest {
+
+    private fun extract(html: String) = extractMicrodataRecipe(Ksoup.parse(html), sourceUrl = "https://example.com/r")
+
+    @Test
+    fun `maps a full microdata recipe`() {
+        val recipe = extract(MicrodataFixtures.FULL_RECIPE)
+
+        assertEquals("Chocolate Chip Cookies", recipe?.title)
+        assertEquals("Classic chewy cookies.", recipe?.description)
+        assertEquals("https://example.com/cookies.jpg", recipe?.imageUrl)
+        assertEquals(20, recipe?.prepTimeMinutes)
+        assertEquals(10, recipe?.cookTimeMinutes)
+        assertEquals(24, recipe?.servings)
+        assertEquals(listOf("2 cups flour", "1 cup sugar"), recipe?.ingredients?.map { it.raw })
+        assertEquals(
+            listOf("Preheat oven to 350F.", "Mix ingredients.", "Bake for 10 minutes."),
+            recipe?.instructions,
+        )
+        assertEquals(listOf("cookies", "dessert"), recipe?.keywords)
+        assertEquals("Baker Bob", recipe?.author)
+        assertEquals("https://example.com/r", recipe?.sourceUrl)
+    }
+
+    @Test
+    fun `reads meta content and link href values`() {
+        val recipe = extract(MicrodataFixtures.META_AND_LINK_VALUES)
+
+        assertEquals("Meta-Driven Recipe", recipe?.title)
+        assertEquals(6, recipe?.servings)
+        assertEquals("https://example.com/from-link.jpg", recipe?.imageUrl)
+    }
+
+    @Test
+    fun `treats a nameless scope as a miss`() {
+        assertNull(extract("""<div itemscope itemtype="https://schema.org/Recipe"></div>"""))
+    }
+
+    @Test
+    fun `returns null when there is no Recipe-typed scope`() {
+        assertNull(extract(MicrodataFixtures.NO_RECIPE_SCOPE))
+        assertNull(extract("<html><body>hello</body></html>"))
+    }
+
+    @Test
+    fun `a name-only scope still maps — ingredient-instruction sufficiency is the caller's job`() {
+        val recipe = extract(MicrodataFixtures.NAME_ONLY)
+
+        assertEquals("Just A Name", recipe?.title)
+        assertEquals(emptyList(), recipe?.ingredients)
+        assertEquals(emptyList(), recipe?.instructions)
+    }
+}

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/microdata/MicrodataFixtures.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/microdata/MicrodataFixtures.kt
@@ -1,0 +1,51 @@
+package com.tenmilelabs.recipescraper.microdata
+
+/** Minimal, hand-authored HTML fixtures exercising the microdata shapes seen in the wild. */
+internal object MicrodataFixtures {
+
+    val FULL_RECIPE = """
+        <html><body>
+        <div itemscope itemtype="https://schema.org/Recipe">
+          <h1 itemprop="name">Chocolate Chip Cookies</h1>
+          <p itemprop="description">Classic <b>chewy</b> cookies.</p>
+          <img itemprop="image" src="https://example.com/cookies.jpg" />
+          <time itemprop="prepTime" datetime="PT20M">20 mins</time>
+          <time itemprop="cookTime" datetime="PT10M">10 mins</time>
+          <span itemprop="recipeYield">24 cookies</span>
+          <ul>
+            <li itemprop="recipeIngredient">2 cups flour</li>
+            <li itemprop="recipeIngredient">1 cup sugar</li>
+          </ul>
+          <ol>
+            <li itemprop="recipeInstructions">Preheat oven to 350F.</li>
+            <li itemprop="recipeInstructions">Mix ingredients.</li>
+            <li itemprop="recipeInstructions">Bake for 10 minutes.</li>
+          </ol>
+          <span itemprop="keywords">cookies, dessert</span>
+          <span itemprop="author">Baker Bob</span>
+        </div>
+        </body></html>
+    """.trimIndent()
+
+    val NAME_ONLY = """
+        <html><body>
+        <div itemscope itemtype="http://schema.org/Recipe">
+          <span itemprop="name">Just A Name</span>
+        </div>
+        </body></html>
+    """.trimIndent()
+
+    val META_AND_LINK_VALUES = """
+        <html><body>
+        <div itemscope itemtype="https://schema.org/Recipe">
+          <meta itemprop="name" content="Meta-Driven Recipe" />
+          <meta itemprop="recipeYield" content="6" />
+          <link itemprop="image" href="https://example.com/from-link.jpg" />
+          <li itemprop="recipeIngredient">1 cup broth</li>
+          <li itemprop="recipeInstructions">Heat the broth.</li>
+        </div>
+        </body></html>
+    """.trimIndent()
+
+    val NO_RECIPE_SCOPE = "<html><body><div itemscope itemtype=\"https://schema.org/Article\">hello</div></body></html>"
+}


### PR DESCRIPTION
## Summary

Completes the recipe URL import feature (plan: `frolicking-squishing-cookie`), building on the
already-merged foundation from #123 (`:recipe-scraper` module scaffolding, T1/T2/T3/T4/T10) and
#124 (`@ScraperHttpClient`, T8).

- **T5/T6/T7** — JSON-LD + microdata extraction tiers in `:recipe-scraper`, and `RecipeHtmlParser`
  wiring the two tiers together. The library is complete and independently testable (59 tests).
- **T9a** — `ScrapedRecipe` → `RecipeDraft` mapper: never-blank numerics, ingredient/tag catalog
  matching to avoid duplicate rows.
- **T9b** — `DefaultRecipeImporter`: fetch (via `@ScraperHttpClient`) → validate URL (rejects
  non-http(s), loopback/private hosts) → parse → map. Ktor `MockEngine`-tested (repo's first use).
- **T11** — `ImportRecipeViewModel`/`Screen` in `recipes/ui/urlimport/` (see note below on the
  package name).
- **T12** — wired into the Recipes tab FAB and nav graph; import screen hides bottom nav/FAB.
- **T13** — ADR-010, CLAUDE.md, gotchas.md, `:recipe-scraper/README.md`.

T14 (share-target intent) is an explicit optional follow-up per the plan — not included here.

## Notable finding

`recipes/ui/import/` (as originally planned) compiles fine with plain `kotlinc` but crashes KSP2's
Analysis-API resolver (`import` is a reserved Kotlin keyword). Reproduced deterministically via a
disposable worktree bisection down to an empty `@HiltViewModel` class in that package; fixed by
renaming to `recipes/ui/urlimport/`. Written up in `docs/claude/gotchas.md` #19 in case it resurfaces
elsewhere.

## Test plan

- [x] `./gradlew :recipe-scraper:jvmTest` — 59/59 passing
- [x] `./gradlew :app:testDebugUnitTest` — 369/369 passing
- [x] `./gradlew :app:assembleDebug` — succeeds
- [x] Manual E2E on `emulator-5554`: FAB → Import Recipe → invalid-URL error (correct copy, field
      error state) → live network-error path (no crash, button re-enables) → Back returns cleanly
      to Recipes with bottom nav/FAB restored
- [ ] Happy-path JSON-LD import against a real, reachable recipe URL — not pixel-verified in this
      environment (network reachability to arbitrary external hosts was unconfirmed on the emulator
      used), but the mechanism is covered by `DefaultRecipeImporterTest`'s 7 MockEngine tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)