### PR TITLE
Recipe import: instrumented test coverage (Room DAO + E2E UI)

### DIFF
--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
@@ -10,9 +10,13 @@ import com.tenmilelabs.chefai.collections.data.repository.DefaultCollectionsRepo
 import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
 import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanApiService
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanNetworkDataSource
 import com.tenmilelabs.chefai.mealplans.data.repository.DefaultMealPlanRepository
 import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
+import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.Binds
 import dagger.Module
@@ -76,6 +80,16 @@ abstract class TestRepositoryModule {
         fun provideSecurePreferences(): SecurePreferencesInterface {
             return FakeSecurePreferences()
         }
+
+        /**
+         * Provides a singleton instance of FakeRecipeImporter — avoids real network calls to
+         * third-party recipe sites in instrumented tests.
+         */
+        @Provides
+        @Singleton
+        fun provideFakeRecipeImporter(): FakeRecipeImporter {
+            return FakeRecipeImporter()
+        }
     }
 
     /**
@@ -105,4 +119,23 @@ abstract class TestRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindMealPlanRepository(repository: DefaultMealPlanRepository): MealPlanRepository
+
+    /**
+     * Binds the meal plan network data source (same as production — real `MealPlanApiService`,
+     * lazily constructed by Dagger and never actually called unless a test exercises meal plan
+     * generation). Was missing from this module entirely, which broke the Hilt test component for
+     * *any* `@HiltAndroidTest` class, not just ones touching meal plans.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindMealPlanNetworkDataSource(service: MealPlanApiService): MealPlanNetworkDataSource
+
+    /**
+     * Binds the fake recipe importer — real fetch/parse is exercised by unit tests
+     * ([com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporterTest] with Ktor
+     * `MockEngine`); instrumented tests only need to exercise the UI/navigation/persistence wiring.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindRecipeImporter(fake: FakeRecipeImporter): RecipeImporter
 }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDraftDaoTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDraftDaoTest.kt
@@ -1,0 +1,116 @@
+package com.tenmilelabs.chefai.data.source.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity
+import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+/**
+ * Instrumented test for [com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDraftDao] against a
+ * real (in-memory) Room database — the recipe URL import flow's final write goes through this DAO,
+ * and its `@Upsert`-generated SQL is otherwise untested (the unit-test suite only exercises
+ * `FakeRecipeDraftDao`, a hand-written in-memory map, not Room's generated implementation).
+ */
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class RecipeDraftDaoTest {
+
+    private lateinit var database: ChefAIDataBase
+
+    private fun draft(recipeId: UUID = UuidV7Generator.newId(), title: String = "Draft Title") =
+        RecipeDraftEntity(
+            recipeId = recipeId,
+            isNewRecipe = true,
+            title = title,
+            description = "A description",
+            imageUrl = "",
+            selectedImageUri = null,
+            prepTimeMinutes = "10",
+            cookTimeMinutes = "20",
+            servings = "4",
+            externalUrl = "https://example.com/recipe",
+            ingredientsJson = "[]",
+            stepsJson = "[]",
+            tagsJson = "[]",
+            labelsJson = "[]",
+            version = 1,
+            updatedAt = System.currentTimeMillis(),
+        )
+
+    @Before
+    fun createDb() {
+        database = Room.inMemoryDatabaseBuilder(getApplicationContext(), ChefAIDataBase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun closeDb() {
+        database.close()
+    }
+
+    @Test
+    fun saveDraft_thenGetDraft_returnsTheSameDraft() = runTest {
+        val entity = draft()
+
+        database.recipeDraftDao().saveDraft(entity)
+        val loaded = database.recipeDraftDao().getDraft(entity.recipeId)
+
+        assertEquals(entity, loaded)
+    }
+
+    @Test
+    fun getDraft_forAnUnknownId_returnsNull() = runTest {
+        assertNull(database.recipeDraftDao().getDraft(UuidV7Generator.newId()))
+    }
+
+    @Test
+    fun saveDraft_upsertsRatherThanDuplicating() = runTest {
+        val recipeId = UuidV7Generator.newId()
+        database.recipeDraftDao().saveDraft(draft(recipeId, title = "First title"))
+        database.recipeDraftDao().saveDraft(draft(recipeId, title = "Updated title"))
+
+        val loaded = database.recipeDraftDao().getDraft(recipeId)
+
+        assertEquals("Updated title", loaded?.title)
+    }
+
+    @Test
+    fun deleteDraft_removesOnlyThatDraft() = runTest {
+        val keep = draft(title = "Keep me")
+        val remove = draft(title = "Remove me")
+        database.recipeDraftDao().saveDraft(keep)
+        database.recipeDraftDao().saveDraft(remove)
+
+        database.recipeDraftDao().deleteDraft(remove.recipeId)
+
+        assertNull(database.recipeDraftDao().getDraft(remove.recipeId))
+        assertEquals(keep, database.recipeDraftDao().getDraft(keep.recipeId))
+    }
+
+    @Test
+    fun deleteAllDrafts_clearsEveryDraft() = runTest {
+        val first = draft()
+        val second = draft()
+        database.recipeDraftDao().saveDraft(first)
+        database.recipeDraftDao().saveDraft(second)
+
+        database.recipeDraftDao().deleteAllDrafts()
+
+        assertNull(database.recipeDraftDao().getDraft(first.recipeId))
+        assertNull(database.recipeDraftDao().getDraft(second.recipeId))
+    }
+}

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
@@ -1,0 +1,27 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+
+/**
+ * Fake implementation of [RecipeImporter] for instrumented tests — avoids real network I/O while
+ * exercising the real navigation graph, ViewModel, and Room-backed draft persistence.
+ *
+ * Duplicated from the `test/` source set fake by design — see `docs/claude/gotchas.md` #15.
+ */
+class FakeRecipeImporter : RecipeImporter {
+
+    var result: RecipeImportResult = RecipeImportResult.InvalidUrl
+    var lastImportedUrl: String? = null
+        private set
+
+    override suspend fun import(url: String): RecipeImportResult {
+        lastImportedUrl = url
+        return result
+    }
+
+    fun reset() {
+        result = RecipeImportResult.InvalidUrl
+        lastImportedUrl = null
+    }
+}

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeE2ETest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeE2ETest.kt
@@ -1,0 +1,156 @@
+package com.tenmilelabs.chefai.recipes.ui.urlimport
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.platform.app.InstrumentationRegistry
+import com.tenmilelabs.chefai.MainActivity
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+/**
+ * End-to-end UI tests for the recipe URL import flow.
+ *
+ * These exercise the real navigation graph, the real [ImportRecipeViewModel], and real Room-backed
+ * draft persistence (via [com.tenmilelabs.chefai.core.di.TestDatabaseModule]'s in-memory database).
+ * Only [FakeRecipeImporter] is swapped in — real fetch/parse behaviour (network errors, HTML
+ * extraction, URL validation) is covered by
+ * [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporterTest] with Ktor `MockEngine`.
+ */
+@HiltAndroidTest
+class ImportRecipeE2ETest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Inject
+    lateinit var fakeRecipeImporter: FakeRecipeImporter
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        fakeRecipeImporter.reset()
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        // The screen prefills its field from the clipboard on first composition; clear it so
+        // whatever's left over on the device/emulator from unrelated use can't leak into a test.
+        clearClipboard()
+    }
+
+    @After
+    fun tearDown() {
+        fakeRecipeImporter.reset()
+        clearClipboard()
+    }
+
+    private fun clearClipboard() {
+        val clipboardManager = context.getSystemService(ClipboardManager::class.java)
+        clipboardManager.setPrimaryClip(ClipData.newPlainText("", ""))
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun navigateToImportScreenViaFab() {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("HomeScreen"), 5_000)
+
+        composeTestRule.onNodeWithText(context.getString(R.string.app_dest_title_recipes)).performClick()
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("RecipesScreen"), 5_000)
+
+        composeTestRule.onNodeWithTag("RecipesFabToggle").performClick()
+        composeTestRule.onNodeWithTag("ImportRecipeFabItem").performClick()
+
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("ImportRecipeScreen"), 5_000)
+    }
+
+    /**
+     * Given: a successful scrape result queued on the fake importer
+     * When: the user reaches the import screen via the FAB, enters a URL and taps Import
+     * Then: the app navigates to the recipe editor — the draft was persisted (real Room) and the
+     *   nav effect fired
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun successfulImport_navigatesToTheRecipeEditor() {
+        val draftId = UuidV7Generator.newId()
+        fakeRecipeImporter.result = RecipeImportResult.Success(
+            RecipeDraft(recipeId = draftId, isNewRecipe = true, title = "Imported Recipe"),
+        )
+
+        navigateToImportScreenViaFab()
+
+        composeTestRule.onNodeWithTag("ImportUrlField").performTextInput("https://example.com/recipe")
+        composeTestRule.onNodeWithTag("ImportButton").performClick()
+
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("RecipeEditorScreen"), 5_000)
+
+        assertEquals("https://example.com/recipe", fakeRecipeImporter.lastImportedUrl)
+    }
+
+    /**
+     * Given: the fake importer configured to report an invalid URL
+     * When: the user taps Import
+     * Then: an error message is shown and the user stays on the import screen (no nav effect)
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun invalidUrl_showsAnErrorAndStaysOnTheImportScreen() {
+        fakeRecipeImporter.result = RecipeImportResult.InvalidUrl
+
+        navigateToImportScreenViaFab()
+
+        composeTestRule.onNodeWithTag("ImportUrlField").performTextInput("not a url")
+        composeTestRule.onNodeWithTag("ImportButton").performClick()
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.import_recipe_invalid_url))
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("ImportRecipeScreen").assertIsDisplayed()
+    }
+
+    /**
+     * Given: the fake importer configured to report no recipe was found on the page
+     * When: the user taps Import
+     * Then: the "enter it manually" offramp is shown alongside the error
+     */
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun noRecipeFound_offersManualEntry() {
+        fakeRecipeImporter.result = RecipeImportResult.NoRecipeFound
+
+        navigateToImportScreenViaFab()
+
+        composeTestRule.onNodeWithTag("ImportUrlField").performTextInput("https://example.com/not-a-recipe")
+        composeTestRule.onNodeWithTag("ImportButton").performClick()
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.import_recipe_no_recipe_found))
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.import_recipe_enter_manually))
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/FloatingActionButtonMenu.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/FloatingActionButtonMenu.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -75,14 +76,16 @@ fun FloatingActionButtonMenu(
                     FabMenuItem(
                         onClick = onImportRecipeClick,
                         icon = Icons.Default.Download,
-                        label = stringResource(id = R.string.fab_import_recipe)
+                        label = stringResource(id = R.string.fab_import_recipe),
+                        buttonTestTag = "ImportRecipeFabItem"
                     )
 
                     // Create Recipe option
                     FabMenuItem(
                         onClick = onCreateRecipeClick,
                         icon = Icons.Default.Create,
-                        label = stringResource(id = R.string.fab_create_recipe)
+                        label = stringResource(id = R.string.fab_create_recipe),
+                        buttonTestTag = "CreateRecipeFabItem"
                     )
                 }
             }
@@ -92,6 +95,7 @@ fun FloatingActionButtonMenu(
                 onClick = {
                     onExpandedChange()
                 },
+                modifier = Modifier.testTag("RecipesFabToggle"),
                 containerColor = MaterialTheme.colorScheme.tertiary,
                 contentColor = MaterialTheme.colorScheme.onTertiary
             ) {
@@ -110,7 +114,8 @@ fun FabMenuItem(
     onClick: () -> Unit,
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     label: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    buttonTestTag: String? = null
 ) {
     Row(
         modifier = modifier,
@@ -135,6 +140,7 @@ fun FabMenuItem(
         // Small FAB
         FloatingActionButton(
             onClick = onClick,
+            modifier = if (buttonTestTag != null) Modifier.testTag(buttonTestTag) else Modifier,
             containerColor = MaterialTheme.colorScheme.tertiaryContainer,
             contentColor = MaterialTheme.colorScheme.onTertiaryContainer
         ) {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/RecipesScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/RecipesScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,6 +46,7 @@ fun RecipesScreen(
     val context = LocalContext.current
 
     PullToRefreshBox(
+        modifier = Modifier.testTag("RecipesScreen"),
         isRefreshing = uiState.isRefreshing,
         onRefresh = viewModel::onRefresh,
     ) {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -138,7 +139,7 @@ fun RecipeEditorScreen(
     if (state.isLoading) {
         LoadingContent()
     } else {
-        Column {
+        Column(modifier = Modifier.testTag("RecipeEditorScreen")) {
             EditorActionBar(
                 mode = state.mode,
                 onSave = {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeScreen.kt
@@ -18,8 +18,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -61,19 +63,30 @@ fun ImportRecipeScreen(
     modifier: Modifier = Modifier,
 ) {
     val clipboard = LocalClipboard.current
+    // Tracks the latest state inside the effect below — the clipboard read is async, so without
+    // re-checking against the current (not the initial) url, text the user types while it's still
+    // in flight would be silently overwritten once it resolves.
+    val currentState = rememberUpdatedState(state)
     LaunchedEffect(Unit) {
-        if (state.url.isNotBlank()) return@LaunchedEffect
+        if (currentState.value.url.isNotBlank()) return@LaunchedEffect
         val clipboardText = runCatching {
             clipboard.getClipEntry()?.clipData?.let { data ->
                 if (data.itemCount > 0) data.getItemAt(0).text?.toString() else null
             }
         }.getOrNull()
-        if (clipboardText != null && (clipboardText.startsWith("http://") || clipboardText.startsWith("https://"))) {
+        val isHttpUrl = clipboardText != null &&
+            (clipboardText.startsWith("http://") || clipboardText.startsWith("https://"))
+        if (isHttpUrl && currentState.value.url.isBlank()) {
             onAction(ImportAction.UrlChanged(clipboardText))
         }
     }
 
-    Column(modifier = modifier.fillMaxSize().padding(dimensionResource(R.dimen.padding_medium))) {
+    Column(
+        modifier = modifier
+            .testTag("ImportRecipeScreen")
+            .fillMaxSize()
+            .padding(dimensionResource(R.dimen.padding_medium)),
+    ) {
         Text(stringResource(R.string.import_recipe_title), style = MaterialTheme.typography.headlineSmall)
 
         Spacer(Modifier.height(dimensionResource(R.dimen.padding_large)))
@@ -88,7 +101,7 @@ fun ImportRecipeScreen(
             isError = state.errorRes != null,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Go),
             keyboardActions = KeyboardActions(onGo = { if (state.canImport) onAction(ImportAction.Import) }),
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag("ImportUrlField"),
         )
 
         Spacer(Modifier.height(dimensionResource(R.dimen.padding_medium)))
@@ -96,7 +109,7 @@ fun ImportRecipeScreen(
         Button(
             onClick = { onAction(ImportAction.Import) },
             enabled = state.canImport,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag("ImportButton"),
         ) {
             if (state.isImporting) {
                 CircularProgressIndicator(

--- a/docs/claude/gotchas.md
+++ b/docs/claude/gotchas.md
@@ -144,3 +144,25 @@ Gradle daemon / cache / heap theories — those were all dead ends here.
 3. `recipe-scraper/build.gradle.kts` targets JVM 11 bytecode via
    `jvm { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } }`, not `jvmToolchain(11)` — the latter
    requires an actual JDK 11 installation, which isn't guaranteed on every machine building this.
+
+### 21. `TestRepositoryModule` (androidTest) must bind every leaf dependency any `@HiltViewModel` needs
+Hilt builds **one shared test component** for the whole `androidTest` source set — every
+`@HiltAndroidTest` class and every `@HiltViewModel` in the app is aggregated into it, whether or not
+a given test actually uses them. `TestRepositoryModule` (`TestAuthModule.kt`) replaces production
+`RepositoryModule` wholesale, so it must independently provide *everything* production would have —
+missing even one binding (e.g. `MealPlanNetworkDataSource`, missed until a second `@HiltAndroidTest`
+class was added) fails `hiltJavaCompileDebugAndroidTest` for **every** instrumented test in the
+module, not just ones touching that dependency. When adding a new production `@Binds`/`@Provides` to
+a module a `Test*Module` replaces, add the equivalent there too — reusing the real implementation
+(as `bindMealPlanNetworkDataSource` does) is fine when nothing in the test suite actually invokes it;
+Dagger bindings are lazy.
+
+### 22. Compose `LaunchedEffect(Unit)` closures don't see later state changes — use `rememberUpdatedState`
+`ImportRecipeScreen`'s clipboard-prefill effect checked `state.url.isNotBlank()` once, before an
+`await`ed clipboard read, then unconditionally applied the clipboard text after. Since
+`LaunchedEffect(Unit)` runs its block once and the `state` parameter it closed over is whatever was
+current at that first composition, a user typing into the field *while* the clipboard read was still
+in flight had their input silently overwritten the moment it resolved — a real race, not
+hypothetical (it fired in an instrumented test run). Fix: wrap the read in `rememberUpdatedState` and
+re-check the *current* value immediately before acting on an awaited result, not just before starting
+the `await`.


### PR DESCRIPTION
## Summary

Fills the instrumented-test gap for recipe import, on top of merged #125/#126.

Unit coverage was already thorough (~100 tests across `:recipe-scraper` and `:app`), but zero
instrumented — matching, not filling, a pre-existing gap: no recipe/editor screen had instrumented
tests before this; only auth did (`AuthE2ETest`).

- **`RecipeDraftDaoTest.kt`** — real in-memory Room DB test for `RecipeDraftDao`, mirroring the
  existing `RecipeDaoTest.kt` pattern. The unit suite only ever exercised `FakeRecipeDraftDao` (a
  hand-written map), never Room's generated `@Upsert`/`@Query` implementation.
- **`ImportRecipeE2ETest.kt`** — real nav graph, real ViewModel, real Room-backed draft persistence;
  only `RecipeImporter` is faked (duplicated into `androidTest` per this repo's existing
  fake-duplication convention). Covers: success → navigates to the editor, invalid URL → error
  shown, no-recipe-found → manual-entry offramp shown.
- Added `testTag`s needed to drive the E2E test: `RecipesScreen`, the FAB toggle + its two menu
  items, `ImportRecipeScreen` + its URL field + Import button, `RecipeEditorScreen` — none of these
  had any before.

## Two real bugs the new tests caught (both fixed here)

1. **`TestRepositoryModule` (androidTest DI) never bound `MealPlanNetworkDataSource`.** This broke
   Hilt's test component graph for *any* `@HiltAndroidTest` class the instant a second one existed
   alongside `AuthE2ETest` (`CreateMealPlanViewModel`'s dependency chain pulls it in globally).
   Pre-existing gap, unrelated to recipe import — fixed by binding the real `MealPlanApiService`,
   matching the module's existing pattern for its other bindings.
2. **`ImportRecipeScreen`'s clipboard-prefill race.** It only checked `state.url.isNotBlank()` once,
   *before* the async clipboard read — text typed while that read was in flight got silently
   overwritten the moment it resolved. The E2E test hit this for real (an emulator clipboard value
   clobbered the test's typed input). Fixed with `rememberUpdatedState` + a re-check right before
   dispatching.

## Test plan

- [x] All 16 instrumented tests pass on `emulator-5554`, including the pre-existing `AuthE2ETest`
      (untouched apart from the DI fix)
- [x] `./gradlew :app:testDebugUnitTest :recipe-scraper:jvmTest` — all green, no regressions
- [x] `./gradlew :app:assembleDebug` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)