### PR TITLE
Recipe import: rendered-DOM fallback for blocked sites + 2 scraper fixes

### DIFF
--- a/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/network/WebViewHtmlFetcherTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/network/WebViewHtmlFetcherTest.kt
@@ -1,0 +1,83 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.tenmilelabs.recipescraper.RecipeHtmlParser
+import com.tenmilelabs.recipescraper.model.ScrapeResult
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Exercises the off-screen WebView against `data:` URLs, so the polling, extraction and give-up
+ * paths are covered without touching the network or depending on any real site's markup.
+ */
+@RunWith(AndroidJUnit4::class)
+class WebViewHtmlFetcherTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val fetcher = WebViewHtmlFetcher(context)
+    private val parser = RecipeHtmlParser()
+
+    private fun dataUrl(html: String): String =
+        "data:text/html;charset=utf-8," + java.net.URLEncoder.encode(html, "UTF-8").replace("+", "%20")
+
+    @Test
+    fun returnsTheRenderedDomOnceItSatisfiesTheParser() = runTest {
+        val html = """
+            <html><head>
+            <script type="application/ld+json">
+            {"@type":"Recipe","name":"Rendered Recipe",
+             "recipeIngredient":["2 cups flour"],"recipeInstructions":["Mix."]}
+            </script>
+            </head><body><h1>Rendered Recipe</h1></body></html>
+        """.trimIndent()
+
+        val result = fetcher.fetchRenderedHtml(dataUrl(html), budget = 10.seconds) { snapshot ->
+            parser.parse(snapshot, "https://example.com/recipe") is ScrapeResult.Success
+        }
+
+        assertNotNull(result)
+        assertTrue("expected the rendered DOM, got: $result", result!!.contains("Rendered Recipe"))
+    }
+
+    @Test
+    fun picksUpMarkupThatOnlyExistsAfterThePagesScriptsRun() = runTest {
+        // The case a plain HTTP fetch cannot handle: the shell carries no recipe at all.
+        val html = """
+            <html><head><script>
+              document.addEventListener('DOMContentLoaded', function () {
+                var s = document.createElement('script');
+                s.type = 'application/ld+json';
+                s.textContent = JSON.stringify({
+                  '@type': 'Recipe', name: 'Late Recipe',
+                  recipeIngredient: ['1 cup sugar'], recipeInstructions: ['Stir.']
+                });
+                document.head.appendChild(s);
+              });
+            </script></head><body></body></html>
+        """.trimIndent()
+
+        val result = fetcher.fetchRenderedHtml(dataUrl(html), budget = 10.seconds) { snapshot ->
+            parser.parse(snapshot, "https://example.com/recipe") is ScrapeResult.Success
+        }
+
+        assertNotNull(result)
+        assertTrue("expected the injected markup, got: $result", result!!.contains("Late Recipe"))
+    }
+
+    @Test
+    fun returnsNullWhenTheBudgetRunsOutWithoutARecipe() = runTest {
+        val html = "<html><body><h1>Just a blog post</h1></body></html>"
+
+        val result = fetcher.fetchRenderedHtml(dataUrl(html), budget = 2.seconds) { snapshot ->
+            parser.parse(snapshot, "https://example.com/blog") is ScrapeResult.Success
+        }
+
+        assertNull(result)
+    }
+}

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
@@ -14,14 +14,23 @@ class FakeRecipeImporter : RecipeImporter {
     var result: RecipeImportResult = RecipeImportResult.InvalidUrl
     var lastImportedUrl: String? = null
         private set
+    var lastImportedHtml: String? = null
+        private set
 
     override suspend fun import(url: String): RecipeImportResult {
         lastImportedUrl = url
         return result
     }
 
+    override suspend fun importFromHtml(html: String, url: String): RecipeImportResult {
+        lastImportedUrl = url
+        lastImportedHtml = html
+        return result
+    }
+
     fun reset() {
         result = RecipeImportResult.InvalidUrl
         lastImportedUrl = null
+        lastImportedHtml = null
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
@@ -402,6 +402,16 @@ class SyncOrchestrator @Inject constructor(
         if (dto.deletedAt != null) {
             bookmarkedRecipeDao.softDelete(userId, recipeId, dto.deletedAt)
         } else {
+            // bookmarked_recipes.recipeId is a foreign key into recipes.uuid. A bookmark can
+            // reference a recipe this device hasn't (or no longer has) locally — a pull for a
+            // recipe from another user, or an out-of-order/partial sync — and upserting it
+            // unconditionally throws SQLiteConstraintException, aborting the whole pull
+            // transaction inside a single bad row. Skip it instead, mirroring how tag/label
+            // cross-refs are validated against their local catalog above.
+            if (recipeDao.getRecipeById(recipeId) == null) {
+                Timber.w("applyPulledBookmark: bookmark references unknown recipe %s, skipping", recipeId)
+                return
+            }
             bookmarkedRecipeDao.upsert(
                 BookmarkedRecipeEntity(
                     userId = userId,

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -17,7 +17,9 @@ import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
+import com.tenmilelabs.chefai.recipes.data.network.WebViewHtmlFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.Binds
 import dagger.Module
@@ -57,6 +59,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindRecipeImporter(importer: DefaultRecipeImporter): RecipeImporter
+
+    @Singleton
+    @Binds
+    abstract fun bindRenderedHtmlFetcher(fetcher: WebViewHtmlFetcher): RenderedHtmlFetcher
 }
 
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/AppDestinations.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.navigation.NavHostController
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.DRAFT_ID_ARG
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.IMPORT_URL_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.MEAL_PLAN_ID_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.PREFILL_URL_ARG
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs.RECIPE_ID_ARG
@@ -22,6 +23,7 @@ internal object ScreenBaseRoutes {
     const val CREATE_RECIPE = "create_recipe_screen"
     const val RECIPE_EDITOR = "recipe_editor_screen"
     const val IMPORT_RECIPE = "import_recipe_screen"
+    const val IMPORT_RECIPE_BROWSER = "import_recipe_browser_screen"
     const val SETTINGS = "settings_screen"
     const val LOGIN = "login_screen"
     const val REGISTER = "register_screen"
@@ -53,6 +55,12 @@ object AppDestinationArgs {
      * in the route, since the value itself is a URL containing reserved characters.
      */
     const val PREFILL_URL_ARG = "prefillUrl"
+
+    /**
+     * The URL the browser-import screen should load so the user can clear a site's bot check.
+     * URL-encoded in the route for the same reason as [PREFILL_URL_ARG].
+     */
+    const val IMPORT_URL_ARG = "importUrl"
 }
 
 /**
@@ -79,6 +87,10 @@ enum class AppDestinations(
     IMPORT_RECIPE(
         R.string.app_dest_title_import_recipe,
         "${ScreenBaseRoutes.IMPORT_RECIPE}?${PREFILL_URL_ARG}={${PREFILL_URL_ARG}}"
+    ),
+    IMPORT_RECIPE_BROWSER(
+        R.string.app_dest_title_import_recipe_browser,
+        "${ScreenBaseRoutes.IMPORT_RECIPE_BROWSER}/{$IMPORT_URL_ARG}"
     ),
     MEAL_PLAN_DETAIL(
         R.string.app_dest_title_meal_plan_detail,
@@ -125,9 +137,20 @@ class NavigationActions(private val navController: NavHostController) {
     }
 
     /**
+     * Opens the in-app browser on [url] so the user can clear a site's bot check, after both the
+     * HTTP fetch and the off-screen browser were refused.
+     */
+    fun navigateToBrowserImport(url: String) {
+        val encoded = URLEncoder.encode(url, "UTF-8")
+        navController.navigate("${ScreenBaseRoutes.IMPORT_RECIPE_BROWSER}/$encoded")
+    }
+
+    /**
      * Opens the editor in **create** mode against an already-persisted draft — the hand-off after a
      * recipe has been scraped from a URL. The import screen is popped so that backing out of the
-     * editor returns to the recipe list rather than to a stale URL field.
+     * editor returns to the recipe list rather than to a stale URL field. That also takes the
+     * browser-import screen with it when the draft came via the fallback, since it sits on top of
+     * the import screen.
      */
     fun navigateToEditorWithDraft(draftId: UUID) {
         navController.navigate("${ScreenBaseRoutes.RECIPE_EDITOR}?${DRAFT_ID_ARG}=$draftId") {

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/navigation/ChefAINavGraph.kt
@@ -50,6 +50,7 @@ import com.tenmilelabs.chefai.recipes.ui.RecipesScreen
 import com.tenmilelabs.chefai.recipes.ui.details.RecipeDetailsScreen
 import com.tenmilelabs.chefai.recipes.ui.editor.RecipeEditorScreen
 import com.tenmilelabs.chefai.recipes.ui.urlimport.ImportRecipeRoute
+import com.tenmilelabs.chefai.recipes.ui.urlimport.browser.BrowserImportRoute
 import timber.log.Timber
 
 @Composable
@@ -222,6 +223,17 @@ fun ChefAINavGraph(
             ),
         ) {
             ImportRecipeRoute(
+                onNavigateToEditorWithDraft = { draftId -> navActions.navigateToEditorWithDraft(draftId) },
+                onNavigateToBrowserImport = { url -> navActions.navigateToBrowserImport(url) },
+                onNavigateToManualEditor = { navActions.navigateToCreateRecipe() },
+                onNavigateBack = { navController.popBackStack() },
+            )
+        }
+        composable(
+            route = AppDestinations.IMPORT_RECIPE_BROWSER.route,
+            arguments = listOf(navArgument(AppDestinationArgs.IMPORT_URL_ARG) { type = NavType.StringType }),
+        ) {
+            BrowserImportRoute(
                 onNavigateToEditorWithDraft = { draftId -> navActions.navigateToEditorWithDraft(draftId) },
                 onNavigateToManualEditor = { navActions.navigateToCreateRecipe() },
                 onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/HtmlCharset.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/HtmlCharset.kt
@@ -1,0 +1,48 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import java.nio.charset.Charset
+
+/** How far into the document to look for a `<meta>` charset declaration. */
+private const val SNIFF_LIMIT_BYTES = 4096
+
+/**
+ * Decodes the first [length] bytes of [bytes] as HTML text.
+ *
+ * Recipe sites are not uniformly UTF-8 — plenty of older European ones still publish
+ * ISO-8859-1 — and decoding those as UTF-8 turns every accented character into a replacement
+ * glyph. The encoding is resolved the way browsers do it:
+ *
+ * 1. the `charset` parameter of the `Content-Type` response header, when the server sent one;
+ * 2. otherwise a `<meta>` declaration sniffed from the head of the document;
+ * 3. otherwise UTF-8, which is right far more often than not.
+ *
+ * Never throws: a charset name the JVM doesn't know falls through to the next step.
+ */
+internal fun decodeHtml(bytes: ByteArray, length: Int, headerCharset: Charset?): String {
+    val charset = headerCharset ?: sniffMetaCharset(bytes, length) ?: Charsets.UTF_8
+    return String(bytes, 0, length, charset)
+}
+
+/**
+ * Reads a `<meta>` charset declaration out of the head of the document.
+ *
+ * Decodes the sniffing window as ISO-8859-1 first, which maps every byte to exactly one character
+ * and so can never fail — the declaration itself is always ASCII, so this reads it correctly
+ * whatever the real encoding turns out to be.
+ */
+private fun sniffMetaCharset(bytes: ByteArray, length: Int): Charset? {
+    val head = String(bytes, 0, minOf(length, SNIFF_LIMIT_BYTES), Charsets.ISO_8859_1)
+    val name = META_CHARSET.find(head)?.groupValues?.get(1)
+        ?: META_HTTP_EQUIV_CHARSET.find(head)?.groupValues?.get(1)
+        ?: return null
+    return runCatching { Charset.forName(name.trim().trim('"', '\'')) }.getOrNull()
+}
+
+/** HTML5 form: `<meta charset="iso-8859-1">`. */
+private val META_CHARSET = Regex("""<meta[^>]+charset\s*=\s*["']?([\w-]+)""", RegexOption.IGNORE_CASE)
+
+/** Legacy form: `<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">`. */
+private val META_HTTP_EQUIV_CHARSET = Regex(
+    """<meta[^>]+http-equiv\s*=\s*["']?content-type["']?[^>]+content\s*=\s*["'][^"']*charset\s*=\s*([\w-]+)""",
+    RegexOption.IGNORE_CASE,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/ScraperWebView.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/ScraperWebView.kt
@@ -1,0 +1,94 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import android.annotation.SuppressLint
+import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+/** Skips absurd snapshots rather than marshalling them across the JNI bridge and parsing them. */
+private const val MAX_SNAPSHOT_CHARS = 4 * 1024 * 1024
+
+/** JS whose result is the whole rendered document, serialised as a JSON string literal. */
+private const val OUTER_HTML_SCRIPT = "document.documentElement.outerHTML"
+
+/**
+ * Applies the settings shared by both recipe-scraping WebViews — the off-screen one in
+ * [WebViewHtmlFetcher] and the visible one on the browser-import screen.
+ *
+ * Scraping means running a third party's JavaScript in our process, so the point of this is to give
+ * that script as little to reach for as possible: no local file or content-provider access, no
+ * cross-origin escape from a `file://` document, no geolocation, no autoplay. There is deliberately
+ * **no `addJavascriptInterface`** anywhere in this feature — it would hand the page a bridge into
+ * app code, and nothing here needs one.
+ *
+ * JavaScript itself stays on: it is the entire reason this path exists.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+internal fun WebView.applyScraperHardening() {
+    settings.apply {
+        javaScriptEnabled = true
+        domStorageEnabled = true
+        allowFileAccess = false
+        allowContentAccess = false
+        @Suppress("DEPRECATION")
+        allowFileAccessFromFileURLs = false
+        @Suppress("DEPRECATION")
+        allowUniversalAccessFromFileURLs = false
+        setGeolocationEnabled(false)
+        mediaPlaybackRequiresUserGesture = true
+        javaScriptCanOpenWindowsAutomatically = false
+        // The stock user agent, minus the tokens that only an *embedded* WebView sends — never the
+        // desktop string the Ktor client uses. Pairing a Windows Chrome UA with Android's TLS and
+        // JS fingerprint would be exactly the mismatch bot detection looks for; this keeps every
+        // real token (device, Android version, actual Chrome build) and removes only "; wv" and
+        // "Version/X.X ", which exist for no reason other than to tell a server "this request came
+        // from inside someone's app, not their browser tab". Interactive challenges like
+        // Cloudflare's are documented to treat an embedded context as one they "do not handle
+        // well" and can re-issue the check in a loop rather than reject it outright — which reads
+        // to the user as the page endlessly reloading.
+        userAgentString = userAgentString
+            .replace("; wv", "")
+            .replace(Regex("Version/[\\d.]+ "), "")
+    }
+
+    // Third-party cookie acceptance is opt-in per WebView instance and defaults to off; without it,
+    // a cookie set by an iframe'd challenge widget on a different subdomain than the top-level page
+    // is silently dropped, so the check clears in the UI but the clearance never sticks.
+    CookieManager.getInstance().apply {
+        setAcceptCookie(true)
+        setAcceptThirdPartyCookies(this@applyScraperHardening, true)
+    }
+}
+
+/**
+ * A [WebViewClient] that keeps the load inside the web: `http(s)` navigations (including the
+ * redirects a bot check bounces through) proceed, anything else — `intent://`, `market://`,
+ * `tel:` — is refused rather than handed to another app.
+ */
+internal open class ScraperWebViewClient : WebViewClient() {
+
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val scheme = request?.url?.scheme?.lowercase()
+        val isWeb = scheme == "http" || scheme == "https"
+        if (!isWeb) Timber.d("Blocked non-web navigation during scrape: %s", request?.url)
+        return !isWeb
+    }
+}
+
+/**
+ * Reads the rendered document out of the WebView, or `null` if it isn't available yet.
+ *
+ * `evaluateJavascript` hands back a JSON-encoded value, so the result is a quoted string literal
+ * with the document's own quotes and newlines escaped; it is decoded rather than unescaped by hand.
+ */
+internal fun WebView.readRenderedHtml(onResult: (String?) -> Unit) {
+    evaluateJavascript(OUTER_HTML_SCRIPT) { encoded ->
+        val html = encoded
+            ?.takeIf { it.isNotBlank() && it != "null" && it.length <= MAX_SNAPSHOT_CHARS }
+            ?.let { runCatching { Json.decodeFromString<String>(it) }.getOrNull() }
+        onResult(html)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/WebViewHtmlFetcher.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/WebViewHtmlFetcher.kt
@@ -1,0 +1,83 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import android.content.Context
+import android.webkit.CookieManager
+import android.webkit.WebView
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/** How often the rendered DOM is re-read while waiting for a recipe to appear. */
+internal val SNAPSHOT_INTERVAL: Duration = 500.milliseconds
+
+/**
+ * Loads pages in an off-screen [WebView] — a real browser engine, on the user's own connection.
+ *
+ * The WebView is never attached to a window; it still fetches, runs scripts and builds a DOM, which
+ * is all this needs. Cookies are left to the process-wide `CookieManager` on purpose: a clearance
+ * cookie earned on the visible browser screen carries over, so the next import of the same site
+ * usually resolves here without troubling the user again.
+ *
+ * A [WebView] must be created, driven and destroyed on the main thread, so everything below hops
+ * there regardless of the caller's dispatcher.
+ */
+@Singleton
+class WebViewHtmlFetcher @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : RenderedHtmlFetcher {
+
+    override suspend fun fetchRenderedHtml(
+        url: String,
+        budget: Duration,
+        accept: (String) -> Boolean,
+    ): String? = withContext(Dispatchers.Main) {
+        val webView = WebView(context).apply {
+            applyScraperHardening()
+            webViewClient = ScraperWebViewClient()
+        }
+
+        try {
+            withTimeoutOrNull(budget) {
+                webView.loadUrl(url)
+                // Polling from the moment the load starts, rather than waiting for onPageFinished,
+                // means a page whose recipe markup is in the initial HTML resolves in one tick
+                // instead of after every last tracker and image has settled.
+                var accepted: String? = null
+                while (accepted == null) {
+                    delay(SNAPSHOT_INTERVAL)
+                    val html = webView.awaitRenderedHtml()
+                    if (html != null && runCatching { accept(html) }.getOrDefault(false)) {
+                        accepted = html
+                    }
+                }
+                accepted
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Rendered fetch failed for %s", url)
+            null
+        } finally {
+            webView.stopLoading()
+            webView.destroy()
+            // Commits any clearance cookie earned this call to disk immediately, rather than
+            // waiting for whatever batches CookieManager would otherwise use.
+            CookieManager.getInstance().flush()
+        }
+    }
+}
+
+/** Suspending wrapper around [readRenderedHtml]'s callback. */
+private suspend fun WebView.awaitRenderedHtml(): String? = suspendCancellableCoroutine { continuation ->
+    readRenderedHtml { html ->
+        if (continuation.isActive) continuation.resume(html)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
@@ -5,8 +5,10 @@ import com.tenmilelabs.chefai.core.di.IoDispatcher
 import com.tenmilelabs.chefai.core.di.ScraperHttpClient
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraft
+import com.tenmilelabs.chefai.recipes.data.network.decodeHtml
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
 import com.tenmilelabs.recipescraper.RecipeHtmlParser
 import com.tenmilelabs.recipescraper.model.ScrapeResult
 import io.ktor.client.HttpClient
@@ -15,24 +17,49 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
-import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.charset
+import io.ktor.http.contentType
 import io.ktor.utils.io.readAvailable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
 import timber.log.Timber
+import java.nio.charset.Charset
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
 
 /** Caps how much of a fetched page is read into memory — well past any real recipe page. */
 private const val MAX_BODY_BYTES = 3 * 1024 * 1024
+
+/**
+ * How long the off-screen browser gets to produce a recipe before the import gives up on it.
+ *
+ * Long enough for a bot check that resolves itself plus a heavy page load, short enough that a URL
+ * which simply isn't a recipe doesn't leave the user watching a spinner. Tune from real use.
+ */
+private val RENDER_BUDGET = 8.seconds
+
+/**
+ * Statuses a bot manager returns to a client it doesn't like. Akamai and Cloudflare both answer
+ * 403; 401, 429 and 503 cover the rate-limit and "under attack mode" variants. A 404 is
+ * deliberately absent — that page really is missing, and a browser won't find it either.
+ */
+private val BOT_WALL_STATUSES = setOf(
+    HttpStatusCode.Unauthorized,
+    HttpStatusCode.Forbidden,
+    HttpStatusCode.TooManyRequests,
+    HttpStatusCode.ServiceUnavailable,
+)
 
 @Singleton
 class DefaultRecipeImporter @Inject constructor(
     @ScraperHttpClient private val httpClient: HttpClient,
     private val recipeHtmlParser: RecipeHtmlParser,
+    private val renderedHtmlFetcher: RenderedHtmlFetcher,
     private val metadataRepository: MetadataRepository,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : RecipeImporter {
@@ -40,42 +67,78 @@ class DefaultRecipeImporter @Inject constructor(
     override suspend fun import(url: String): RecipeImportResult = withContext(ioDispatcher) {
         val normalizedUrl = normalizeAndValidateUrl(url) ?: return@withContext RecipeImportResult.InvalidUrl
 
-        val html = fetchHtml(normalizedUrl).let { result ->
-            if (result is FetchOutcome.Failure) return@withContext result.error
-            (result as FetchOutcome.Html).body
+        val fetched = fetchHtml(normalizedUrl)
+        val httpResult = when (fetched) {
+            is FetchOutcome.Failure -> fetched.error
+            is FetchOutcome.Html -> importFromHtml(fetched.body, normalizedUrl)
         }
 
-        when (val scrapeResult = recipeHtmlParser.parse(html, normalizedUrl)) {
-            is ScrapeResult.Success -> {
-                val knownIngredients = metadataRepository.observeAllIngredients().first()
-                val knownTags = metadataRepository.observeAllTags().first()
-                val draft = scrapeResult.recipe.toRecipeDraft(
-                    recipeId = UuidV7Generator.newId(),
-                    knownIngredients = knownIngredients,
-                    knownTags = knownTags,
-                )
-                RecipeImportResult.Success(draft)
-            }
+        // A plain GET is enough for the large majority of recipe sites. Exactly two shapes of
+        // failure are worth a second attempt in a real browser engine:
+        //  - the site refused a non-browser client outright (a bot manager's 403);
+        //  - it served a shell whose recipe markup only exists once its own scripts have run.
+        // Anything else — a 404, a DNS failure, a timeout — would fail the same way in a browser,
+        // several seconds later, so it is returned as-is.
+        val refused = fetched is FetchOutcome.Failure && fetched.looksLikeBotWall
+        if (!refused && httpResult !is RecipeImportResult.NoRecipeFound) return@withContext httpResult
 
-            ScrapeResult.NoRecipeFound -> RecipeImportResult.NoRecipeFound
-            is ScrapeResult.ParseError -> RecipeImportResult.ParseError(scrapeResult.message)
+        Timber.i("HTTP import fell short for %s, retrying with a rendered fetch", normalizedUrl)
+        val rendered = renderedHtmlFetcher.fetchRenderedHtml(normalizedUrl, RENDER_BUDGET) { html ->
+            recipeHtmlParser.parse(html, normalizedUrl) is ScrapeResult.Success
+        }
+
+        when {
+            rendered != null -> importFromHtml(rendered, normalizedUrl)
+            // Out of automated options. Only a browser the user can interact with clears an
+            // interactive check — but a page that simply has no recipe on it stays that way, so
+            // there is nothing to send them to.
+            refused -> RecipeImportResult.NeedsBrowser(normalizedUrl)
+            else -> httpResult
         }
     }
 
+    override suspend fun importFromHtml(html: String, url: String): RecipeImportResult =
+        withContext(ioDispatcher) {
+            when (val scrapeResult = recipeHtmlParser.parse(html, url)) {
+                is ScrapeResult.Success -> {
+                    val knownIngredients = metadataRepository.observeAllIngredients().first()
+                    val knownTags = metadataRepository.observeAllTags().first()
+                    val draft = scrapeResult.recipe.toRecipeDraft(
+                        recipeId = UuidV7Generator.newId(),
+                        knownIngredients = knownIngredients,
+                        knownTags = knownTags,
+                    )
+                    RecipeImportResult.Success(draft)
+                }
+
+                ScrapeResult.NoRecipeFound -> RecipeImportResult.NoRecipeFound
+                is ScrapeResult.ParseError -> RecipeImportResult.ParseError(scrapeResult.message)
+            }
+        }
+
     private sealed interface FetchOutcome {
         data class Html(val body: String) : FetchOutcome
-        data class Failure(val error: RecipeImportResult.NetworkError) : FetchOutcome
+
+        /**
+         * @property looksLikeBotWall the server answered, and answered with a refusal rather than
+         *   a "no such page" — the signature of bot protection turning away a non-browser client.
+         */
+        data class Failure(
+            val error: RecipeImportResult.NetworkError,
+            val looksLikeBotWall: Boolean = false,
+        ) : FetchOutcome
     }
 
     private suspend fun fetchHtml(url: String): FetchOutcome = try {
         val response = httpClient.get(url)
-        val contentType = response.headers[HttpHeaders.ContentType].orEmpty()
-        if (!contentType.contains("text/html", ignoreCase = true) &&
-            !contentType.contains("application/xhtml+xml", ignoreCase = true)
+        val contentType = response.contentType()
+        val mimeType = contentType?.withoutParameters()?.toString().orEmpty()
+        if (!mimeType.equals("text/html", ignoreCase = true) &&
+            !mimeType.equals("application/xhtml+xml", ignoreCase = true)
         ) {
             FetchOutcome.Failure(RecipeImportResult.NetworkError("Not an HTML page"))
         } else {
-            FetchOutcome.Html(response.readBodyCapped())
+            FetchOutcome.Html(response.readBodyCapped(contentType?.charset()))
         }
     } catch (e: CancellationException) {
         throw e
@@ -84,14 +147,20 @@ class DefaultRecipeImporter @Inject constructor(
         FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Request timed out"))
     } catch (e: ResponseException) {
         Timber.w(e, "Recipe import received an error response")
-        FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Request failed"))
+        FetchOutcome.Failure(
+            error = RecipeImportResult.NetworkError(e.message ?: "Request failed"),
+            looksLikeBotWall = e.response.status in BOT_WALL_STATUSES,
+        )
     } catch (e: IOException) {
         Timber.w(e, "Recipe import network error")
         FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Network error"))
     }
 
-    /** Reads at most [MAX_BODY_BYTES] of the response body, protecting against a hostile/huge page. */
-    private suspend fun HttpResponse.readBodyCapped(): String {
+    /**
+     * Reads at most [MAX_BODY_BYTES] of the response body, protecting against a hostile/huge page,
+     * and decodes it using [responseCharset] when the server declared one — see [decodeHtml].
+     */
+    private suspend fun HttpResponse.readBodyCapped(responseCharset: Charset?): String {
         val channel = bodyAsChannel()
         val buffer = ByteArray(MAX_BODY_BYTES)
         var offset = 0
@@ -100,6 +169,6 @@ class DefaultRecipeImporter @Inject constructor(
             if (read == -1) break
             offset += read
         }
-        return buffer.decodeToString(0, offset)
+        return decodeHtml(buffer, offset, responseCharset)
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/model/RecipeImportResult.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/model/RecipeImportResult.kt
@@ -3,6 +3,14 @@ package com.tenmilelabs.chefai.recipes.domain.model
 /** The outcome of importing a recipe from a URL — explicit and sealed rather than thrown. */
 sealed interface RecipeImportResult {
     data class Success(val draft: RecipeDraft) : RecipeImportResult
+
+    /**
+     * Neither the HTTP fetch nor the off-screen browser could reach a recipe — the page is behind
+     * an interactive bot check that only a human can clear. [url] is the normalised URL to open in
+     * a browser the user can see.
+     */
+    data class NeedsBrowser(val url: String) : RecipeImportResult
+
     data object InvalidUrl : RecipeImportResult
     data object NoRecipeFound : RecipeImportResult
     data class NetworkError(val message: String) : RecipeImportResult

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RecipeImporter.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RecipeImporter.kt
@@ -4,5 +4,18 @@ import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
 
 /** Fetches a third-party recipe page and extracts a [RecipeImportResult.Success] draft from it. */
 interface RecipeImporter {
+
+    /**
+     * Fetches [url] and extracts a recipe from it, falling back to a browser engine for pages that
+     * refuse plain HTTP clients. Returns [RecipeImportResult.NeedsBrowser] when the page can only
+     * be reached by a browser the user can interact with.
+     */
     suspend fun import(url: String): RecipeImportResult
+
+    /**
+     * Extracts a recipe from HTML that has already been fetched — the hand-back from the visible
+     * browser fallback, which does its own loading. [url] is recorded on the draft as the source
+     * and is not fetched.
+     */
+    suspend fun importFromHtml(html: String, url: String): RecipeImportResult
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RenderedHtmlFetcher.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RenderedHtmlFetcher.kt
@@ -1,0 +1,23 @@
+package com.tenmilelabs.chefai.recipes.domain.repository
+
+import kotlin.time.Duration
+
+/**
+ * Loads a page in a browser engine and hands back its rendered DOM.
+ *
+ * The plain HTTP fetch in [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter] is
+ * the fast path and handles the large majority of recipe sites. This exists for the ones that
+ * refuse it — bot protection that scores TLS and JS fingerprints, or markup only assembled once
+ * the page's own scripts have run.
+ */
+interface RenderedHtmlFetcher {
+
+    /**
+     * Loads [url], polling the rendered DOM until [accept] returns `true` or [budget] elapses.
+     *
+     * @param accept called with each DOM snapshot; returning `true` stops the load and yields that
+     *   snapshot. Must be cheap and must not throw.
+     * @return the accepted HTML, or `null` if the budget ran out without one.
+     */
+    suspend fun fetchRenderedHtml(url: String, budget: Duration, accept: (String) -> Boolean): String?
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/SaveImportedDraft.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/SaveImportedDraft.kt
@@ -1,0 +1,24 @@
+package com.tenmilelabs.chefai.recipes.domain.usecase
+
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDraftDao
+import com.tenmilelabs.chefai.core.di.IoDispatcher
+import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraftEntity
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Persists a scraped [RecipeDraft] so the editor can pick it up by id after navigation.
+ *
+ * Shared by both import entry points — the URL screen and the browser fallback — which must hand
+ * off to the editor identically.
+ */
+class SaveImportedDraft @Inject constructor(
+    private val recipeDraftDao: RecipeDraftDao,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+    suspend operator fun invoke(draft: RecipeDraft) = withContext(ioDispatcher) {
+        recipeDraftDao.saveDraft(draft.toRecipeDraftEntity())
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeScreen.kt
@@ -37,6 +37,7 @@ import java.util.UUID
 @Composable
 fun ImportRecipeRoute(
     onNavigateToEditorWithDraft: (UUID) -> Unit,
+    onNavigateToBrowserImport: (String) -> Unit,
     onNavigateToManualEditor: () -> Unit,
     onNavigateBack: () -> Unit,
     viewModel: ImportRecipeViewModel = hiltViewModel(),
@@ -47,6 +48,7 @@ fun ImportRecipeRoute(
         viewModel.effects.collect { effect ->
             when (effect) {
                 is ImportEffect.NavigateToEditorWithDraft -> onNavigateToEditorWithDraft(effect.draftId)
+                is ImportEffect.NavigateToBrowserImport -> onNavigateToBrowserImport(effect.url)
                 ImportEffect.NavigateToManualEditor -> onNavigateToManualEditor()
                 ImportEffect.NavigateBack -> onNavigateBack()
             }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeState.kt
@@ -12,6 +12,10 @@ sealed interface ImportAction {
 
 sealed interface ImportEffect {
     data class NavigateToEditorWithDraft(val draftId: UUID) : ImportEffect
+
+    /** Opens the in-app browser so the user can clear the site's bot check. */
+    data class NavigateToBrowserImport(val url: String) : ImportEffect
+
     data object NavigateToManualEditor : ImportEffect
     data object NavigateBack : ImportEffect
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModel.kt
@@ -5,14 +5,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tenmilelabs.chefai.R
-import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDraftDao
-import com.tenmilelabs.chefai.core.di.IoDispatcher
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
-import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraftEntity
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.usecase.SaveImportedDraft
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,15 +18,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.net.URLDecoder
 import javax.inject.Inject
 
 @HiltViewModel
 class ImportRecipeViewModel @Inject constructor(
     private val recipeImporter: RecipeImporter,
-    private val recipeDraftDao: RecipeDraftDao,
-    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val saveImportedDraft: SaveImportedDraft,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -65,11 +60,16 @@ class ImportRecipeViewModel @Inject constructor(
 
             when (val result = recipeImporter.import(url)) {
                 is RecipeImportResult.Success -> {
-                    withContext(ioDispatcher) {
-                        recipeDraftDao.saveDraft(result.draft.toRecipeDraftEntity())
-                    }
+                    saveImportedDraft(result.draft)
                     _state.update { it.copy(isImporting = false) }
                     _effects.send(ImportEffect.NavigateToEditorWithDraft(result.draft.recipeId))
+                }
+
+                // The site refused every automated fetch — hand it to a browser the user can see
+                // and interact with, which is the only thing that gets past an interactive check.
+                is RecipeImportResult.NeedsBrowser -> {
+                    _state.update { it.copy(isImporting = false) }
+                    _effects.send(ImportEffect.NavigateToBrowserImport(result.url))
                 }
 
                 RecipeImportResult.InvalidUrl -> failWith(R.string.import_recipe_invalid_url)

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportScreen.kt
@@ -1,0 +1,250 @@
+package com.tenmilelabs.chefai.recipes.ui.urlimport.browser
+
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+import com.tenmilelabs.chefai.recipes.data.network.ScraperWebViewClient
+import com.tenmilelabs.chefai.recipes.data.network.applyScraperHardening
+import com.tenmilelabs.chefai.recipes.data.network.readRenderedHtml
+import kotlinx.coroutines.delay
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/** Matches the off-screen fetcher's cadence — cheap, and fast enough to feel instant. */
+private val SNAPSHOT_INTERVAL = 500.milliseconds
+
+/** After this, the hint switches from "loading" to "you may need to do something". */
+private val SETTLE_TIMEOUT = 3.seconds
+
+/** How long the user gets before the screen admits defeat and offers manual entry. */
+private val GIVE_UP_TIMEOUT = 60.seconds
+
+@Composable
+fun BrowserImportRoute(
+    onNavigateToEditorWithDraft: (UUID) -> Unit,
+    onNavigateToManualEditor: () -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: BrowserImportViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is BrowserImportEffect.NavigateToEditorWithDraft -> onNavigateToEditorWithDraft(effect.draftId)
+                BrowserImportEffect.NavigateToManualEditor -> onNavigateToManualEditor()
+                BrowserImportEffect.NavigateBack -> onNavigateBack()
+            }
+        }
+    }
+
+    BrowserImportScreen(state = state, onAction = viewModel::dispatch)
+}
+
+/**
+ * The last resort for a site that refuses automated fetches: show it to the user in a real browser.
+ *
+ * Nothing here tries to defeat the bot check — the user clears it themselves, exactly as they would
+ * in Chrome. The rendered DOM is polled throughout, so the moment the real page appears the recipe
+ * is picked up and the screen gets out of the way.
+ */
+@Composable
+fun BrowserImportScreen(
+    state: BrowserImportState,
+    onAction: (BrowserImportAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.testTag("BrowserImportScreen").fillMaxSize()) {
+        BrowserImportBanner(state = state, onAction = onAction)
+
+        if (state.errorRes == null) {
+            RecipePageWebView(
+                url = state.url,
+                isPolling = state.isPolling,
+                onAction = onAction,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BrowserImportBanner(
+    state: BrowserImportState,
+    onAction: (BrowserImportAction) -> Unit,
+) {
+    Surface(tonalElevation = 3.dp) {
+        Column(modifier = Modifier.fillMaxWidth().padding(dimensionResource(R.dimen.padding_medium))) {
+            // Deliberately not keyed on state.isExtracting: a parse attempt on a snapshot with no
+            // recipe on it (the common case, every 500ms while the check sits unsolved) resolves
+            // in milliseconds, and briefly swapping the hint text in and out reflows this banner
+            // between one and two lines several times a second — the "page keeps reloading" look.
+            // A real recipe extraction is only ever visible for that same instant before the whole
+            // screen navigates away, so there is nothing worth surfacing here either way.
+            val hintRes = when {
+                state.errorRes != null -> state.errorRes
+                state.phase == BrowserImportState.Phase.AWAITING_USER -> R.string.import_recipe_browser_hint
+                else -> R.string.import_recipe_browser_loading
+            }
+            Text(
+                text = stringResource(hintRes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (state.errorRes != null) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+            )
+
+            if (state.errorRes == null) {
+                Spacer(Modifier.height(dimensionResource(R.dimen.padding_small)))
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_small))) {
+                TextButton(onClick = { onAction(BrowserImportAction.Cancel) }) {
+                    Text(stringResource(R.string.import_recipe_browser_cancel))
+                }
+                if (state.errorRes != null) {
+                    TextButton(onClick = { onAction(BrowserImportAction.EnterManually) }) {
+                        Text(stringResource(R.string.import_recipe_enter_manually))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Hosts the WebView and drives the polling loop.
+ *
+ * The View is created once and kept across recompositions — recreating it would restart the load
+ * and throw away a bot check the user had already cleared.
+ */
+@Composable
+private fun RecipePageWebView(
+    url: String,
+    isPolling: Boolean,
+    onAction: (BrowserImportAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val webView = remember(context) {
+        WebView(context).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            applyScraperHardening()
+            webViewClient = ScraperWebViewClient()
+        }
+    }
+
+    LaunchedEffect(webView, url) {
+        if (url.isNotBlank()) webView.loadUrl(url)
+    }
+
+    DisposableEffect(webView) {
+        onDispose {
+            webView.stopLoading()
+            webView.destroy()
+            // Commits any clearance cookie the user just earned to disk, so the off-screen fetcher
+            // can pick it up on the next import instead of showing this screen again.
+            CookieManager.getInstance().flush()
+        }
+    }
+
+    val currentIsPolling by rememberUpdatedState(isPolling)
+    val currentOnAction by rememberUpdatedState(onAction)
+    LaunchedEffect(webView) {
+        var elapsed = 0.seconds
+        var settled = false
+        while (elapsed < GIVE_UP_TIMEOUT) {
+            delay(SNAPSHOT_INTERVAL)
+            elapsed += SNAPSHOT_INTERVAL
+            if (!settled && elapsed >= SETTLE_TIMEOUT) {
+                settled = true
+                currentOnAction(BrowserImportAction.SettleTimeoutElapsed)
+            }
+            if (currentIsPolling) {
+                webView.readRenderedHtml { html ->
+                    if (html != null) currentOnAction(BrowserImportAction.SnapshotCaptured(html))
+                }
+            }
+        }
+        currentOnAction(BrowserImportAction.GiveUp)
+    }
+
+    AndroidView(factory = { webView }, modifier = modifier.testTag("BrowserImportWebView"))
+}
+
+@Preview(name = "Loading — Light", showBackground = true)
+@Composable
+private fun BrowserImportLoadingLightPreview() {
+    ChefAITheme(darkTheme = false) {
+        BrowserImportScreen(
+            state = BrowserImportState(url = "https://example.com/recipe"),
+            onAction = {},
+        )
+    }
+}
+
+@Preview(name = "Awaiting user — Dark", showBackground = true)
+@Composable
+private fun BrowserImportAwaitingUserDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        BrowserImportScreen(
+            state = BrowserImportState(
+                url = "https://example.com/recipe",
+                phase = BrowserImportState.Phase.AWAITING_USER,
+            ),
+            onAction = {},
+        )
+    }
+}
+
+@Preview(name = "Gave up — Light", showBackground = true)
+@Composable
+private fun BrowserImportGaveUpLightPreview() {
+    ChefAITheme(darkTheme = false) {
+        BrowserImportScreen(
+            state = BrowserImportState(
+                url = "https://example.com/recipe",
+                errorRes = R.string.import_recipe_browser_gave_up,
+            ),
+            onAction = {},
+        )
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportState.kt
@@ -1,0 +1,52 @@
+package com.tenmilelabs.chefai.recipes.ui.urlimport.browser
+
+import androidx.annotation.StringRes
+import java.util.UUID
+
+sealed interface BrowserImportAction {
+    /** A snapshot of the rendered DOM, pushed up from the WebView's polling loop. */
+    data class SnapshotCaptured(val html: String) : BrowserImportAction
+
+    /** The page has been up long enough that the user is probably being asked to do something. */
+    data object SettleTimeoutElapsed : BrowserImportAction
+
+    /** Nothing readable ever appeared, after a generously long wait. */
+    data object GiveUp : BrowserImportAction
+
+    data object EnterManually : BrowserImportAction
+    data object Cancel : BrowserImportAction
+}
+
+data class BrowserImportState(
+    val url: String = "",
+    val phase: Phase = Phase.LOADING,
+    /**
+     * A snapshot is being parsed and mapped right now — a concurrency guard only, never surfaced
+     * in the UI. It's true for a few milliseconds on every failed poll (the common case, while the
+     * check sits unsolved), so displaying it would flicker the banner in and out several times a
+     * second rather than communicate anything real.
+     */
+    val isExtracting: Boolean = false,
+    @param:StringRes val errorRes: Int? = null,
+) {
+    /** True while the WebView should keep being polled for a recipe. */
+    val isPolling: Boolean = errorRes == null && !isExtracting
+
+    enum class Phase {
+        /** The page is loading and nothing has asked the user for anything yet. */
+        LOADING,
+
+        /**
+         * Long enough has passed that the page is probably showing a bot check. Detecting one
+         * outright would mean pattern-matching every vendor's markup and re-doing it whenever they
+         * change it; a timer says the same thing to the user and never goes stale.
+         */
+        AWAITING_USER,
+    }
+}
+
+sealed interface BrowserImportEffect {
+    data class NavigateToEditorWithDraft(val draftId: UUID) : BrowserImportEffect
+    data object NavigateToManualEditor : BrowserImportEffect
+    data object NavigateBack : BrowserImportEffect
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportViewModel.kt
@@ -1,0 +1,92 @@
+package com.tenmilelabs.chefai.recipes.ui.urlimport.browser
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.usecase.SaveImportedDraft
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.net.URLDecoder
+import javax.inject.Inject
+
+/**
+ * Drives the visible browser fallback: the screen owns the WebView and feeds DOM snapshots in here,
+ * where each is run through the ordinary import path until one yields a recipe.
+ *
+ * Snapshots are cheap to reject — the parser bails immediately on a page with no schema.org markup
+ * — so this deliberately does no "is the challenge done yet?" detection. It just keeps looking.
+ */
+@HiltViewModel
+class BrowserImportViewModel @Inject constructor(
+    private val recipeImporter: RecipeImporter,
+    private val saveImportedDraft: SaveImportedDraft,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val url: String = savedStateHandle.get<String>(AppDestinationArgs.IMPORT_URL_ARG)
+        ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrNull() }
+        .orEmpty()
+
+    private val _state = MutableStateFlow(BrowserImportState(url = url))
+    val state: StateFlow<BrowserImportState> = _state.asStateFlow()
+
+    private val _effects = Channel<BrowserImportEffect>(Channel.BUFFERED)
+    val effects: Flow<BrowserImportEffect> = _effects.receiveAsFlow()
+
+    fun dispatch(action: BrowserImportAction) {
+        when (action) {
+            is BrowserImportAction.SnapshotCaptured -> handleSnapshot(action.html)
+
+            BrowserImportAction.SettleTimeoutElapsed -> _state.update {
+                it.copy(phase = BrowserImportState.Phase.AWAITING_USER)
+            }
+
+            BrowserImportAction.GiveUp -> _state.update {
+                it.copy(errorRes = R.string.import_recipe_browser_gave_up)
+            }
+
+            BrowserImportAction.EnterManually -> viewModelScope.launch {
+                _effects.send(BrowserImportEffect.NavigateToManualEditor)
+            }
+
+            BrowserImportAction.Cancel -> viewModelScope.launch {
+                _effects.send(BrowserImportEffect.NavigateBack)
+            }
+        }
+    }
+
+    private fun handleSnapshot(html: String) {
+        // The polling loop can land another snapshot while the previous one is still being mapped;
+        // parsing them concurrently would race two drafts to the editor.
+        if (!_state.value.isPolling) return
+        _state.update { it.copy(isExtracting = true) }
+
+        viewModelScope.launch {
+            when (val result = recipeImporter.importFromHtml(html, url)) {
+                is RecipeImportResult.Success -> {
+                    saveImportedDraft(result.draft)
+                    _effects.send(BrowserImportEffect.NavigateToEditorWithDraft(result.draft.recipeId))
+                }
+
+                // Not there yet — the challenge is still up, or the page is mid-render. Keep
+                // polling rather than treating this as a failure.
+                else -> {
+                    Timber.d("Browser import snapshot had no recipe yet: %s", result)
+                    _state.update { it.copy(isExtracting = false) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="app_dest_title_register">Register</string>
     <string name="app_dest_title_recipe_editor">Recipe Editor</string>
     <string name="app_dest_title_import_recipe">Import Recipe</string>
+    <string name="app_dest_title_import_recipe_browser">Import Recipe</string>
     <string name="app_dest_title_settings">Settings</string>
     <string name="app_name">ChefAI</string>
     <string name="button_select_photo">Select Photo from Gallery</string>
@@ -181,5 +182,9 @@
     <string name="import_recipe_no_recipe_found">We couldn\'t find a recipe on that page</string>
     <string name="import_recipe_network_error">Couldn\'t reach that site — check your connection</string>
     <string name="import_recipe_parse_error">Something went wrong reading that page</string>
+    <string name="import_recipe_browser_loading">Opening the page…</string>
+    <string name="import_recipe_browser_hint">This site checks that you\'re human. Complete the check and the recipe will import itself.</string>
+    <string name="import_recipe_browser_gave_up">We still couldn\'t read a recipe from that page</string>
+    <string name="import_recipe_browser_cancel">Cancel</string>
 
 </resources>

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
@@ -29,6 +29,7 @@ import com.tenmilelabs.chefai.core.data.sync.network.FakeSyncNetworkDataSource
 import com.tenmilelabs.chefai.core.data.sync.network.dto.AcceptedEntityDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.ConflictEntityDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncErrorDto
+import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncBookmarkPullDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncCreatorDto
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPullResponse
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPushResponse
@@ -39,6 +40,7 @@ import com.tenmilelabs.chefai.auth.domain.SessionManager
 import com.tenmilelabs.chefai.core.testutil.createTestSessionManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -548,6 +550,65 @@ class SyncOrchestratorTest {
         assertThat(steps[0].instruction).isEqualTo("Step 1")
         assertThat(steps[0].syncState).isEqualTo(SyncState.SYNCED)
     }
+
+    @Test
+    fun `pull upserts a bookmark for a recipe that exists locally`() = runTest(testDispatcher) {
+        recipeDao.upsertRecipe(createDirtyRecipe(uuid = recipeId1, syncState = SyncState.SYNCED))
+        val userId = UuidV7Generator.newId()
+        syncNetworkDataSource.pullResponses.addLast(
+            SyncPullResponse(
+                recipes = emptyList(),
+                serverTimestamp = 5000L,
+                hasMore = false,
+                bookmarkedRecipes = listOf(
+                    SyncBookmarkPullDto(
+                        userId = userId.toString(),
+                        recipeId = recipeId1.toString(),
+                        updatedAt = 5000L,
+                        deletedAt = null,
+                    )
+                ),
+            )
+        )
+
+        syncOrchestrator.sync()
+
+        val bookmarked = bookmarkedRecipeDao.observeBookmarkedRecipeIds(userId).first()
+        assertThat(bookmarked).containsExactly(recipeId1)
+    }
+
+    @Test
+    fun `pull skips a bookmark referencing a recipe not known locally rather than failing the sync`() =
+        runTest(testDispatcher) {
+            // The real Room schema has a foreign key from bookmarked_recipes.recipeId to
+            // recipes.uuid — a bookmark for a recipe this device doesn't have (another user's
+            // recipe, or an out-of-order/partial pull) must not abort the whole pull transaction.
+            val userId = UuidV7Generator.newId()
+            val unknownRecipeId = UuidV7Generator.newId()
+            syncNetworkDataSource.pullResponses.addLast(
+                SyncPullResponse(
+                    recipes = emptyList(),
+                    serverTimestamp = 5000L,
+                    hasMore = false,
+                    bookmarkedRecipes = listOf(
+                        SyncBookmarkPullDto(
+                            userId = userId.toString(),
+                            recipeId = unknownRecipeId.toString(),
+                            updatedAt = 5000L,
+                            deletedAt = null,
+                        )
+                    ),
+                )
+            )
+
+            val result = syncOrchestrator.sync()
+
+            assertThat(bookmarkedRecipeDao.observeBookmarkedRecipeIds(userId).first()).isEmpty()
+            // The checkpoint still advances — one bad bookmark doesn't roll back everything else
+            // that arrived in the same page.
+            assertThat(syncMetadataDao.getLastSyncedAt(SyncOrchestrator.ENTITY_TYPE_RECIPES)).isEqualTo(5000L)
+            assertThat(result.pullResult.pages).isEqualTo(1)
+        }
 
     @Test
     fun `push filters out ingredient refs not known to server`() = runTest(testDispatcher) {

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/network/HtmlCharsetTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/network/HtmlCharsetTest.kt
@@ -1,0 +1,78 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.nio.charset.Charset
+
+class HtmlCharsetTest {
+
+    private fun decode(html: String, encodedAs: Charset, headerCharset: Charset? = null): String {
+        val bytes = html.toByteArray(encodedAs)
+        return decodeHtml(bytes, bytes.size, headerCharset)
+    }
+
+    @Test
+    fun `uses the charset from the response header`() {
+        val decoded = decode("<html><body>cocido madrileño</body></html>", Charsets.ISO_8859_1, Charsets.ISO_8859_1)
+
+        assertThat(decoded).contains("madrileño")
+    }
+
+    @Test
+    fun `header charset wins over a contradicting meta declaration`() {
+        val html = """<html><head><meta charset="utf-8"></head><body>garbanzos jamón</body></html>"""
+
+        val decoded = decode(html, Charsets.ISO_8859_1, headerCharset = Charsets.ISO_8859_1)
+
+        assertThat(decoded).contains("jamón")
+    }
+
+    @Test
+    fun `sniffs the html5 meta charset when the header omits one`() {
+        val html = """<html><head><meta charset="iso-8859-1"></head><body>puré de patatas</body></html>"""
+
+        val decoded = decode(html, Charsets.ISO_8859_1, headerCharset = null)
+
+        assertThat(decoded).contains("puré")
+    }
+
+    @Test
+    fun `sniffs the legacy http-equiv meta charset`() {
+        val html = """
+            <html><head>
+            <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+            </head><body>añejo</body></html>
+        """.trimIndent()
+
+        val decoded = decode(html, Charsets.ISO_8859_1, headerCharset = null)
+
+        assertThat(decoded).contains("añejo")
+    }
+
+    @Test
+    fun `defaults to utf-8 when nothing declares a charset`() {
+        val html = "<html><body>crème brûlée</body></html>"
+
+        val decoded = decode(html, Charsets.UTF_8, headerCharset = null)
+
+        assertThat(decoded).contains("crème brûlée")
+    }
+
+    @Test
+    fun `falls back to utf-8 when the declared charset name is unknown`() {
+        val html = """<html><head><meta charset="definitely-not-a-charset"></head><body>café</body></html>"""
+
+        val decoded = decode(html, Charsets.UTF_8, headerCharset = null)
+
+        assertThat(decoded).contains("café")
+    }
+
+    @Test
+    fun `only decodes the first length bytes`() {
+        val bytes = "<html>keep</html>DISCARD".toByteArray(Charsets.UTF_8)
+
+        val decoded = decodeHtml(bytes, "<html>keep</html>".length, headerCharset = null)
+
+        assertThat(decoded).isEqualTo("<html>keep</html>")
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporterTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporterTest.kt
@@ -34,9 +34,13 @@ private const val NO_RECIPE_HTML = "<html><body><h1>Just a blog post</h1></body>
 
 class DefaultRecipeImporterTest {
 
-    private fun importer(engine: MockEngine): DefaultRecipeImporter = DefaultRecipeImporter(
+    private fun importer(
+        engine: MockEngine,
+        renderedHtmlFetcher: FakeRenderedHtmlFetcher = FakeRenderedHtmlFetcher(),
+    ): DefaultRecipeImporter = DefaultRecipeImporter(
         httpClient = HttpClient(engine) { expectSuccess = true },
         recipeHtmlParser = RecipeHtmlParser(),
+        renderedHtmlFetcher = renderedHtmlFetcher,
         metadataRepository = FakeMetadataRepository(),
         ioDispatcher = Dispatchers.Unconfined,
     )
@@ -104,5 +108,71 @@ class DefaultRecipeImporterTest {
         val result = importer(htmlEngine(JSON_LD_RECIPE_HTML)).import("http://192.168.1.5/x")
 
         assertThat(result).isEqualTo(RecipeImportResult.InvalidUrl)
+    }
+
+    // --- Rendered fallback ---
+
+    @Test
+    fun `does not render when the http fetch already produced a recipe`() = runTest {
+        val fetcher = FakeRenderedHtmlFetcher(JSON_LD_RECIPE_HTML)
+
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML), fetcher).import("https://example.com/recipe")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.Success::class.java)
+        assertThat(fetcher.callCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `renders in a browser engine when the site refuses the http client`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.Forbidden) }
+        val fetcher = FakeRenderedHtmlFetcher(JSON_LD_RECIPE_HTML)
+
+        val result = importer(engine, fetcher).import("https://blocked.example.com/recipe")
+
+        val success = result as? RecipeImportResult.Success
+        assertThat(success).isNotNull()
+        assertThat(success!!.draft.title).isEqualTo("Mock Recipe")
+        assertThat(fetcher.lastUrl).isEqualTo("https://blocked.example.com/recipe")
+    }
+
+    @Test
+    fun `asks for a visible browser when rendering cannot get past the refusal either`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.Forbidden) }
+        // The bot check is still up, so the rendered DOM has no recipe on it.
+        val fetcher = FakeRenderedHtmlFetcher(NO_RECIPE_HTML)
+
+        val result = importer(engine, fetcher).import("https://blocked.example.com/recipe")
+
+        assertThat(result).isEqualTo(RecipeImportResult.NeedsBrowser("https://blocked.example.com/recipe"))
+    }
+
+    @Test
+    fun `renders when the page loaded but carried no recipe markup`() = runTest {
+        // A JS-rendered site: the shell arrives empty and the markup only exists after scripts run.
+        val fetcher = FakeRenderedHtmlFetcher(JSON_LD_RECIPE_HTML)
+
+        val result = importer(htmlEngine(NO_RECIPE_HTML), fetcher).import("https://spa.example.com/recipe")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.Success::class.java)
+    }
+
+    @Test
+    fun `stays NoRecipeFound rather than sending the user to a browser for a page with no recipe`() = runTest {
+        val fetcher = FakeRenderedHtmlFetcher(NO_RECIPE_HTML)
+
+        val result = importer(htmlEngine(NO_RECIPE_HTML), fetcher).import("https://example.com/blog")
+
+        assertThat(result).isEqualTo(RecipeImportResult.NoRecipeFound)
+    }
+
+    @Test
+    fun `does not render a 404 — a browser would not find the page either`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.NotFound) }
+        val fetcher = FakeRenderedHtmlFetcher(JSON_LD_RECIPE_HTML)
+
+        val result = importer(engine, fetcher).import("https://example.com/missing")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.NetworkError::class.java)
+        assertThat(fetcher.callCount).isEqualTo(0)
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRecipeImporter.kt
@@ -11,6 +11,8 @@ class FakeRecipeImporter : RecipeImporter {
         private set
     var lastImportedUrl: String? = null
         private set
+    var lastImportedHtml: String? = null
+        private set
 
     /** When set, [import] suspends until this completes — lets tests assert in-flight behaviour. */
     var gate: CompletableDeferred<Unit>? = null
@@ -18,6 +20,14 @@ class FakeRecipeImporter : RecipeImporter {
     override suspend fun import(url: String): RecipeImportResult {
         callCount++
         lastImportedUrl = url
+        gate?.await()
+        return result
+    }
+
+    override suspend fun importFromHtml(html: String, url: String): RecipeImportResult {
+        callCount++
+        lastImportedUrl = url
+        lastImportedHtml = html
         gate?.await()
         return result
     }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRenderedHtmlFetcher.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRenderedHtmlFetcher.kt
@@ -1,0 +1,28 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
+import kotlin.time.Duration
+
+/**
+ * Stands in for the off-screen WebView so the importer's tiering can be tested on plain JVM.
+ *
+ * [html] is offered to the caller's `accept` predicate exactly as the real fetcher offers a DOM
+ * snapshot, so a fixture that doesn't parse exercises the give-up path faithfully.
+ */
+class FakeRenderedHtmlFetcher(private val html: String? = null) : RenderedHtmlFetcher {
+
+    var callCount: Int = 0
+        private set
+    var lastUrl: String? = null
+        private set
+
+    override suspend fun fetchRenderedHtml(
+        url: String,
+        budget: Duration,
+        accept: (String) -> Boolean,
+    ): String? {
+        callCount++
+        lastUrl = url
+        return html?.takeIf(accept)
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
@@ -10,6 +10,7 @@ import com.tenmilelabs.chefai.core.util.MainCoroutineRule
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.usecase.SaveImportedDraft
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -42,7 +43,11 @@ class ImportRecipeViewModelTest {
                 set(AppDestinationArgs.PREFILL_URL_ARG, URLEncoder.encode(prefillUrl, "UTF-8"))
             }
         }
-        return ImportRecipeViewModel(recipeImporter, recipeDraftDao, mainCoroutineRule.testDispatcher, savedStateHandle)
+        return ImportRecipeViewModel(
+            recipeImporter = recipeImporter,
+            saveImportedDraft = SaveImportedDraft(recipeDraftDao, mainCoroutineRule.testDispatcher),
+            savedStateHandle = savedStateHandle,
+        )
     }
 
     @Test
@@ -104,6 +109,23 @@ class ImportRecipeViewModelTest {
         viewModel.dispatch(ImportAction.Import)
 
         assertThat(viewModel.state.value.errorRes).isEqualTo(R.string.import_recipe_parse_error)
+    }
+
+    @Test
+    fun `NeedsBrowser hands the url to the in-app browser instead of showing an error`() = runTest {
+        recipeImporter.result = RecipeImportResult.NeedsBrowser("https://blocked.example.com/recipe")
+
+        viewModel.effects.test {
+            viewModel.dispatch(ImportAction.UrlChanged("https://blocked.example.com/recipe"))
+            viewModel.dispatch(ImportAction.Import)
+
+            val effect = awaitItem()
+            assertThat(effect)
+                .isEqualTo(ImportEffect.NavigateToBrowserImport("https://blocked.example.com/recipe"))
+        }
+
+        assertThat(viewModel.state.value.errorRes).isNull()
+        assertThat(viewModel.state.value.isImporting).isFalse()
     }
 
     @Test

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportViewModelTest.kt
@@ -1,0 +1,125 @@
+package com.tenmilelabs.chefai.recipes.ui.urlimport.browser
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDraftDao
+import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
+import com.tenmilelabs.chefai.core.util.MainCoroutineRule
+import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
+import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.usecase.SaveImportedDraft
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.net.URLEncoder
+import java.util.UUID
+
+private const val BLOCKED_URL = "https://blocked.example.com/recipe"
+
+@ExperimentalCoroutinesApi
+class BrowserImportViewModelTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private lateinit var recipeImporter: FakeRecipeImporter
+    private lateinit var recipeDraftDao: FakeRecipeDraftDao
+    private lateinit var viewModel: BrowserImportViewModel
+
+    @Before
+    fun setup() {
+        recipeImporter = FakeRecipeImporter()
+        recipeDraftDao = FakeRecipeDraftDao()
+        viewModel = createViewModel()
+    }
+
+    private fun createViewModel(url: String = BLOCKED_URL): BrowserImportViewModel {
+        val savedStateHandle = SavedStateHandle().apply {
+            set(AppDestinationArgs.IMPORT_URL_ARG, URLEncoder.encode(url, "UTF-8"))
+        }
+        return BrowserImportViewModel(
+            recipeImporter = recipeImporter,
+            saveImportedDraft = SaveImportedDraft(recipeDraftDao, mainCoroutineRule.testDispatcher),
+            savedStateHandle = savedStateHandle,
+        )
+    }
+
+    @Test
+    fun `decodes the url from the route argument`() = runTest {
+        assertThat(viewModel.state.value.url).isEqualTo(BLOCKED_URL)
+    }
+
+    @Test
+    fun `a snapshot carrying a recipe persists a draft and hands off to the editor`() = runTest {
+        val draftId = UUID.randomUUID()
+        recipeImporter.result = RecipeImportResult.Success(
+            RecipeDraft(recipeId = draftId, isNewRecipe = true, title = "Blocked Recipe"),
+        )
+
+        viewModel.effects.test {
+            viewModel.dispatch(BrowserImportAction.SnapshotCaptured("<html>recipe</html>"))
+
+            assertThat(awaitItem()).isEqualTo(BrowserImportEffect.NavigateToEditorWithDraft(draftId))
+        }
+
+        assertThat(recipeDraftDao.getDraft(draftId)).isNotNull()
+        assertThat(recipeImporter.lastImportedHtml).isEqualTo("<html>recipe</html>")
+        assertThat(recipeImporter.lastImportedUrl).isEqualTo(BLOCKED_URL)
+    }
+
+    @Test
+    fun `a snapshot with no recipe keeps polling rather than failing`() = runTest {
+        // What every snapshot looks like while the bot check is still on screen.
+        recipeImporter.result = RecipeImportResult.NoRecipeFound
+
+        viewModel.dispatch(BrowserImportAction.SnapshotCaptured("<html>challenge</html>"))
+
+        assertThat(viewModel.state.value.isPolling).isTrue()
+        assertThat(viewModel.state.value.errorRes).isNull()
+    }
+
+    @Test
+    fun `ignores a snapshot that lands while the previous one is still being parsed`() = runTest {
+        recipeImporter.gate = kotlinx.coroutines.CompletableDeferred()
+        recipeImporter.result = RecipeImportResult.NoRecipeFound
+
+        viewModel.dispatch(BrowserImportAction.SnapshotCaptured("<html>first</html>"))
+        viewModel.dispatch(BrowserImportAction.SnapshotCaptured("<html>second</html>"))
+
+        assertThat(recipeImporter.callCount).isEqualTo(1)
+        recipeImporter.gate?.complete(Unit)
+    }
+
+    @Test
+    fun `the settle timeout switches the hint to ask the user to act`() = runTest {
+        assertThat(viewModel.state.value.phase).isEqualTo(BrowserImportState.Phase.LOADING)
+
+        viewModel.dispatch(BrowserImportAction.SettleTimeoutElapsed)
+
+        assertThat(viewModel.state.value.phase).isEqualTo(BrowserImportState.Phase.AWAITING_USER)
+    }
+
+    @Test
+    fun `giving up stops the polling and offers manual entry`() = runTest {
+        viewModel.dispatch(BrowserImportAction.GiveUp)
+
+        assertThat(viewModel.state.value.errorRes).isEqualTo(R.string.import_recipe_browser_gave_up)
+        assertThat(viewModel.state.value.isPolling).isFalse()
+    }
+
+    @Test
+    fun `EnterManually and Cancel emit their nav effects`() = runTest {
+        viewModel.effects.test {
+            viewModel.dispatch(BrowserImportAction.EnterManually)
+            assertThat(awaitItem()).isEqualTo(BrowserImportEffect.NavigateToManualEditor)
+
+            viewModel.dispatch(BrowserImportAction.Cancel)
+            assertThat(awaitItem()).isEqualTo(BrowserImportEffect.NavigateBack)
+        }
+    }
+}

--- a/docs/adrs/adr-010-client-side-recipe-scraping.md
+++ b/docs/adrs/adr-010-client-side-recipe-scraping.md
@@ -112,6 +112,71 @@ handing the body to the parser.
 
 ---
 
+## Decision 5: A rendered-DOM fallback for sites that refuse HTTP clients
+
+**Added August 2026, amending Decision 1.**
+
+Decision 1 claimed "no headless browser or JS execution is needed — an HTTP GET plus an HTML parse
+is enough". That holds for the large majority of recipe sites, and stays the default. It does not
+hold for all of them. Measured against three reported failures:
+
+| Site | Response to the Ktor client | Cause |
+|---|---|---|
+| `foodnetwork.com` | 403, a 426-byte Akamai "Access Denied" page | Akamai Bot Manager scoring TLS/IP fingerprints. Sending a full set of real Chrome headers does not help. |
+| `seriouseats.com` | 403, a 680 KB JS interstitial | Cloudflare Turnstile — an **interactive** check that does not resolve on its own. |
+| `directoalpaladar.com` | 200, parses correctly | Not a scraping failure at all; see the ingredient-parser note below. |
+
+Both blocked pages carry perfectly ordinary schema.org `Recipe` JSON-LD once loaded in a real
+browser. The extraction tier was never the problem — the fetch tier is.
+
+Two tiers were added below the HTTP fetch, both reusing `RecipeHtmlParser` unchanged:
+
+1. **Off-screen `WebView`** (`WebViewHtmlFetcher`, behind the `RenderedHtmlFetcher` port). A real
+   browser engine on the user's own connection, unattached to any window, polling
+   `document.documentElement.outerHTML` every 500ms for up to 8s and stopping at the first snapshot
+   the parser accepts. This clears Food Network with no UI at all, and also rescues sites whose
+   markup only exists after their own scripts run.
+2. **Visible in-app browser** (`BrowserImportScreen`). For an interactive check, the user clears it
+   themselves — the same thing they would do in Chrome. Nothing here attempts to defeat a CAPTCHA;
+   the screen just keeps polling and gets out of the way the moment a recipe appears.
+
+**Escalation is narrow on purpose.** Only a `401`/`403`/`429`/`503` — a server *refusing* us —
+escalates to the visible browser. A `404`, a DNS failure or a timeout returns immediately: a
+browser would fail the same way, eight seconds later. A page that loaded fine but simply has no
+recipe on it gets the rendered retry (for the JS-rendered case) but never sends the user to a
+browser, because there would be nothing there for them to do.
+
+**Why not a backend endpoint.** Delegating the fetch to the Ktor backend was the obvious
+alternative and is *worse* for exactly the two sites that motivated this: it concentrates requests
+on one datacenter IP, which Akamai and Cloudflare score far more harshly than the residential
+mobile IPs Decision 1 deliberately chose. A backend endpoint would need its own headless browser or
+a paid unblocking service to beat what a `WebView` on the device does for free. The
+cache-by-normalized-URL layer Decision 1 anticipated remains the right *additive* next step, and is
+unaffected by this.
+
+**Cost accepted.** This runs a third party's JavaScript in our process. Both WebViews share one
+hardening config (`applyScraperHardening`): no file or content-provider access, no cross-origin
+escape from `file://`, no geolocation, no autoplay, no window popups, and a `WebViewClient` that
+refuses any non-`http(s)` navigation. There is deliberately **no `addJavascriptInterface`** anywhere
+in this feature — it would hand the page a bridge into app code, and nothing here needs one. The
+stock WebView user agent is left alone rather than reusing Decision 4's desktop string: pairing a
+Windows Chrome UA with Android's TLS and JS fingerprint is the exact mismatch bot detection looks
+for. Cookies are left to the process-wide `CookieManager` on purpose, so a clearance cookie earned
+on the visible screen carries over and the next import of that site usually resolves off-screen.
+
+Two parser bugs surfaced by the same investigation were fixed alongside it:
+
+- **Fused metric amounts.** `"300g Garbanzos"` parsed to a null quantity *and* null unit, so
+  `ScrapedRecipeMapper` substituted `1.0`/`"unit"` and the editor showed *"1 unit of 300g
+  Garbanzos"* — 8 of the 14 ingredients on the cocido madrileño page. `IngredientTextParser` now
+  splits a token that fuses the two, but only when the suffix normalises to a known unit, so pan
+  sizes (`"9x13"`) and multipliers (`"1x"`) are untouched.
+- **Response charset.** The body was decoded as UTF-8 unconditionally, turning every accented
+  character on an ISO-8859-1 site into a replacement glyph. `decodeHtml` now honours the
+  `Content-Type` charset, falls back to a sniffed `<meta>` declaration, and only then to UTF-8.
+
+---
+
 ## Consequences
 
 **Positive:**
@@ -128,6 +193,9 @@ handing the body to the parser.
 - Per-user, per-request scraping cost (no shared cache) — see Decision 1.
 - No per-site scrapers — some sites with non-schema.org markup will simply fail to import in v1 and
   fall back to `NoRecipeFound` with a manual-entry offramp.
+- A URL that loads fine but isn't a recipe now costs the extra 8s render budget (Decision 5) before
+  reporting `NoRecipeFound`, up from roughly a second. `RENDER_BUDGET` is a single constant; tune it
+  once there is real usage to tune against.
 - `RecipeDraft.toRecipe()` still throws `NumberFormatException` on a blank numeric string, a
   pre-existing contract the mapper works around by emitting `"0"` rather than `""` for absent
   numerics — see `docs/claude/gotchas.md`. Hardening that contract (`toIntOrNull() ?: 0`) is a good

--- a/docs/claude/decisions.md
+++ b/docs/claude/decisions.md
@@ -13,7 +13,7 @@ All ADRs live in [`docs/adrs/`](../adrs/). This file is a quick-reference index.
 | 005 | [Feature-Based Packages](../adrs/adr-0005-feature-based-package-structure.md) | Nov 2025 | Feature packages over layer packages. Start in feature, move to core/ when shared. |
 | 006 | [Anonymous-First Sync](../adrs/adr-006-sync-protocol.md) | Feb 2026 | App works without login. Anonymous → Authenticated upgrade merges data. |
 | 009 | [Navigation-Scoped ViewModel for Wizards](../adrs/adr-009-navigation-scoped-viewmodel-for-wizards.md) | Mar 2026 | Multi-screen wizard flows use a nested NavGraph-scoped ViewModel; state lives exactly as long as the flow. |
-| 010 | [Client-Side Recipe URL Scraping](../adrs/adr-010-client-side-recipe-scraping.md) | Aug 2026 | Paste-a-URL import scrapes JSON-LD/microdata on-device via a new pure-Kotlin `:recipe-scraper` module; no backend endpoint, no per-site scrapers, unauthenticated `@ScraperHttpClient` prevents auth-token leakage to third-party hosts. |
+| 010 | [Client-Side Recipe URL Scraping](../adrs/adr-010-client-side-recipe-scraping.md) | Aug 2026 | Paste-a-URL import scrapes JSON-LD/microdata on-device via a new pure-Kotlin `:recipe-scraper` module; no backend endpoint, no per-site scrapers, unauthenticated `@ScraperHttpClient` prevents auth-token leakage to third-party hosts. Decision 5 (Aug 2026) adds a rendered-DOM fallback — an off-screen `WebView`, then a visible one — for the minority of sites that refuse HTTP clients outright. |
 
 ## RFCs
 

--- a/recipe-scraper/README.md
+++ b/recipe-scraper/README.md
@@ -14,6 +14,12 @@ Recipe sites are SEO-driven, so they almost universally embed
 HTML for Google's rich-snippet search results. That's enough to extract a usable recipe from most
 sites without a headless browser or JS execution.
 
+A minority of sites won't hand that HTML to a plain HTTP client at all — bot protection scoring TLS
+and IP fingerprints, or markup only assembled once the page's own scripts have run. That's a
+*fetching* problem, not a parsing one: `:app` retries those through a `WebView` and feeds the
+rendered DOM back into this same parser. See
+[ADR-010 Decision 5](../docs/adrs/adr-010-client-side-recipe-scraping.md).
+
 ## Public API
 
 ```kotlin

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParser.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParser.kt
@@ -18,8 +18,10 @@ internal fun parseIngredient(raw: String): ScrapedIngredient {
     val tokens = text.split(' ').filter { it.isNotEmpty() }
     var index = 0
     var quantity: Double? = null
+    var unit: String? = null
 
-    parseNumber(tokens[0])?.let { leading ->
+    val leading = parseNumber(tokens[0])
+    if (leading != null) {
         quantity = leading
         index = 1
 
@@ -41,12 +43,20 @@ internal fun parseIngredient(raw: String): ScrapedIngredient {
 
         // A parenthetical size qualifier often sits between amount and unit: "1 (14 oz) can".
         index = skipParenthetical(tokens, index)
+    } else {
+        // Metric sites — Spanish and French ones especially — routinely fuse the amount and the
+        // unit into a single token: "300g Garbanzos".
+        splitFusedAmountAndUnit(tokens[0])?.let { (amount, fusedUnit) ->
+            quantity = amount
+            unit = fusedUnit
+            index = skipParenthetical(tokens, 1)
+        }
     }
 
-    var unit: String? = null
     // Only look for a unit behind an amount; without one, a leading word is far more likely to be
-    // part of the name ("Salt to taste") than a unit.
-    if (quantity != null && index < tokens.size) {
+    // part of the name ("Salt to taste") than a unit. A fused token already supplied one, and
+    // re-running this would swallow the first word of the name as a second unit.
+    if (quantity != null && unit == null && index < tokens.size) {
         normalizeUnit(tokens[index])?.let { matched ->
             unit = matched
             index = skipParenthetical(tokens, index + 1)
@@ -62,6 +72,21 @@ internal fun parseIngredient(raw: String): ScrapedIngredient {
         .ifEmpty { text }
 
     return ScrapedIngredient(raw = raw, quantity = quantity, unit = unit, name = name)
+}
+
+/**
+ * Splits a token that fuses an amount and a unit — `"300g"`, `"1.5kg"`, `"½kg"`, `"300-400g"` —
+ * into the two, or returns `null` when it isn't one.
+ *
+ * Deliberately conservative: the trailing part must normalise to a *known* unit, so pan sizes
+ * (`"9x13"`), multipliers (`"1x"`) and product codes (`"1A"`) fall through untouched.
+ */
+private fun splitFusedAmountAndUnit(token: String): Pair<Double, String>? {
+    val splitAt = token.indexOfFirst { it.isLetter() }
+    if (splitAt <= 0) return null
+    val amount = parseNumber(token.substring(0, splitAt)) ?: return null
+    val unit = normalizeUnit(token.substring(splitAt)) ?: return null
+    return amount to unit
 }
 
 /** Advances past a `( … )` group starting at [index], leaving [index] untouched if none is there. */

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParserTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/ingredient/IngredientTextParserTest.kt
@@ -104,6 +104,42 @@ class IngredientTextParserTest {
         assertParsed("all-purpose flour", null, null, "all-purpose flour")
     }
 
+    // --- Fused amount and unit ---
+
+    @Test
+    fun `splits an amount fused to its unit`() {
+        // How metric sites overwhelmingly write it — directoalpaladar.com's cocido madrileño
+        // publishes every weighed ingredient this way.
+        assertParsed("300g Garbanzos", 300.0, "g", "Garbanzos")
+        assertParsed("250ml leche", 250.0, "ml", "leche")
+        assertParsed("2kg patatas", 2.0, "kg", "patatas")
+    }
+
+    @Test
+    fun `splits a fused decimal or fraction amount`() {
+        assertParsed("1.5kg harina", 1.5, "kg", "harina")
+        assertParsed("½kg tomates", 0.5, "kg", "tomates")
+    }
+
+    @Test
+    fun `takes the lower bound of a fused range`() {
+        assertParsed("300-400g morcillo", 300.0, "g", "morcillo")
+    }
+
+    @Test
+    fun `does not treat a non-unit suffix as a fused amount`() {
+        // Pan sizes, multipliers and product codes all lead with a digit but carry no unit.
+        assertParsed("9x13 inch pan", null, null, "9x13 inch pan")
+        assertParsed("1x large egg", null, null, "1x large egg")
+        assertParsed("1A vanilla pod", null, null, "1A vanilla pod")
+    }
+
+    @Test
+    fun `does not read a second unit after a fused one`() {
+        // "cup" here is part of the name, not a unit — the amount already carried "g".
+        assertParsed("200g cup mushrooms", 200.0, "g", "cup mushrooms")
+    }
+
     // --- Parentheticals ---
 
     @Test


### PR DESCRIPTION
## Summary

Investigated three sites the client failed to scrape (`directoalpaladar.com`, `foodnetwork.com`, `seriouseats.com`) and found the fetch tier — not the parser — was the bottleneck for two of them: both return a 403 from a bot manager (Akamai / Cloudflare) even with real browser headers, but load fine in an actual browser.

- **Headless WebView fallback** (Tier 2a): on a bot-wall refusal or a JS-rendered empty shell, retry in an off-screen WebView and poll the rendered DOM until `RecipeHtmlParser` accepts a snapshot. Fixes Food Network with no UI shown at all.
- **Visible browser fallback** (Tier 2b): Serious Eats sits behind an interactive Cloudflare Turnstile checkbox that only a human can clear. `RecipeImportResult.NeedsBrowser` sends the user to a new screen with a real, visible WebView; the same polling picks up the recipe the moment the check clears.
- **Two scraper bugs** found along the way, both fixed: fused metric ingredient amounts (`"300g Garbanzos"` lost both quantity and unit), and hardcoded UTF-8 decoding (garbled any ISO-8859-1 site).
- **One unrelated sync bug**, found via logcat while testing the above on-device: a pulled bookmark referencing a recipe not present locally threw a `SQLiteConstraintException` and rolled back the entire pull-page transaction on every retry — which is what "recipes missing + broken sync icon" turned out to be. Small, isolated fix; flagged separately in the commit.

ADR-010 gets a new Decision 5 explaining why a backend fetch was rejected as the alternative (concentrates requests on one datacenter IP, which these bot managers score worse than a user's own connection).

## Commits

1. `Parse fused amount+unit ingredient tokens (e.g. "300g")` — `:recipe-scraper` only
2. `Add rendered-DOM fallback for recipe sites that block plain HTTP fetches` — headless WebView + charset fix, both live in `DefaultRecipeImporter`'s fetch path
3. `Add visible browser fallback for sites needing an interactive bot check` — the new screen + navigation wiring
4. `Document the rendered-DOM fallback in ADR-010`
5. `Fix sync: skip bookmarks referencing a recipe not known locally` — unrelated pre-existing bug, not part of this feature

## Known follow-up (filed, not in this PR)

[#130](https://github.com/jmuci/ChefAI/issues/130) — imported recipe images from Food Network/Serious Eats 403 the same way the HTML did; Coil needs the same "real browser" treatment or a backend proxy.

## Test plan

- [x] `./gradlew :recipe-scraper:jvmTest :app:testDebugUnitTest` — 474/474 passing (64 + 410)
- [x] `WebViewHtmlFetcherTest` (instrumented, `data:` URLs, no network) compiles and is included, though I could not execute it against a healthy emulator in this session — both attached emulators were unresponsive to `adb`. Worth running before merge: `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.tenmilelabs.chefai.recipes.data.network.WebViewHtmlFetcherTest`
- [x] Manually verified on-device: Food Network resolves via the headless fallback with no visible browser; Serious Eats surfaces the Cloudflare checkbox and completes after solving it; directoalpaladar unaffected (was already working)
- [ ] Re-verify the sync fix end-to-end on a clean pull once merged — I confirmed the root cause and added regression tests, but didn't have a live backend session to reproduce the original failure end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)