### PR TITLE
Add recipe delete feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,8 @@ After completing any code change (bug fix, feature, refactor), always run the un
 | Meal Plans — Android sync wiring | Not started — extend `SyncOrchestrator` + `SyncDtos`         |
 | Conflict resolution | SyncState.CONFLICT defined but unused                                     |
 | RecipesViewModel user wiring | Hardcoded test UUID, needs real user from SessionManager           |
-| Recipe URL import | Done — paste a URL, scrape via `:recipe-scraper` (JSON-LD/microdata), pre-fill the editor. No per-site scrapers, no nutrition data, no image download. Share-target intent (T14) not started — optional follow-up. |
+| Recipe URL import | Done — paste a URL, scrape via `:recipe-scraper` (JSON-LD/microdata), pre-fill the editor. No per-site scrapers, no nutrition data, no image download. Share-target intent (T14) done (#126). |
+| Recipe delete | Done — soft delete via a button on the recipe details screen. No undo, no list swipe-to-delete, no delete from the meal-plan recipe route. |
 
 **Next milestone**: Complete all tasks to prepare for Monstro Demo
 

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
@@ -10,9 +10,13 @@ import com.tenmilelabs.chefai.collections.data.repository.DefaultCollectionsRepo
 import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
 import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanApiService
+import com.tenmilelabs.chefai.mealplans.data.network.MealPlanNetworkDataSource
 import com.tenmilelabs.chefai.mealplans.data.repository.DefaultMealPlanRepository
 import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.Binds
 import dagger.Module
@@ -105,4 +109,21 @@ abstract class TestRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindMealPlanRepository(repository: DefaultMealPlanRepository): MealPlanRepository
+
+    /**
+     * Binds the meal plan network data source (same as production) — required for Hilt's shared
+     * test component to resolve MealPlansViewModel's graph, even though this DAO test never uses it.
+     * See docs/claude/gotchas.md #21.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindMealPlanNetworkDataSource(service: MealPlanApiService): MealPlanNetworkDataSource
+
+    /**
+     * Binds the recipe importer (same as production) — required for Hilt's shared test component
+     * to resolve ImportRecipeViewModel's graph. See docs/claude/gotchas.md #21.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindRecipeImporter(importer: DefaultRecipeImporter): RecipeImporter
 }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDaoTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDaoTest.kt
@@ -9,8 +9,11 @@ import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
 import com.tenmilelabs.chefai.core.data.local.room.UserEntity
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
+import com.tenmilelabs.chefai.core.data.local.util.SyncState
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -150,5 +153,77 @@ class RecipeDaoTest {
         val recipeWithDetails = database.recipeDao().getRecipeWithDetails(recipe1.uuid)
         assertEquals(null, loadedRecipe)
         assertEquals(null, recipeWithDetails)
+    }
+
+    @Test
+    fun softDelete_removesRecipeFromObserveRecipesWithDetails() = runTest {
+        // GIVEN - two recipes exist
+        database.recipeDao().upsertRecipe(recipe1)
+        database.recipeDao().upsertRecipe(recipe2)
+
+        // WHEN - recipe1 is soft-deleted
+        database.recipeDao().softDelete(recipe1.uuid, System.currentTimeMillis())
+
+        // THEN - only recipe2 remains in the details stream
+        val recipes = database.recipeDao().observeRecipesWithDetails().first()
+        assertEquals(1, recipes.size)
+        assertEquals(recipe2.uuid, recipes.first().recipe.uuid)
+    }
+
+    @Test
+    fun softDelete_causesObserveRecipeWithDetailsToEmitNull() = runTest {
+        // GIVEN - a recipe exists
+        database.recipeDao().upsertRecipe(recipe1)
+
+        // WHEN - it is soft-deleted
+        database.recipeDao().softDelete(recipe1.uuid, System.currentTimeMillis())
+
+        // THEN - the single-recipe details stream now emits null, as if it doesn't exist
+        val details = database.recipeDao().observeRecipeWithDetails(recipe1.uuid).first()
+        assertNull(details)
+    }
+
+    @Test
+    fun softDelete_getRecipeByIdStillReturnsTheTombstone() = runTest {
+        // GIVEN - a recipe exists
+        database.recipeDao().upsertRecipe(recipe1)
+
+        // WHEN - it is soft-deleted
+        val deletedAt = System.currentTimeMillis()
+        database.recipeDao().softDelete(recipe1.uuid, deletedAt)
+
+        // THEN - getRecipeById (used by sync as an existence check) still returns the row,
+        // marked DELETED — sync must never treat a tombstone as "not found".
+        val entity = database.recipeDao().getRecipeById(recipe1.uuid)
+        assertNotNull(entity)
+        assertEquals(deletedAt, entity?.deletedAt)
+        assertEquals(SyncState.DELETED, entity?.syncState)
+    }
+
+    @Test
+    fun softDelete_recipeStillAppearsInGetAllDirty() = runTest {
+        // GIVEN - a recipe exists
+        database.recipeDao().upsertRecipe(recipe1)
+
+        // WHEN - it is soft-deleted
+        database.recipeDao().softDelete(recipe1.uuid, System.currentTimeMillis())
+
+        // THEN - it still appears in getAllDirty, which is how the delete gets pushed to the backend
+        val dirty = database.recipeDao().getAllDirty()
+        assertTrue(dirty.any { it.uuid == recipe1.uuid && it.syncState == SyncState.DELETED })
+    }
+
+    @Test
+    fun softDelete_decrementsCountRecipesForUser() = runTest {
+        // GIVEN - two recipes for the same user
+        database.recipeDao().upsertRecipe(recipe1)
+        database.recipeDao().upsertRecipe(recipe2)
+        assertEquals(2, database.recipeDao().countRecipesForUser(testUser.uuid))
+
+        // WHEN - one is soft-deleted
+        database.recipeDao().softDelete(recipe1.uuid, System.currentTimeMillis())
+
+        // THEN - the count drops by one
+        assertEquals(1, database.recipeDao().countRecipesForUser(testUser.uuid))
     }
 }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreenTest.kt
@@ -1,0 +1,163 @@
+package com.tenmilelabs.chefai.recipes.ui.details
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.preview.RecipeData
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Compose UI tests for the delete button and confirmation dialog added to
+ * [RecipeDetailsContent]. Exercises the stateless composable directly with plain parameters —
+ * no Hilt, no ViewModel, no Activity — covering the conditional rendering and click wiring that
+ * the ViewModel-level tests in [RecipeDetailsViewModelTest] can't reach.
+ */
+class RecipeDetailsScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+    }
+
+    @Test
+    fun deleteButton_hidden_whenOnDeleteClickIsNull() {
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(recipe = RecipeData.recipe, onDeleteClick = null)
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DeleteRecipeButton").assertDoesNotExist()
+    }
+
+    @Test
+    fun deleteButton_shown_andInvokesCallback_whenProvided() {
+        var clicked = false
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(
+                    recipe = RecipeData.recipe,
+                    onDeleteClick = { clicked = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DeleteRecipeButton").assertIsDisplayed().performClick()
+
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun deleteButton_disabled_doesNotInvokeCallback_whenIsDeleting() {
+        var clicked = false
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(
+                    recipe = RecipeData.recipe,
+                    onDeleteClick = { clicked = true },
+                    isDeleting = true,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("DeleteRecipeButton")
+            .assertIsNotEnabled()
+            .performClick()
+
+        assertFalse(clicked)
+    }
+
+    @Test
+    fun confirmationDialog_notShown_byDefault() {
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(
+                    recipe = RecipeData.recipe,
+                    onDeleteClick = {},
+                    showDeleteConfirmation = false,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.delete_recipe_confirmation_title))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun confirmationDialog_shown_whenFlagTrue() {
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(
+                    recipe = RecipeData.recipe,
+                    onDeleteClick = {},
+                    showDeleteConfirmation = true,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.delete_recipe_confirmation_title))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.delete_recipe_confirmation_message))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun confirmationDialog_confirm_invokesOnConfirmDelete() {
+        var confirmed = false
+        var dismissed = false
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(
+                    recipe = RecipeData.recipe,
+                    onDeleteClick = {},
+                    showDeleteConfirmation = true,
+                    onConfirmDelete = { confirmed = true },
+                    onDismissDeleteDialog = { dismissed = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.delete_recipe_button)).performClick()
+
+        assertTrue(confirmed)
+        assertFalse(dismissed)
+    }
+
+    @Test
+    fun confirmationDialog_cancel_invokesOnDismissDeleteDialog() {
+        var confirmed = false
+        var dismissed = false
+        composeTestRule.setContent {
+            ChefAITheme {
+                RecipeDetailsContent(
+                    recipe = RecipeData.recipe,
+                    onDeleteClick = {},
+                    showDeleteConfirmation = true,
+                    onConfirmDelete = { confirmed = true },
+                    onDismissDeleteDialog = { dismissed = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.cancel_button)).performClick()
+
+        assertTrue(dismissed)
+        assertFalse(confirmed)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 @Dao
 interface RecipeDao {
 
-    @Query("SELECT * FROM recipes WHERE creatorId = :creatorId")
+    @Query("SELECT * FROM recipes WHERE creatorId = :creatorId AND deletedAt IS NULL")
     fun observeAllRecipesForUser(creatorId: UUID): Flow<List<RecipeEntity>>
 
     @Query("""
@@ -46,39 +46,39 @@ interface RecipeDao {
     fun observeRecipeById(uuid: UUID): Flow<RecipeEntity?>
 
     @Transaction
-    @Query("SELECT * FROM recipes WHERE uuid = :uuid")
+    @Query("SELECT * FROM recipes WHERE uuid = :uuid AND deletedAt IS NULL")
     suspend fun getRecipeWithDetails(uuid: UUID): RecipeWithDetails?
 
     @Transaction
-    @Query("SELECT * FROM recipes WHERE uuid = :uuid")
+    @Query("SELECT * FROM recipes WHERE uuid = :uuid AND deletedAt IS NULL")
     fun observeRecipeWithDetails(uuid: UUID): Flow<RecipeWithDetails?>
 
     @Transaction
-    @Query("SELECT * FROM recipes")
+    @Query("SELECT * FROM recipes WHERE deletedAt IS NULL")
     fun observeRecipesWithDetails(): Flow<List<RecipeWithDetails>>
 
     @Transaction
-    @Query("SELECT * FROM recipes WHERE creatorId = :creatorId")
+    @Query("SELECT * FROM recipes WHERE creatorId = :creatorId AND deletedAt IS NULL")
     fun observeRecipesWithDetailsForUser(creatorId: UUID): Flow<List<RecipeWithDetails>>
 
     @Transaction
-    @Query("SELECT * FROM recipes WHERE privacy = 'PUBLIC'")
+    @Query("SELECT * FROM recipes WHERE privacy = 'PUBLIC' AND deletedAt IS NULL")
     fun observePublicRecipesWithDetails(): Flow<List<RecipeWithDetails>>
 
     @Transaction
-    @Query("SELECT * FROM recipes WHERE uuid = :uuid")
+    @Query("SELECT * FROM recipes WHERE uuid = :uuid AND deletedAt IS NULL")
     suspend fun getRecipeWithTags(uuid: UUID): RecipeWithTags?
 
     @Transaction
-    @Query("SELECT * FROM recipes")
+    @Query("SELECT * FROM recipes WHERE deletedAt IS NULL")
     fun observeRecipesWithTags(): Flow<List<RecipeWithTags>>
 
     @Transaction
-    @Query("SELECT * FROM recipes WHERE uuid = :uuid")
+    @Query("SELECT * FROM recipes WHERE uuid = :uuid AND deletedAt IS NULL")
     suspend fun getRecipeWithLabels(uuid: UUID): RecipeWithLabels?
 
     @Transaction
-    @Query("SELECT * FROM recipes")
+    @Query("SELECT * FROM recipes WHERE deletedAt IS NULL")
     fun observeRecipesWithLabels(): Flow<List<RecipeWithLabels>>
 
     @Query("DELETE FROM recipes WHERE uuid = :uuid")
@@ -116,7 +116,7 @@ interface RecipeDao {
     @Query("SELECT uuid FROM recipes WHERE creatorId = :creatorId")
     suspend fun getRecipeIdsForUser(creatorId: UUID): List<UUID>
 
-    @Query("SELECT COUNT(*) FROM recipes WHERE creatorId = :creatorId")
+    @Query("SELECT COUNT(*) FROM recipes WHERE creatorId = :creatorId AND deletedAt IS NULL")
     suspend fun countRecipesForUser(creatorId: UUID): Int
 
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -188,6 +188,7 @@ fun ChefAINavGraph(
                 onEditClick = { recipeId ->
                     navActions.navigateToEditRecipe(recipeId)
                 },
+                onNavigateBack = { navController.popBackStack() },
             )
         }
         composable(

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/components/DeleteConfirmationDialog.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/components/DeleteConfirmationDialog.kt
@@ -1,0 +1,34 @@
+package com.tenmilelabs.chefai.recipes.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.tenmilelabs.chefai.R
+
+@Composable
+fun DeleteConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.delete_recipe_confirmation_title)) },
+        text = { Text(stringResource(R.string.delete_recipe_confirmation_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    stringResource(R.string.delete_recipe_button),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel_button))
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
@@ -12,16 +12,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -43,6 +46,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,6 +66,7 @@ import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
 import com.tenmilelabs.chefai.core.util.EmptyContent
 import com.tenmilelabs.chefai.core.util.LoadingContent
 import com.tenmilelabs.chefai.core.util.MathUtils
+import com.tenmilelabs.chefai.recipes.ui.components.DeleteConfirmationDialog
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -71,8 +76,25 @@ fun RecipeDetailsScreen(
     viewModel: RecipeDetailsViewModel = hiltViewModel(),
     snackbarHostState: SnackbarHostState,
     onEditClick: ((java.util.UUID) -> Unit)? = null,
+    onNavigateBack: (() -> Unit)? = null,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val recipeDeletedText = stringResource(R.string.recipe_deleted)
+    LaunchedEffect(viewModel, snackbarHostState, onNavigateBack, recipeDeletedText) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                RecipeDetailsEffect.RecipeDeleted -> {
+                    snackbarHostState.showSnackbar(
+                        message = recipeDeletedText,
+                        duration = SnackbarDuration.Short,
+                    )
+                    onNavigateBack?.invoke()
+                }
+            }
+        }
+    }
+
     if (uiState.isLoading) {
         LoadingContent()
     } else {
@@ -84,6 +106,11 @@ fun RecipeDetailsScreen(
                 },
                 isBookmarked = uiState.isBookmarked,
                 onToggleBookmark = viewModel::toggleBookmark,
+                onDeleteClick = onNavigateBack?.let { { viewModel.onDeleteClick() } },
+                showDeleteConfirmation = uiState.showDeleteConfirmation,
+                onConfirmDelete = viewModel::confirmDelete,
+                onDismissDeleteDialog = viewModel::dismissDeleteDialog,
+                isDeleting = uiState.isDeleting,
             )
         } else {
             EmptyContent(
@@ -115,7 +142,19 @@ fun RecipeDetailsContent(
     onEditClick: (() -> Unit)? = null,
     isBookmarked: Boolean = false,
     onToggleBookmark: () -> Unit = {},
+    onDeleteClick: (() -> Unit)? = null,
+    showDeleteConfirmation: Boolean = false,
+    onConfirmDelete: () -> Unit = {},
+    onDismissDeleteDialog: () -> Unit = {},
+    isDeleting: Boolean = false,
 ) {
+    if (showDeleteConfirmation) {
+        DeleteConfirmationDialog(
+            onConfirm = onConfirmDelete,
+            onDismiss = onDismissDeleteDialog,
+        )
+    }
+
     val tabTitles = listOf(stringResource(R.string.ingredients), stringResource(R.string.steps))
     val pagerState = rememberPagerState { tabTitles.size }
     val coroutineScope = rememberCoroutineScope()
@@ -147,6 +186,26 @@ fun RecipeDetailsContent(
                         ),
                         tint = if (isBookmarked) Color(0xFFFFD700) else MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+                if (onDeleteClick != null) {
+                    IconButton(
+                        onClick = onDeleteClick,
+                        enabled = !isDeleting,
+                        modifier = Modifier.testTag("DeleteRecipeButton"),
+                    ) {
+                        if (isDeleting) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = stringResource(R.string.delete_recipe_button),
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
                 }
             }
 
@@ -314,5 +373,17 @@ fun RecipeDetailsFullScreenPreview() {
 fun RecipeDetailsBookmarkedPreview() {
     ChefAITheme {
         RecipeDetailsContent(recipe = RecipeData.recipe, isBookmarked = true)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RecipeDetailsDeleteConfirmationPreview() {
+    ChefAITheme {
+        RecipeDetailsContent(
+            recipe = RecipeData.recipe,
+            onDeleteClick = {},
+            showDeleteConfirmation = true,
+        )
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModel.kt
@@ -14,6 +14,7 @@ import com.tenmilelabs.chefai.core.util.WhileUiSubscribed
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,8 +23,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -32,12 +35,24 @@ data class RecipesDetailsUiState(
     val isLoading: Boolean = false,
     val isBookmarked: Boolean = false,
     val userMessage: Int? = null,
+    val showDeleteConfirmation: Boolean = false,
+    val isDeleting: Boolean = false,
+)
+
+/** One-shot side effects emitted by [RecipeDetailsViewModel], consumed by the UI. */
+sealed interface RecipeDetailsEffect {
+    data object RecipeDeleted : RecipeDetailsEffect
+}
+
+private data class DeleteUiState(
+    val showConfirmation: Boolean = false,
+    val isDeleting: Boolean = false,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class RecipeDetailsViewModel @Inject constructor(
-    recipesRepository: RecipesRepository,
+    private val recipesRepository: RecipesRepository,
     private val collectionsRepository: CollectionsRepository,
     private val sessionManager: SessionManager,
     savedStateHandle: SavedStateHandle,
@@ -47,6 +62,20 @@ class RecipeDetailsViewModel @Inject constructor(
 
     private val _isLoading = MutableStateFlow(false)
     private val _userMessage: MutableStateFlow<Int?> = MutableStateFlow(null)
+    private val _deleteUi = MutableStateFlow(DeleteUiState())
+
+    /**
+     * Set right before the soft-delete write, ahead of the repository call completing. Once true,
+     * a null emission from [_recipeAsync] is our own delete taking effect (Room's `deletedAt IS
+     * NULL` filter dropping the row), not a load failure — the combine below reads this to avoid
+     * flashing the "recipe not found" error while [RecipeDetailsEffect.RecipeDeleted] navigates
+     * the screen away.
+     */
+    private val _isDeleted = MutableStateFlow(false)
+
+    private val _effects = Channel<RecipeDetailsEffect>(Channel.BUFFERED)
+    val effects: Flow<RecipeDetailsEffect> = _effects.receiveAsFlow()
+
     private val _recipeAsync: Flow<Async<Recipe>> = recipesRepository.getRecipeStream(recipeUuid)
         .map {
             if (it != null) {
@@ -68,15 +97,19 @@ class RecipeDetailsViewModel @Inject constructor(
         }
 
     val uiState: StateFlow<RecipesDetailsUiState> = combine(
-        _isLoading, _recipeAsync, _userMessage, _isBookmarked
-    ) { isLoading, recipeAsync, userMessage, isBookmarked ->
+        _isLoading, _recipeAsync, _userMessage, _isBookmarked, _deleteUi
+    ) { isLoading, recipeAsync, userMessage, isBookmarked, deleteUi ->
         when (recipeAsync) {
             Async.Loading -> {
                 RecipesDetailsUiState(isLoading = true)
             }
 
             is Async.Error -> {
-                RecipesDetailsUiState(userMessage = recipeAsync.errorMessage)
+                if (_isDeleted.value) {
+                    RecipesDetailsUiState(isLoading = true, isDeleting = deleteUi.isDeleting)
+                } else {
+                    RecipesDetailsUiState(userMessage = recipeAsync.errorMessage)
+                }
             }
 
             is Async.Success -> {
@@ -84,6 +117,9 @@ class RecipeDetailsViewModel @Inject constructor(
                     recipe = recipeAsync.data,
                     isLoading = isLoading,
                     isBookmarked = isBookmarked,
+                    userMessage = userMessage,
+                    showDeleteConfirmation = deleteUi.showConfirmation,
+                    isDeleting = deleteUi.isDeleting,
                 )
             }
         }
@@ -105,6 +141,29 @@ class RecipeDetailsViewModel @Inject constructor(
                 collectionsRepository.removeBookmark(userId, recipeUuid)
             } else {
                 collectionsRepository.addBookmark(userId, recipeUuid)
+            }
+        }
+    }
+
+    fun onDeleteClick() {
+        _deleteUi.value = _deleteUi.value.copy(showConfirmation = true)
+    }
+
+    fun dismissDeleteDialog() {
+        _deleteUi.value = _deleteUi.value.copy(showConfirmation = false)
+    }
+
+    fun confirmDelete() {
+        _isDeleted.value = true
+        _deleteUi.value = DeleteUiState(showConfirmation = false, isDeleting = true)
+        viewModelScope.launch {
+            try {
+                recipesRepository.softDeleteRecipe(recipeUuid)
+                _effects.send(RecipeDetailsEffect.RecipeDeleted)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to delete recipe")
+                _deleteUi.value = DeleteUiState(isDeleting = false)
+                _userMessage.value = R.string.delete_recipe_error
             }
         }
     }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt
@@ -60,7 +60,7 @@ import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
 import com.tenmilelabs.chefai.core.util.LoadingContent
 import com.tenmilelabs.chefai.recipes.domain.model.EditorMode
-import com.tenmilelabs.chefai.recipes.ui.editor.components.DeleteConfirmationDialog
+import com.tenmilelabs.chefai.recipes.ui.components.DeleteConfirmationDialog
 import com.tenmilelabs.chefai.recipes.ui.editor.components.UnsavedChangesDialog
 import com.tenmilelabs.chefai.recipes.ui.editor.components.AutocompleteInput
 import com.tenmilelabs.chefai.recipes.ui.editor.components.ImageUploadContent

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/components/EditorDialogs.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/components/EditorDialogs.kt
@@ -32,28 +32,3 @@ fun UnsavedChangesDialog(
         },
     )
 }
-
-@Composable
-fun DeleteConfirmationDialog(
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.delete_recipe_confirmation_title)) },
-        text = { Text(stringResource(R.string.delete_recipe_confirmation_message)) },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(
-                    stringResource(R.string.delete_recipe_button),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel_button))
-            }
-        },
-    )
-}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,8 @@
     <string name="delete_recipe_button">Delete</string>
     <string name="delete_recipe_confirmation_title">Delete Recipe</string>
     <string name="delete_recipe_confirmation_message">Are you sure you want to delete this recipe? This action cannot be undone.</string>
+    <string name="recipe_deleted">Recipe deleted</string>
+    <string name="delete_recipe_error">Couldn\'t delete recipe</string>
     <string name="cancel_button">Cancel</string>
     <string name="edit_button">Edit</string>
 

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
@@ -97,7 +97,7 @@ class FakeRecipeDao : RecipeDao {
     }
 
     override fun observeAllRecipesForUser(creatorId: UUID): Flow<List<RecipeEntity>> {
-        return trigger.map { recipes.values.filter { it.creatorId == creatorId } }
+        return trigger.map { recipes.values.filter { it.creatorId == creatorId && it.deletedAt == null } }
     }
 
     override fun observeIngredientsForRecipe(recipeId: UUID): Flow<List<RecipeIngredient>> {
@@ -127,34 +127,42 @@ class FakeRecipeDao : RecipeDao {
     override fun observeRecipeById(uuid: UUID): Flow<RecipeEntity?> = trigger.map { recipes[uuid] }
 
     override suspend fun getRecipeWithDetails(uuid: UUID): RecipeWithDetails? {
-        return recipes[uuid]?.let { assembleRecipeWithDetails(it) }
+        return recipes[uuid]?.takeIf { it.deletedAt == null }?.let { assembleRecipeWithDetails(it) }
     }
 
     override fun observeRecipeWithDetails(uuid: UUID): Flow<RecipeWithDetails?> {
-        return trigger.map { recipes[uuid]?.let { assembleRecipeWithDetails(it) } }
+        return trigger.map { recipes[uuid]?.takeIf { it.deletedAt == null }?.let { assembleRecipeWithDetails(it) } }
     }
 
     override fun observeRecipesWithDetails(): Flow<List<RecipeWithDetails>> {
-        return trigger.map { recipes.values.map { assembleRecipeWithDetails(it) } }
+        return trigger.map { recipes.values.filter { it.deletedAt == null }.map { assembleRecipeWithDetails(it) } }
     }
 
     override fun observeRecipesWithDetailsForUser(creatorId: UUID): Flow<List<RecipeWithDetails>> {
-        return trigger.map { recipes.values.filter { it.creatorId == creatorId }.map { assembleRecipeWithDetails(it) } }
+        return trigger.map {
+            recipes.values
+                .filter { it.creatorId == creatorId && it.deletedAt == null }
+                .map { assembleRecipeWithDetails(it) }
+        }
     }
 
     override fun observePublicRecipesWithDetails(): Flow<List<RecipeWithDetails>> {
-        return trigger.map { recipes.values.filter { it.privacy == RecipePrivacy.PUBLIC }.map { assembleRecipeWithDetails(it) } }
+        return trigger.map {
+            recipes.values
+                .filter { it.privacy == RecipePrivacy.PUBLIC && it.deletedAt == null }
+                .map { assembleRecipeWithDetails(it) }
+        }
     }
 
     override suspend fun getRecipeWithTags(uuid: UUID): RecipeWithTags? {
-        val recipe = recipes[uuid] ?: return null
+        val recipe = recipes[uuid]?.takeIf { it.deletedAt == null } ?: return null
         val tagIds = recipeTags.filter { it.recipeId == uuid }.map { it.tagId }
         return RecipeWithTags(recipe, tags.values.filter { it.uuid in tagIds })
     }
 
     override fun observeRecipesWithTags(): Flow<List<RecipeWithTags>> {
         return trigger.map {
-            recipes.values.map { recipe ->
+            recipes.values.filter { it.deletedAt == null }.map { recipe ->
                 val tagIds = recipeTags.filter { it.recipeId == recipe.uuid }.map { it.tagId }
                 RecipeWithTags(recipe, tags.values.filter { it.uuid in tagIds })
             }
@@ -162,14 +170,14 @@ class FakeRecipeDao : RecipeDao {
     }
 
     override suspend fun getRecipeWithLabels(uuid: UUID): RecipeWithLabels? {
-        val recipe = recipes[uuid] ?: return null
+        val recipe = recipes[uuid]?.takeIf { it.deletedAt == null } ?: return null
         val labelIds = recipeLabels.filter { it.recipeId == uuid }.map { it.labelId }
         return RecipeWithLabels(recipe, labels.values.filter { it.uuid in labelIds })
     }
 
     override fun observeRecipesWithLabels(): Flow<List<RecipeWithLabels>> {
         return trigger.map {
-            recipes.values.map { recipe ->
+            recipes.values.filter { it.deletedAt == null }.map { recipe ->
                 val labelIds = recipeLabels.filter { it.recipeId == recipe.uuid }.map { it.labelId }
                 RecipeWithLabels(recipe, labels.values.filter { it.uuid in labelIds })
             }
@@ -261,6 +269,6 @@ class FakeRecipeDao : RecipeDao {
     }
 
     override suspend fun countRecipesForUser(creatorId: UUID): Int {
-        return recipes.values.count { it.creatorId == creatorId }
+        return recipes.values.count { it.creatorId == creatorId && it.deletedAt == null }
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
@@ -73,6 +73,7 @@ class DefaultRecipeRepositoryTest {
     private lateinit var recipeLabelDao: FakeRecipeLabelCrossRefDao
     private lateinit var remoteDataSource: FakeApiService
     private lateinit var sessionManager: SessionManager
+    private lateinit var syncManager: FakeSyncManager
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var testScope: TestScope
 
@@ -133,6 +134,7 @@ class DefaultRecipeRepositoryTest {
         recipeTagDao = FakeRecipeTagCrossRefDao()
         recipeLabelDao = FakeRecipeLabelCrossRefDao()
         remoteDataSource = FakeApiService()
+        syncManager = FakeSyncManager()
 
         recipeRepository =
             DefaultRecipeRepository(
@@ -146,7 +148,7 @@ class DefaultRecipeRepositoryTest {
                 recipeLabelDao,
                 remoteDataSource,
                 sessionManager,
-                FakeSyncManager()
+                syncManager
             )
 
         // Seed the fake DAO with our test data.
@@ -440,5 +442,40 @@ class DefaultRecipeRepositoryTest {
         // And: It appears in getAllDirty (DELETED state)
         val dirtyRecipes = recipeDao.getAllDirty()
         assertThat(dirtyRecipes.any { it.uuid == recipeId1 && it.syncState == SyncState.DELETED }).isTrue()
+    }
+
+    @Test
+    fun `softDeleteRecipe() hides the recipe from getRecipesPreviewStream`() = runTest {
+        // Given: 3 recipes are visible
+        assertThat(recipeRepository.getRecipesPreviewStream().first()).hasSize(3)
+
+        // When: recipe1 is soft-deleted
+        recipeRepository.softDeleteRecipe(recipeId1)
+
+        // Then: only the other 2 remain in the preview stream
+        val previews = recipeRepository.getRecipesPreviewStream().first()
+        assertThat(previews).hasSize(2)
+        assertThat(previews.find { it.uuid == recipeId1 }).isNull()
+    }
+
+    @Test
+    fun `softDeleteRecipe() causes getRecipeStream to emit null`() = runTest {
+        // Given: the recipe loads normally
+        assertThat(recipeRepository.getRecipeStream(recipeId1).first()).isNotNull()
+
+        // When: it is soft-deleted
+        recipeRepository.softDeleteRecipe(recipeId1)
+
+        // Then: the detail stream now emits null, as if the recipe doesn't exist
+        assertThat(recipeRepository.getRecipeStream(recipeId1).first()).isNull()
+    }
+
+    @Test
+    fun `softDeleteRecipe() requests a mutation sync`() = runTest {
+        assertThat(syncManager.mutationSyncCount).isEqualTo(0)
+
+        recipeRepository.softDeleteRecipe(recipeId1)
+
+        assertThat(syncManager.mutationSyncCount).isEqualTo(1)
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipesRepository.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipesRepository.kt
@@ -32,6 +32,13 @@ class FakeRecipesRepository : RecipesRepository {
         private set
     var lastSoftDeletedId: UUID? = null
         private set
+    private var shouldReturnErrorForSoftDelete = false
+    private var exceptionForSoftDelete: Exception? = null
+
+    fun setShouldReturnErrorForSoftDelete(value: Boolean, exception: Exception? = null) {
+        shouldReturnErrorForSoftDelete = value
+        this.exceptionForSoftDelete = exception ?: Exception("Test repository error for softDeleteRecipe")
+    }
 
     fun setRecipesToEmit(recipes: List<Recipe>) {
         recipesListFlow.tryEmit(recipes)
@@ -147,8 +154,14 @@ class FakeRecipesRepository : RecipesRepository {
     }
 
     override suspend fun softDeleteRecipe(recipeId: UUID) {
+        if (shouldReturnErrorForSoftDelete) {
+            throw (exceptionForSoftDelete ?: Exception("Configured repository error"))
+        }
         lastSoftDeletedId = recipeId
         storedRecipes.remove(recipeId)
+        // Mirror what Room does after the delete-filter change: the detail stream for this
+        // recipe now emits null, as if the row no longer exists.
+        getFlowForRecipe(recipeId).tryEmit(null)
     }
 
     override fun getRecipePreviewsByIds(ids: List<UUID>): Flow<List<RecipePreview>> {

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.tenmilelabs.chefai.recipes.ui.details
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.collections.data.repository.FakeCollectionsRepository
@@ -199,6 +200,129 @@ class RecipeDetailsViewModelTest {
             assertThat(awaitItem().isBookmarked).isFalse()
 
             cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onDeleteClick - shows the confirmation dialog`() = runTest {
+        initializeViewModel()
+
+        viewModel.uiState.test {
+            assertThat(awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            assertThat(awaitItem().showDeleteConfirmation).isFalse()
+
+            viewModel.onDeleteClick()
+            assertThat(awaitItem().showDeleteConfirmation).isTrue()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `dismissDeleteDialog - hides the dialog without deleting`() = runTest {
+        initializeViewModel()
+
+        viewModel.uiState.test {
+            assertThat(awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            awaitItem() // initial success state
+            viewModel.onDeleteClick()
+            assertThat(awaitItem().showDeleteConfirmation).isTrue()
+
+            viewModel.dismissDeleteDialog()
+            assertThat(awaitItem().showDeleteConfirmation).isFalse()
+
+            cancelAndConsumeRemainingEvents()
+        }
+        assertThat(recipesRepository.lastSoftDeletedId).isNull()
+    }
+
+    @Test
+    fun `confirmDelete - success - calls repository and emits RecipeDeleted`() = runTest {
+        initializeViewModel()
+
+        turbineScope {
+            val states = viewModel.uiState.testIn(backgroundScope)
+            val effects = viewModel.effects.testIn(backgroundScope)
+
+            assertThat(states.awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            assertThat(states.awaitItem().recipe).isEqualTo(recipe1)
+
+            viewModel.confirmDelete()
+
+            val deletingState = states.awaitItem()
+            assertThat(deletingState.isDeleting).isTrue()
+            assertThat(deletingState.showDeleteConfirmation).isFalse()
+
+            // The recipe stream emits null once the delete lands (T1's filter); the T4 guard
+            // replaces that with a neutral loading state instead of the "not found" error.
+            val guardedState = states.awaitItem()
+            assertThat(guardedState.recipe).isNull()
+            assertThat(guardedState.userMessage).isNotEqualTo(R.string.loading_recipe_details_error)
+
+            assertThat(effects.awaitItem()).isEqualTo(RecipeDetailsEffect.RecipeDeleted)
+        }
+
+        assertThat(recipesRepository.lastSoftDeletedId).isEqualTo(recipeId1)
+    }
+
+    @Test
+    fun `confirmDelete - failure - no effect emitted, isDeleting cleared, error message shown`() = runTest {
+        recipesRepository.setShouldReturnErrorForSoftDelete(true)
+        initializeViewModel()
+
+        turbineScope {
+            val states = viewModel.uiState.testIn(backgroundScope)
+            val effects = viewModel.effects.testIn(backgroundScope)
+
+            assertThat(states.awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            assertThat(states.awaitItem().recipe).isEqualTo(recipe1)
+
+            viewModel.confirmDelete()
+
+            // _deleteUi and _userMessage are separate StateFlows, both cleared in the catch
+            // block via two sequential assignments — that can surface as either one combined
+            // emission or two, so drain until both land rather than assuming an exact count.
+            var failedState = states.awaitItem()
+            while (failedState.isDeleting || failedState.userMessage != R.string.delete_recipe_error) {
+                failedState = states.awaitItem()
+            }
+            assertThat(failedState.recipe).isEqualTo(recipe1) // recipe still shown, delete failed
+
+            effects.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `confirmDelete - recipe stream emitting null afterward does not surface the load error`() = runTest {
+        initializeViewModel()
+
+        turbineScope {
+            val states = viewModel.uiState.testIn(backgroundScope)
+            val effects = viewModel.effects.testIn(backgroundScope)
+
+            assertThat(states.awaitItem().isLoading).isTrue()
+            recipesRepository.emitRecipe(recipeId1, recipe1)
+            assertThat(states.awaitItem().recipe).isEqualTo(recipe1)
+
+            viewModel.confirmDelete() // FakeRecipesRepository emits null on this recipe's flow
+
+            // Every state observed from here on must never carry the generic load-failure message —
+            // this is the T4 race: getRecipeStream(recipeUuid) emitting null because *we* deleted it
+            // must not be confused with a genuine load failure. Drain until the null emission has
+            // actually landed (recipe == null), not just until isDeleting flips (that happens
+            // synchronously, before the race this test targets even occurs).
+            var sawNullRecipe = false
+            while (!sawNullRecipe) {
+                val state = states.awaitItem()
+                assertThat(state.userMessage).isNotEqualTo(R.string.loading_recipe_details_error)
+                sawNullRecipe = state.recipe == null
+            }
+
+            assertThat(effects.awaitItem()).isEqualTo(RecipeDetailsEffect.RecipeDeleted)
         }
     }
 }

--- a/docs/prompts/recipe-delete-plan.md
+++ b/docs/prompts/recipe-delete-plan.md
@@ -1,0 +1,348 @@
+# Recipe Delete — Implementation Plan
+
+**Branch**: `claude/recipe-delete-feature-02fac1`
+**Goal**: Users can delete a recipe they created or imported, via a button on the recipe details screen.
+**Author**: plan drafted 2026-08-12
+
+---
+
+## Context: what already exists
+
+Most of the delete machinery is already in the codebase. Read this before writing code.
+
+| Piece | Location | Status |
+|---|---|---|
+| `RecipesRepository.softDeleteRecipe(UUID)` | `recipes/domain/repository/RecipesRepository.kt:28` | Exists |
+| `DefaultRecipeRepository.softDeleteRecipe` — sets `deletedAt`, requests sync | `recipes/data/repository/DefaultRecipeRepository.kt:267` | Exists |
+| `RecipeDao.softDelete(uuid, deletedAt)` — sets `deletedAt`, `syncState='DELETED'` | `core/data/local/room/dao/RecipeDao.kt:108` | Exists |
+| `DeleteConfirmationDialog` composable | `recipes/ui/editor/components/EditorDialogs.kt:37` | Exists |
+| Strings: `delete_recipe_button`, `delete_recipe_confirmation_title`, `delete_recipe_confirmation_message` | `res/values/strings.xml:130-132` | Exists |
+| Delete flow in the **editor** screen (action → reducer → VM → effect → pop) | `recipes/ui/editor/*` | Exists |
+| Sync push of `DELETED` rows (`getAllDirty()`), tombstone kept after accept | `core/data/sync/SyncOrchestrator.kt:101,193` | Exists |
+| Sync pull applies remote deletes | `SyncOrchestrator.applyPulledRecipe` (`:315`) | Exists |
+
+### The gap
+
+**No `RecipeDao` read query filters `deletedAt IS NULL`.** Verified by
+`grep -rn "deletedAt IS NULL" app/src/main/java/` — only `MealPlanDao` and `BookmarkedRecipeDao`
+do it. Consequence: the editor's existing delete marks the row deleted, pops back, and the recipe is
+**still visible** in the Recipes list and details screen. Fixing this is the core of the work; the
+details-screen button is the smaller half.
+
+### Design decisions (already made — don't re-litigate)
+
+- **Soft delete, not hard delete.** Required by the sync protocol ([ADR-006](../adrs/adr-006-sync-protocol.md)):
+  the tombstone row is what gets pushed so the backend learns about the delete. `deleteRecipe()`
+  (hard) stays on the interface but is not what the UI calls.
+- **Confirm dialog, not undo-snackbar.** Matches the editor flow and the existing
+  "This action cannot be undone" copy. Undo is out of scope.
+- **Details screen only.** No swipe-to-delete on the list, no multi-select. Out of scope.
+- **No delete from the meal-plan recipe detail route.** Gate it the same way `onEditClick` is
+  gated — pass the callback only from `RECIPE_DETAILS`, not `MEAL_PLAN_RECIPE_DETAIL`.
+- **`DeleteConfirmationDialog` moves to a shared location.** It currently lives in
+  `recipes/ui/editor/components/EditorDialogs.kt` and is used only by the editor. Since the details
+  screen now needs it too, it moves to `recipes/ui/components/DeleteConfirmationDialog.kt` (new file,
+  sibling to `editor/` and `urlimport/` within the `recipes` feature package — not `core/ui/`, per
+  [ADR-005](../adrs/adr-0005-feature-based-package-structure.md): stay in the feature package until a
+  second *feature* needs it, not just a second screen). `UnsavedChangesDialog` stays put — it's
+  editor-only. This is T2 below, and both editor and details screens update their imports.
+- **Filed as a follow-up, not fixed here**: [#128](https://github.com/jmuci/ChefAI/issues/128) —
+  `Recipe.toRoomEntity()` hardcodes `deletedAt = null`, so `updateRecipe()` on a tombstone would
+  resurrect it. Unreachable through the UI after T1 (a deleted recipe can no longer be opened for
+  editing), but worth tracking.
+
+---
+
+## Tasks
+
+Each task is independently reviewable. T1–T3 are the data layer, T4–T6 the UI, T7–T9 tests and
+cleanup. Do them in order — T4 depends on T1 for correct behavior.
+
+---
+
+### T1 — Filter soft-deleted recipes out of UI-facing DAO reads
+
+**File**: `app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt`
+
+Add a `deletedAt IS NULL` predicate to the queries that feed the UI:
+
+- `observeAllRecipesForUser` (`:22`)
+- `getRecipeWithDetails` (`:49`)
+- `observeRecipeWithDetails` (`:53`)
+- `observeRecipesWithDetails` (`:57`)
+- `observeRecipesWithDetailsForUser` (`:61`)
+- `observePublicRecipesWithDetails` (`:65`)
+- `getRecipeWithTags` (`:69`), `observeRecipesWithTags` (`:73`)
+- `getRecipeWithLabels` (`:77`), `observeRecipesWithLabels` (`:81`)
+- `countRecipesForUser` (`:119`)
+
+Example: `@Query("SELECT * FROM recipes WHERE uuid = :uuid AND deletedAt IS NULL")`
+
+**Do NOT filter these — filtering them breaks sync:**
+
+| Query | Why it must still see tombstones |
+|---|---|
+| `getRecipeById` (`:42`) | `SyncOrchestrator.applyPulledRecipe:312` and `DefaultHomeRecipeSidecarRepository:54` use it as an existence check. Filtering makes a deleted recipe look "new" and it gets re-inserted. |
+| `getDirty` / `getAllDirty` (`:99,:102`) | `getAllDirty` is exactly how the delete reaches the backend. |
+| `getRecipeIdsForUser` (`:116`) | Account upgrade must reassign tombstones too. |
+| `reassignCreatorAndMarkPending`, `updateSyncState`, `softDelete`, all `DELETE FROM` | Writes. |
+
+`observeIngredientsForRecipe` (`:25`) needs no change — it is already scoped to one recipe id, and
+the caller (`getRecipeStream`) returns null once the recipe row is filtered out.
+
+**Notes**
+- Query-only change → **no Room schema version bump and no migration.** The schema hash covers
+  entities, not queries.
+- This automatically fixes downstream surfaces: bookmarks and meal-plan days resolve previews
+  through `getRecipePreviewsByIds` → `getRecipesPreviewStream()`, so a deleted recipe drops out of
+  the Collections tab and out of meal plan days with no extra work.
+
+**Done when**: file compiles, `./gradlew :app:assembleDebug` passes.
+
+---
+
+### T2 — Mirror the filter in `FakeRecipeDao`
+
+**File**: `app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt`
+
+The JVM fake backs most repository/VM tests. Apply the same `deletedAt == null` filter to exactly the
+same set of read methods listed in T1, and leave the sync-facing ones (`getRecipeById`, `getDirty`,
+`getAllDirty`, `getRecipeIdsForUser`) unfiltered. If the fake and the real DAO disagree, tests will
+pass while the app is broken.
+
+**Done when**: `./gradlew :app:testDebugUnitTest` still passes (T3 adds the new coverage).
+
+---
+
+### T3 — DAO tests for the filter
+
+**Files**:
+- `app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDaoTest.kt` (in-memory Room)
+- optionally a small JVM test alongside `FakeRecipeDraftDaoTest.kt` for the fake
+
+Given/When/Then cases:
+1. `softDelete` on a recipe → `observeRecipesWithDetails()` no longer emits it.
+2. `softDelete` → `observeRecipeWithDetails(uuid)` emits `null`.
+3. `softDelete` → `getRecipeById(uuid)` **still returns the row** with `deletedAt != null` and
+   `syncState == DELETED` (guards the sync path against a future over-eager filter).
+4. `softDelete` → `getAllDirty()` **still contains** the recipe (guards push).
+5. `countRecipesForUser` drops by one after a soft delete.
+
+**Done when**: new tests pass. The androidTest suite needs a device/emulator; if none is available,
+say so and make sure cases 3–5 are covered by JVM tests against `FakeRecipeDao` instead.
+
+---
+
+### T4 — Delete action + one-shot navigation effect in `RecipeDetailsViewModel`
+
+**File**: `app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModel.kt`
+
+Add to `RecipesDetailsUiState`:
+```kotlin
+val showDeleteConfirmation: Boolean = false,
+val isDeleting: Boolean = false,
+```
+
+Add a one-shot effect channel (mirror `RecipeEditorViewModel`'s `_effects` — same pattern, don't
+invent a new one):
+```kotlin
+sealed interface RecipeDetailsEffect {
+    data object RecipeDeleted : RecipeDetailsEffect
+}
+```
+exposed as `val effects: Flow<RecipeDetailsEffect>` from a `Channel(Channel.BUFFERED)` via
+`receiveAsFlow()`.
+
+Add three functions:
+- `fun onDeleteClick()` → sets `showDeleteConfirmation = true`
+- `fun dismissDeleteDialog()` → sets it false
+- `fun confirmDelete()` → `viewModelScope.launch { ... }`: set `isDeleting = true`,
+  `showDeleteConfirmation = false`, call `recipesRepository.softDeleteRecipe(recipeUuid)`, send
+  `RecipeDeleted`. On failure, log with Timber, clear `isDeleting`, set
+  `_userMessage` to a new `delete_recipe_error` string.
+
+**The race to handle — don't skip this.** After T1, `getRecipeStream(recipeUuid)` emits `null` the
+moment the delete lands, which the existing `_recipeAsync` mapping turns into
+`Async.Error(R.string.loading_recipe_details_error)`. Without a guard the user sees a "couldn't load
+recipe" snackbar and the not-found empty state flash before the pop. Fix: track a
+`_isDeleting`/`_isDeleted` `MutableStateFlow` and, in the `combine`, suppress the error branch (keep
+the last-known recipe rendered, or show a plain loading state) while it is true. Verify this
+visually, not just in tests.
+
+`recipesRepository` is currently an unnamed constructor param (not a `private val`) — promote it to
+`private val` so `confirmDelete` can use it.
+
+**Done when**: compiles; T8 covers it with tests.
+
+---
+
+### T5 — Delete button + confirmation dialog on the details screen
+
+**Files**:
+- `app/src/main/java/com/tenmilelabs/chefai/recipes/ui/components/DeleteConfirmationDialog.kt` (new)
+- `app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/components/EditorDialogs.kt` (remove `DeleteConfirmationDialog`, keep `UnsavedChangesDialog`)
+- `app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt` (update import)
+- `app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt`
+
+First, relocate `DeleteConfirmationDialog` per the design decision above: cut it out of
+`EditorDialogs.kt` into a new `recipes/ui/components/DeleteConfirmationDialog.kt`, fix the one import
+in `RecipeEditorScreen.kt`. Verify with
+`grep -rn "editor.components.DeleteConfirmationDialog" app/src/main/java/` — should return nothing
+after the move.
+
+`RecipeDetailsContent` stays stateless. Add parameters:
+```kotlin
+onDeleteClick: (() -> Unit)? = null,
+showDeleteConfirmation: Boolean = false,
+onConfirmDelete: () -> Unit = {},
+onDismissDeleteDialog: () -> Unit = {},
+isDeleting: Boolean = false,
+```
+
+Placement: an `IconButton` with `Icons.Default.Delete` (same icon the editor's delete button already
+uses — `material-icons-extended` isn't an actual dependency of `:app`, only declared unused in the
+version catalog, so `DeleteOutline` isn't available), tinted `MaterialTheme.colorScheme.error`, in the
+existing title `Row` **next to the bookmark button** (`:141`). Shown only when `onDeleteClick !=
+null`. Disabled while `isDeleting`, showing a small `CircularProgressIndicator` in its place (mirror
+`EditorActionBar`'s delete button). Needs a `contentDescription` — reuse `R.string.delete_recipe_button`.
+
+Render `DeleteConfirmationDialog(onConfirm = onConfirmDelete, onDismiss = onDismissDeleteDialog)`
+when `showDeleteConfirmation` is true. Import it from
+`com.tenmilelabs.chefai.recipes.ui.editor.components` — same feature package, zero-risk reuse. Do
+**not** move the file; if the cross-package import bothers a reviewer, relocating it to a shared
+`recipes/ui/components/` is a separate follow-up.
+
+In the stateful `RecipeDetailsScreen`, thread the new params from `uiState` and the VM, and add an
+`onNavigateBack: (() -> Unit)? = null` param (see T6) — **nullable**, mirroring `onEditClick`. Its
+presence is what gates the delete button (`onDeleteClick = onNavigateBack?.let { { viewModel.onDeleteClick() } }`),
+the same way `onEditClick`'s presence gates the edit FAB. `MEAL_PLAN_RECIPE_DETAIL` doesn't pass it,
+so it stays `null` there and the delete button never renders — no separate boolean flag needed.
+
+Add a `@Preview` with the dialog visible. Existing previews are light-only; follow the file's
+existing convention rather than adding dark variants here.
+
+**Done when**: previews render; button appears in the details screen.
+
+---
+
+### T6 — Nav wiring: pop back and confirm to the user
+
+**File**: `app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt`
+
+At the `AppDestinations.RECIPE_DETAILS` composable (`:184`), pass
+`onNavigateBack = { navController.popBackStack() }`. Leave the `MEAL_PLAN_RECIPE_DETAIL` composable
+(`:111`) alone — no delete there, same as it has no edit.
+
+In `RecipeDetailsScreen`, collect the effect with a plain `LaunchedEffect(Unit) { viewModel.effects.collect { ... } }`
+— match `RecipeEditorScreen:81` exactly, no `repeatOnLifecycle` (the existing editor screen doesn't
+use it either). On `RecipeDeleted`: `snackbarHostState.showSnackbar(recipeDeletedText, duration =
+SnackbarDuration.Short)` **then** `onNavigateBack?.invoke()` — sequential, matching how
+`RecipeEditorScreen:84-91` already sequences `ShowError` before `NavigateBack` in the same collector.
+`showSnackbar` suspends until the snackbar is dismissed or times out, so the pop happens a couple
+seconds after the delete completes, with the screen showing its neutral "deleting" state in the
+meantime (see T4's `_isDeleted` guard). Don't try to fire-and-forget the snackbar to pop instantly —
+the snackbar's coroutine would be a child of this screen's own `LaunchedEffect`, which gets cancelled
+the moment the screen leaves composition, so it would never actually show.
+
+**New strings** (`res/values/strings.xml`): `recipe_deleted`, `delete_recipe_error`
+("Couldn't delete recipe").
+
+**Done when**: manual run — open a recipe → Delete → confirm → back on the list, recipe gone,
+snackbar shown.
+
+---
+
+### T7 — Repository-level test: deleted recipe hidden but still pushable
+
+**File**: `app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt`
+
+1. `softDeleteRecipe(id)` → `getRecipesPreviewStream()` (Turbine) no longer contains the recipe.
+2. `softDeleteRecipe(id)` → `getRecipeStream(id)` emits `null`.
+3. `softDeleteRecipe(id)` → `syncManager.requestMutationSync()` was called (the existing fake/mock
+   in that test file already tracks this — check before adding a new one).
+
+---
+
+### T8 — ViewModel tests for delete
+
+**File**: `app/src/test/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsViewModelTest.kt`
+
+Extend `FakeRecipesRepository` (`recipes/data/repository/FakeRecipesRepository.kt:149`) if needed so
+`softDeleteRecipe` records the call and makes the recipe flow emit `null`.
+
+Cases:
+1. `onDeleteClick()` → `showDeleteConfirmation == true`.
+2. `dismissDeleteDialog()` → false, repository not called.
+3. `confirmDelete()` → repository `softDeleteRecipe(recipeUuid)` called once, and
+   `RecipeDetailsEffect.RecipeDeleted` emitted (Turbine on `effects`).
+4. `confirmDelete()` when the repository throws → no effect emitted, `isDeleting == false`,
+   `userMessage == R.string.delete_recipe_error`.
+5. **Regression for the T4 race**: after `confirmDelete()` and the recipe flow emitting `null`, the
+   state does **not** carry `R.string.loading_recipe_details_error`.
+
+---
+
+### T10 — Compose UI tests for the delete button and dialog
+
+**File**: `app/src/androidTest/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreenTest.kt` (new)
+
+The DAO/repository/ViewModel tests (T3, T7, T8) cover the data and state layers, but nothing exercises
+`RecipeDetailsContent`'s actual conditional rendering and click wiring — whether the delete button
+really is absent when `onDeleteClick == null`, whether it's really disabled while `isDeleting`,
+whether the dialog's buttons really call the right callbacks. Since `RecipeDetailsContent` is
+stateless (plain parameters, no ViewModel/Hilt), test it directly with `createComposeRule()` — no
+`createAndroidComposeRule<MainActivity>()`, no `@HiltAndroidTest` needed (that heavier pattern is for
+`AuthE2ETest`-style full-navigation tests, not a single composable). Reuse the `RecipeData.recipe`
+preview fixture already used by this file's own `@Preview`s.
+
+Added `Modifier.testTag("DeleteRecipeButton")` to the delete `IconButton` in
+`RecipeDetailsScreen.kt`, matching the plain-string `testTag` convention already used in
+`LoginScreen.kt`/`RegisterScreen.kt`/`AuthE2ETest.kt`. Necessary because the button's `Icon` (which
+carries the only other identifying signal, its `contentDescription`) is swapped for a
+`CircularProgressIndicator` while `isDeleting`, so content-description lookup can't find the button in
+that state — the tag is the only stable way to locate it regardless of which child is showing.
+
+Cases:
+1. `onDeleteClick == null` → button doesn't exist.
+2. `onDeleteClick` provided → button displayed, click invokes it.
+3. `isDeleting == true` → button disabled (`assertIsNotEnabled()`), click does **not** invoke the
+   callback (Compose's `clickable`/`IconButton` `enabled` gate blocks the click at the gesture level,
+   verified rather than assumed).
+4. `showDeleteConfirmation == false` → dialog title text doesn't exist.
+5. `showDeleteConfirmation == true` → dialog title and message both displayed.
+6. Tapping the dialog's "Delete" → `onConfirmDelete` fires, `onDismissDeleteDialog` doesn't.
+7. Tapping the dialog's "Cancel" → `onDismissDeleteDialog` fires, `onConfirmDelete` doesn't.
+
+Assertion library: plain JUnit (`junit.framework.TestCase.assertTrue`/`assertFalse`), matching
+`RecipeDaoTest.kt` — Truth is `testImplementation` only (JVM tests), not wired into
+`androidTestImplementation`.
+
+**Done when**: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.tenmilelabs.chefai.recipes.ui.details.RecipeDetailsScreenTest`
+passes on-device.
+
+---
+
+### T9 — Verify and document
+
+1. `./gradlew :app:testDebugUnitTest` — report pass/fail counts, fix anything red.
+2. `./gradlew :app:assembleDebug`.
+3. Manual E2E on emulator: create a recipe → open details → Delete → confirm → gone from the list;
+   reopen the app to confirm it stays gone; if signed in, confirm the delete pushes on next sync.
+4. Update `.claude/session-context.md` (recent changes, status row for recipe delete).
+5. Update the CLAUDE.md "Current Gaps" table if a row applies.
+
+---
+
+## Out of scope (call these out in the PR, don't build them)
+
+- Undo / trash / restore.
+- Swipe-to-delete or multi-select on the recipes list.
+- Deleting from the meal-plan recipe detail route.
+- Permission checks (can only the creator delete?) — today every local recipe is the user's.
+  Worth an issue once real user wiring lands.
+- **Pre-existing, do not fix here**: `Recipe.toRoomEntity()`
+  (`recipes/data/mapper/RoomDomainMap.kt:148`) hardcodes `deletedAt = null`, so an `updateRecipe()`
+  on a tombstone would resurrect it. Unreachable through the UI after T1 (deleted recipes can't be
+  opened), but it is a real latent bug — file an issue.
+- **Pre-existing**: `DefaultRecipeRepository.createRecipe` carries a `@Transaction` annotation that
+  is a no-op outside a DAO class.


### PR DESCRIPTION
## Summary
- Adds a delete button + confirmation dialog to the recipe details screen, soft-deleting via the existing `RecipesRepository.softDeleteRecipe()`
- **The core fix**: no `RecipeDao` read query filtered `deletedAt IS NULL` (unlike `MealPlanDao`/`BookmarkedRecipeDao`, which already did) — a "deleted" recipe stayed visible everywhere. Added the filter to 11 UI-facing queries, deliberately leaving sync-facing ones (`getRecipeById`, `getDirty`/`getAllDirty`, `getRecipeIdsForUser`) untouched so `SyncOrchestrator` still sees tombstones and pushes deletes correctly
- `RecipeDetailsViewModel` guards a real race: once the DAO filter lands, the recipe's own delete makes `getRecipeStream` emit `null`, which would otherwise flash a "recipe not found" error right before the screen pops
- Relocated `DeleteConfirmationDialog` out of the editor-only package into a shared `recipes/ui/components/` so both the editor and details screens use it
- Fixed a pre-existing dead `_userMessage` parameter in `RecipeDetailsViewModel`'s `combine()` that silently dropped any message set while a recipe was loaded — needed for the new delete-failure error to actually reach the UI
- Fixed a pre-existing androidTest Hilt DI gap (`TestRepositoryModule` missing `MealPlanNetworkDataSource`/`RecipeImporter` bindings, documented as gotcha #21) that was blocking `hiltJavaCompileDebugAndroidTest` for the whole module, not just new tests
- Filed #128 for a related but out-of-scope bug found along the way (`Recipe.toRoomEntity()` hardcodes `deletedAt = null`, so `updateRecipe()` on a tombstone would resurrect it) — not reachable through the UI after this change, tracked separately rather than fixed here

Full task breakdown and design rationale in [`docs/prompts/recipe-delete-plan.md`](docs/prompts/recipe-delete-plan.md).

## Test plan
- [x] `:app:testDebugUnitTest` — 387 tests, 0 failures
- [x] `:app:connectedDebugAndroidTest` (real emulator) — 20 tests, 0 failures, including 6 new `RecipeDaoTest` cases and 7 new `RecipeDetailsScreenTest` Compose UI tests
- [x] `:app:assembleDebug` — clean
- [x] Manual E2E on emulator: create recipe → open details → delete → confirm → snackbar → gone from list → force-stopped and relaunched the app to confirm the delete persisted to Room, not just in-memory UI state

🤖 Generated with [Claude Code](https://claude.com/claude-code)