### PR TITLE
Recipe import: share-target intent (T14)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,11 +16,18 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/tenmilelabs/chefai/MainActivity.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/MainActivity.kt
@@ -1,31 +1,53 @@
 package com.tenmilelabs.chefai
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.tenmilelabs.chefai.core.ui.navigation.ChefAINavGraph
 import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+import com.tenmilelabs.chefai.core.util.extractSharedRecipeUrl
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    private var pendingSharedUrl by mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        consumeShareIntent(intent)
         setContent {
             ChefAITheme {
                 Surface(tonalElevation = 5.dp) {
                     ChefAINavGraph(
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.fillMaxSize(),
+                        pendingSharedUrl = pendingSharedUrl,
+                        onPendingSharedUrlConsumed = { pendingSharedUrl = null },
                     )
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        consumeShareIntent(intent)
+    }
+
+    /** Handles a `Share` from another app (e.g. Chrome's share sheet) landing on this activity. */
+    private fun consumeShareIntent(intent: Intent) {
+        if (intent.action != Intent.ACTION_SEND || intent.type != "text/plain") return
+        pendingSharedUrl = extractSharedRecipeUrl(intent.getStringExtra(Intent.EXTRA_TEXT))
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
@@ -5,8 +5,10 @@ import androidx.navigation.NavHostController
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.DRAFT_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.MEAL_PLAN_ID_ARG
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.PREFILL_URL_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.RECIPE_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.ScreenBaseRoutes.RECIPE_DETAILS
+import java.net.URLEncoder
 import java.util.UUID
 
 /**
@@ -44,6 +46,13 @@ object AppDestinationArgs {
      * which puts the editor in edit mode against an already-saved recipe.
      */
     const val DRAFT_ID_ARG = "draftUuid"
+
+    /**
+     * A URL to pre-fill the import screen's field with, used when the app is opened via the
+     * Android share sheet (see [MainActivity][com.tenmilelabs.chefai.MainActivity]). URL-encoded
+     * in the route, since the value itself is a URL containing reserved characters.
+     */
+    const val PREFILL_URL_ARG = "prefillUrl"
 }
 
 /**
@@ -67,7 +76,10 @@ enum class AppDestinations(
             "?${RECIPE_ID_ARG}={${RECIPE_ID_ARG}}" +
             "&${DRAFT_ID_ARG}={${DRAFT_ID_ARG}}"
     ),
-    IMPORT_RECIPE(R.string.app_dest_title_import_recipe, ScreenBaseRoutes.IMPORT_RECIPE),
+    IMPORT_RECIPE(
+        R.string.app_dest_title_import_recipe,
+        "${ScreenBaseRoutes.IMPORT_RECIPE}?${PREFILL_URL_ARG}={${PREFILL_URL_ARG}}"
+    ),
     MEAL_PLAN_DETAIL(
         R.string.app_dest_title_meal_plan_detail,
         "${ScreenBaseRoutes.MEAL_PLAN_DETAIL}/{$MEAL_PLAN_ID_ARG}"
@@ -99,8 +111,17 @@ class NavigationActions(private val navController: NavHostController) {
         navController.navigate("${ScreenBaseRoutes.RECIPE_EDITOR}?${RECIPE_ID_ARG}=$recipeId")
     }
 
-    fun navigateToImportRecipe() {
-        navController.navigate(ScreenBaseRoutes.IMPORT_RECIPE)
+    /**
+     * @param prefillUrl a URL to pre-fill the field with, e.g. from a share-sheet intent. `null`
+     *   for the normal FAB entry point, which starts with an empty field.
+     */
+    fun navigateToImportRecipe(prefillUrl: String? = null) {
+        if (prefillUrl == null) {
+            navController.navigate(ScreenBaseRoutes.IMPORT_RECIPE)
+        } else {
+            val encoded = URLEncoder.encode(prefillUrl, "UTF-8")
+            navController.navigate("${ScreenBaseRoutes.IMPORT_RECIPE}?${PREFILL_URL_ARG}=$encoded")
+        }
     }
 
     /**

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -58,10 +58,21 @@ fun ChefAINavGraph(
     navController: NavHostController = rememberNavController(),
     navActions: NavigationActions = remember(navController) {
         NavigationActions(navController)
-    }
+    },
+    pendingSharedUrl: String? = null,
+    onPendingSharedUrlConsumed: () -> Unit = {},
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val backPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+
+    // A URL shared into the app from another app (e.g. Chrome's share sheet) jumps straight to the
+    // import screen, prefilled — regardless of which screen is currently on top.
+    LaunchedEffect(pendingSharedUrl) {
+        if (pendingSharedUrl != null) {
+            navActions.navigateToImportRecipe(prefillUrl = pendingSharedUrl)
+            onPendingSharedUrlConsumed()
+        }
+    }
 
     // Home is always the start destination (anonymous-first model).
     // Login/Register are available via profile menu or settings.
@@ -199,7 +210,16 @@ fun ChefAINavGraph(
                 snackbarHostState = snackbarHostState,
             )
         }
-        composable(route = AppDestinations.IMPORT_RECIPE.route) {
+        composable(
+            route = AppDestinations.IMPORT_RECIPE.route,
+            arguments = listOf(
+                navArgument(AppDestinationArgs.PREFILL_URL_ARG) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+            ),
+        ) {
             ImportRecipeRoute(
                 onNavigateToEditorWithDraft = { draftId -> navActions.navigateToEditorWithDraft(draftId) },
                 onNavigateToManualEditor = { navActions.navigateToCreateRecipe() },

--- a/app/src/main/java/com/tenmilelabs/chefai/core/util/ShareTextUrlExtractor.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/util/ShareTextUrlExtractor.kt
@@ -1,0 +1,24 @@
+package com.tenmilelabs.chefai.core.util
+
+import com.tenmilelabs.chefai.recipes.data.repository.normalizeAndValidateUrl
+
+private val URL_REGEX = Regex("https?://\\S+")
+
+/** Trailing punctuation a sentence wraps a shared link in, e.g. "...check it out: https://x.com/r." */
+private val TRAILING_PUNCTUATION = Regex("[.,;:!?)\\]\"']+$")
+
+/**
+ * Extracts a usable recipe URL from arbitrary shared text — typically Android's share-sheet
+ * `EXTRA_TEXT`, which often reads like "Check out this recipe! https://example.com/r Enjoy!"
+ * rather than a bare URL.
+ *
+ * The text comes from another app and is exactly as untrusted as a pasted URL, so the candidate is
+ * run through the same [normalizeAndValidateUrl] check used for manual paste — an invalid or
+ * private-network URL yields `null` here too, rather than being handed to the importer.
+ */
+fun extractSharedRecipeUrl(sharedText: String?): String? {
+    val match = sharedText?.let { URL_REGEX.find(it)?.value } ?: return null
+    val trimmed = match.replace(TRAILING_PUNCTUATION, "")
+    if (trimmed.isBlank()) return null
+    return normalizeAndValidateUrl(trimmed)
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModel.kt
@@ -1,11 +1,13 @@
 package com.tenmilelabs.chefai.recipes.ui.urlimport
 
 import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDraftDao
 import com.tenmilelabs.chefai.core.di.IoDispatcher
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
 import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraftEntity
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
@@ -20,6 +22,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.net.URLDecoder
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,9 +30,15 @@ class ImportRecipeViewModel @Inject constructor(
     private val recipeImporter: RecipeImporter,
     private val recipeDraftDao: RecipeDraftDao,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(ImportRecipeState())
+    /** Set when the screen was opened via the share sheet, e.g. Chrome's "Share" → Pocket Chef. */
+    private val prefillUrl: String? = savedStateHandle.get<String>(AppDestinationArgs.PREFILL_URL_ARG)
+        ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrNull() }
+        ?.takeIf { it.isNotBlank() }
+
+    private val _state = MutableStateFlow(ImportRecipeState(url = prefillUrl.orEmpty()))
     val state: StateFlow<ImportRecipeState> = _state.asStateFlow()
 
     private val _effects = Channel<ImportEffect>(Channel.BUFFERED)

--- a/app/src/test/java/com/tenmilelabs/chefai/core/util/ShareTextUrlExtractorTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/util/ShareTextUrlExtractorTest.kt
@@ -1,0 +1,54 @@
+package com.tenmilelabs.chefai.core.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ShareTextUrlExtractorTest {
+
+    @Test
+    fun `extracts a bare url`() {
+        assertThat(extractSharedRecipeUrl("https://example.com/recipe")).isEqualTo("https://example.com/recipe")
+    }
+
+    @Test
+    fun `extracts a url embedded in prose`() {
+        val shared = "Check out this recipe! https://example.com/recipe/143 So good."
+        assertThat(extractSharedRecipeUrl(shared)).isEqualTo("https://example.com/recipe/143")
+    }
+
+    @Test
+    fun `strips trailing sentence punctuation`() {
+        assertThat(extractSharedRecipeUrl("Try this: https://example.com/recipe."))
+            .isEqualTo("https://example.com/recipe")
+        assertThat(extractSharedRecipeUrl("(https://example.com/recipe)"))
+            .isEqualTo("https://example.com/recipe")
+    }
+
+    @Test
+    fun `returns null when there is no url`() {
+        assertThat(extractSharedRecipeUrl("Just a note about dinner, no link here.")).isNull()
+    }
+
+    @Test
+    fun `returns null for null or blank input`() {
+        assertThat(extractSharedRecipeUrl(null)).isNull()
+        assertThat(extractSharedRecipeUrl("")).isNull()
+    }
+
+    @Test
+    fun `returns null for a private-network url, same as manual paste`() {
+        assertThat(extractSharedRecipeUrl("check this out http://192.168.1.5/recipe")).isNull()
+        assertThat(extractSharedRecipeUrl("http://localhost:8080/recipe")).isNull()
+    }
+
+    @Test
+    fun `ignores a non-http scheme`() {
+        assertThat(extractSharedRecipeUrl("ftp://example.com/recipe")).isNull()
+    }
+
+    @Test
+    fun `picks the first url when multiple are present`() {
+        val shared = "https://example.com/first and also https://example.com/second"
+        assertThat(extractSharedRecipeUrl(shared)).isEqualTo("https://example.com/first")
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
@@ -1,9 +1,11 @@
 package com.tenmilelabs.chefai.recipes.ui.urlimport
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDraftDao
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
 import com.tenmilelabs.chefai.core.util.MainCoroutineRule
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
@@ -14,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.net.URLEncoder
 import java.util.UUID
 
 @ExperimentalCoroutinesApi
@@ -30,7 +33,16 @@ class ImportRecipeViewModelTest {
     fun setup() {
         recipeImporter = FakeRecipeImporter()
         recipeDraftDao = FakeRecipeDraftDao()
-        viewModel = ImportRecipeViewModel(recipeImporter, recipeDraftDao, mainCoroutineRule.testDispatcher)
+        viewModel = createViewModel()
+    }
+
+    private fun createViewModel(prefillUrl: String? = null): ImportRecipeViewModel {
+        val savedStateHandle = SavedStateHandle().apply {
+            if (prefillUrl != null) {
+                set(AppDestinationArgs.PREFILL_URL_ARG, URLEncoder.encode(prefillUrl, "UTF-8"))
+            }
+        }
+        return ImportRecipeViewModel(recipeImporter, recipeDraftDao, mainCoroutineRule.testDispatcher, savedStateHandle)
     }
 
     @Test
@@ -123,5 +135,18 @@ class ImportRecipeViewModelTest {
         viewModel.dispatch(ImportAction.Import)
 
         assertThat(recipeImporter.callCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `seeds the url field from a PREFILL_URL_ARG passed via SavedStateHandle`() = runTest {
+        val prefilled = createViewModel(prefillUrl = "https://example.com/shared-recipe")
+
+        assertThat(prefilled.state.value.url).isEqualTo("https://example.com/shared-recipe")
+        assertThat(prefilled.state.value.canImport).isTrue()
+    }
+
+    @Test
+    fun `starts with an empty url when there is no PREFILL_URL_ARG`() = runTest {
+        assertThat(viewModel.state.value.url).isEqualTo("")
     }
 }


### PR DESCRIPTION
## Summary

Completes T14 (optional follow-up) from the recipe URL import plan, on top of the merged #125.

Lets users share a URL from another app's share sheet (Chrome, etc.) straight into Pocket Chef's
import screen, instead of copy-pasting.

- `AndroidManifest.xml`: `ACTION_SEND` / `text/plain` intent-filter on `MainActivity`,
  `launchMode="singleTask"` so a share while the app is already running reuses the existing
  instance (`onNewIntent`) instead of spawning a duplicate task.
- `core/util/ShareTextUrlExtractor.kt`: finds the first http(s) URL in free share text (e.g.
  "Check this out! `<url>` Enjoy"), strips trailing sentence punctuation, and runs it through the
  same `normalizeAndValidateUrl` used for manual paste — shared text is exactly as untrusted as
  user paste, so a private/loopback URL is rejected the same way.
- New `PREFILL_URL_ARG` nav arg (URL-encoded in the route) carries the extracted URL into
  `ImportRecipeViewModel`'s initial state via `SavedStateHandle`.
- `ChefAINavGraph` deep-links to the import screen from wherever the user currently is when a
  share lands.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 379/379 passing (10 new: `ShareTextUrlExtractorTest` +
      2 new `ImportRecipeViewModelTest` prefill cases)
- [x] `./gradlew :app:assembleDebug` — succeeds
- [x] Manual verification on `emulator-5554` via `adb shell am start -a android.intent.action.SEND`:
  - Cold start (app force-stopped, fresh process) → prefills and opens the import screen
  - Warm start (app already running) → hits `onNewIntent`, re-prefills, no duplicate task
  - Share text with no URL → no-op, doesn't disrupt whatever screen is currently showing
  - Normal launcher-icon tap → unaffected by the `singleTask` launch mode change

🤖 Generated with [Claude Code](https://claude.com/claude-code)