### PR TITLE
Recipe import: on-device image fetch infrastructure (1/4, #130)

### DIFF
--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestAuthModule.kt
@@ -14,11 +14,13 @@ import com.tenmilelabs.chefai.mealplans.data.network.MealPlanApiService
 import com.tenmilelabs.chefai.mealplans.data.network.MealPlanNetworkDataSource
 import com.tenmilelabs.chefai.mealplans.data.repository.DefaultMealPlanRepository
 import com.tenmilelabs.chefai.mealplans.domain.repository.MealPlanRepository
+import com.tenmilelabs.chefai.recipes.data.network.WebViewImageFetcher
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -138,4 +140,14 @@ abstract class TestRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindRecipeImporter(fake: FakeRecipeImporter): RecipeImporter
+
+    /**
+     * Binds the real [WebViewImageFetcher] (same as production) — required for Hilt's shared test
+     * component to resolve `SaveImportedDraft`'s graph (see docs/claude/gotchas.md #21), even though
+     * every instrumented test's fake-importer drafts use a blank `imageUrl`, so `CacheRecipeImage`
+     * never actually reaches it at runtime.
+     */
+    @Binds
+    @Singleton
+    abstract fun bindRenderedImageFetcher(fetcher: WebViewImageFetcher): RenderedImageFetcher
 }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/network/WebViewImageFetcherTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/recipes/data/network/WebViewImageFetcherTest.kt
@@ -1,0 +1,51 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
+
+/** A minimal (1x1, transparent) valid PNG — small enough to inline, real enough to decode. */
+private const val ONE_PIXEL_PNG_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+
+/**
+ * Exercises the off-screen WebView's image fetch against `data:` URLs and unroutable addresses, so
+ * the round-trip and give-up paths are covered without depending on any real CDN.
+ */
+@RunWith(AndroidJUnit4::class)
+class WebViewImageFetcherTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val fetcher = WebViewImageFetcher(context)
+
+    @Test
+    fun returnsTheDecodedBytesForADataUrl() = runTest {
+        val dataUrl = "data:image/png;base64,$ONE_PIXEL_PNG_BASE64"
+
+        val result = fetcher.fetchImageBytes(dataUrl, budget = 10.seconds)
+
+        assertArrayEquals(Base64.decode(ONE_PIXEL_PNG_BASE64, Base64.DEFAULT), result)
+    }
+
+    @Test
+    fun returnsNullWhenTheConnectionIsRefused() = runTest {
+        // Loopback, nothing listening — refused near-instantly, no real network needed.
+        val result = fetcher.fetchImageBytes("http://127.0.0.1:1/nope.jpg", budget = 10.seconds)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun returnsNullWhenTheBudgetRunsOutWithoutAResponse() = runTest {
+        // RFC 5737 TEST-NET-1 — reserved for documentation/testing, never routable.
+        val result = fetcher.fetchImageBytes("http://192.0.2.1/nope.jpg", budget = 3.seconds)
+
+        assertNull(result)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -18,8 +18,10 @@ import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
 import com.tenmilelabs.chefai.recipes.data.network.WebViewHtmlFetcher
+import com.tenmilelabs.chefai.recipes.data.network.WebViewImageFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
 import dagger.Binds
 import dagger.Module
@@ -63,6 +65,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindRenderedHtmlFetcher(fetcher: WebViewHtmlFetcher): RenderedHtmlFetcher
+
+    @Singleton
+    @Binds
+    abstract fun bindRenderedImageFetcher(fetcher: WebViewImageFetcher): RenderedImageFetcher
 }
 
 

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/local/RecipeImageStore.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/local/RecipeImageStore.kt
@@ -1,0 +1,71 @@
+package com.tenmilelabs.chefai.recipes.data.local
+
+import android.content.Context
+import com.tenmilelabs.chefai.core.di.IoDispatcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persists downloaded recipe images to app-internal storage, keyed by recipe id.
+ *
+ * Lives in `filesDir`, not `cacheDir` — these bytes came from a CDN that may 403 a plain HTTP
+ * client (see [com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage]), so an OS-triggered
+ * cache eviction would lose the image permanently rather than merely cost a re-fetch. Filenames
+ * carry no extension; Coil sniffs the content type from the bytes themselves.
+ */
+@Singleton
+class RecipeImageStore @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    private val directory: File
+        get() = File(context.filesDir, "recipe_images")
+
+    private fun fileFor(recipeId: UUID) = File(directory, recipeId.toString())
+
+    /**
+     * Writes [bytes] for [recipeId], atomically (a `.tmp` file is written first, then renamed).
+     *
+     * @return the absolute path of the stored file, or `null` if the write failed.
+     */
+    suspend fun write(recipeId: UUID, bytes: ByteArray): String? = withContext(ioDispatcher) {
+        try {
+            val dir = directory
+            if (!dir.exists() && !dir.mkdirs()) {
+                Timber.w("Failed to create recipe image directory")
+                return@withContext null
+            }
+            val target = fileFor(recipeId)
+            val tmpFile = File(dir, "${recipeId}.tmp")
+            tmpFile.writeBytes(bytes)
+            if (!tmpFile.renameTo(target)) {
+                Timber.w("Failed to move recipe image into place for %s", recipeId)
+                tmpFile.delete()
+                return@withContext null
+            }
+            target.absolutePath
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to write recipe image for %s", recipeId)
+            null
+        }
+    }
+
+    /** Removes the stored image for [recipeId], if any. */
+    suspend fun delete(recipeId: UUID): Unit = withContext(ioDispatcher) {
+        fileFor(recipeId).delete()
+        Unit
+    }
+
+    /** Removes every stored recipe image — used when the local database is wiped wholesale. */
+    suspend fun deleteAll(): Unit = withContext(ioDispatcher) {
+        directory.deleteRecursively()
+        Unit
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapper.kt
@@ -8,6 +8,7 @@ import com.tenmilelabs.chefai.core.domain.model.Tag
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
 import com.tenmilelabs.recipescraper.model.ScrapedIngredient
 import com.tenmilelabs.recipescraper.model.ScrapedRecipe
+import java.net.URI
 import java.util.UUID
 
 private const val MAX_KEYWORDS = 8
@@ -34,7 +35,7 @@ fun ScrapedRecipe.toRecipeDraft(
     isNewRecipe = true,
     title = title,
     description = description.orEmpty(),
-    imageUrl = imageUrl.orEmpty(),
+    imageUrl = resolvedImageUrl().orEmpty(),
     prepTimeMinutes = prepTimeMinutes?.toString() ?: "0",
     cookTimeMinutes = cookTimeMinutesOrFallback(),
     servings = servings?.toString() ?: "0",
@@ -45,6 +46,15 @@ fun ScrapedRecipe.toRecipeDraft(
     labels = emptyList(),
     version = 1,
 )
+
+/**
+ * Resolves [ScrapedRecipe.imageUrl] against [ScrapedRecipe.sourceUrl] — the scraper's own KDoc
+ * flags that the value "may be relative to sourceUrl", and resolution is documented as the caller's
+ * job (`:recipe-scraper` reports what a page published without fabricating or defaulting a value).
+ * Falls back to the raw value on any malformed input rather than dropping the image outright.
+ */
+private fun ScrapedRecipe.resolvedImageUrl(): String? =
+    imageUrl?.let { url -> runCatching { URI(sourceUrl).resolve(url).toString() }.getOrDefault(url) }
 
 /** Prefers [ScrapedRecipe.cookTimeMinutes]; falls back to total-minus-prep, then to `"0"`. */
 private fun ScrapedRecipe.cookTimeMinutesOrFallback(): String {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/BotWall.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/BotWall.kt
@@ -1,0 +1,19 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import io.ktor.http.HttpStatusCode
+
+/**
+ * Statuses a bot manager returns to a client it doesn't like. Akamai and Cloudflare both answer
+ * 403; 401, 429 and 503 cover the rate-limit and "under attack mode" variants. A 404 is
+ * deliberately absent — that page really is missing, and a browser won't find it either.
+ *
+ * Shared by [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter] (HTML fetch) and
+ * [com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage] (image fetch) — both escalate to
+ * a WebView on exactly these statuses.
+ */
+internal val BOT_WALL_STATUSES = setOf(
+    HttpStatusCode.Unauthorized,
+    HttpStatusCode.Forbidden,
+    HttpStatusCode.TooManyRequests,
+    HttpStatusCode.ServiceUnavailable,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/ScraperWebView.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/ScraperWebView.kt
@@ -15,6 +15,55 @@ private const val MAX_SNAPSHOT_CHARS = 4 * 1024 * 1024
 private const val OUTER_HTML_SCRIPT = "document.documentElement.outerHTML"
 
 /**
+ * Caps how large a downloaded recipe image is allowed to be — comfortably past any real hero
+ * image, while bounding how much a hostile response can inflate memory (twice over: once as raw
+ * bytes in the WebView's own fetch, again as the base64 string handed back across the JNI bridge).
+ */
+internal const val MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+/** Base64 inflates by ~4/3; a little headroom is left for the `data:<mime>;base64,` prefix. */
+private const val MAX_IMAGE_DATA_URL_CHARS = MAX_IMAGE_BYTES * 4 / 3 + 128
+
+/**
+ * JS that fetches the document's own URL and hands back its bytes as a `data:` URL.
+ *
+ * Navigating a WebView directly to an image URL loads it inside a synthetic image document whose
+ * origin *is* the image's origin — the only way to read the bytes back with `fetch()` without
+ * hitting CORS, and the reason this loads [WebView]'s own `location.href` rather than being handed
+ * a URL as an argument. `cache: 'force-cache'` reuses the bytes the navigation itself just
+ * downloaded rather than fetching twice.
+ *
+ * `fetch` is async and `evaluateJavascript` is not, so the outcome is stashed on a `window` global
+ * and each call to this script just reads whatever state is current — polled the same way
+ * [readRenderedHtml] polls for parseable markup. This is a plain `fetch`, not a bridge into app
+ * code: there is deliberately no `addJavascriptInterface` anywhere in this feature (see
+ * [applyScraperHardening]'s KDoc).
+ */
+private val IMAGE_FETCH_SCRIPT = """
+    (function () {
+      var s = window.__chefaiImg;
+      if (!s) {
+        window.__chefaiImg = { state: 'pending' };
+        fetch(location.href, { cache: 'force-cache' })
+          .then(function (r) { if (!r.ok) throw new Error('http ' + r.status); return r.blob(); })
+          .then(function (b) {
+            if (b.size > $MAX_IMAGE_BYTES) throw new Error('too large: ' + b.size);
+            return new Promise(function (res, rej) {
+              var fr = new FileReader();
+              fr.onload = function () { res(fr.result); };
+              fr.onerror = function () { rej(fr.error); };
+              fr.readAsDataURL(b);
+            });
+          })
+          .then(function (d) { window.__chefaiImg = { state: 'ok', data: d }; })
+          .catch(function (e) { window.__chefaiImg = { state: 'error', message: String(e) }; });
+        return 'pending';
+      }
+      return s.state === 'ok' ? s.data : s.state;
+    })()
+""".trimIndent()
+
+/**
  * Applies the settings shared by both recipe-scraping WebViews — the off-screen one in
  * [WebViewHtmlFetcher] and the visible one on the browser-import screen.
  *
@@ -90,5 +139,18 @@ internal fun WebView.readRenderedHtml(onResult: (String?) -> Unit) {
             ?.takeIf { it.isNotBlank() && it != "null" && it.length <= MAX_SNAPSHOT_CHARS }
             ?.let { runCatching { Json.decodeFromString<String>(it) }.getOrNull() }
         onResult(html)
+    }
+}
+
+/**
+ * Reads the current state of [IMAGE_FETCH_SCRIPT]'s in-page fetch — `"pending"`, `"error"`, a
+ * `data:` URL on success, or `null` if the bridge call itself couldn't be decoded.
+ */
+internal fun WebView.readImageDataUrl(onResult: (String?) -> Unit) {
+    evaluateJavascript(IMAGE_FETCH_SCRIPT) { encoded ->
+        val result = encoded
+            ?.takeIf { it.isNotBlank() && it != "null" && it.length <= MAX_IMAGE_DATA_URL_CHARS }
+            ?.let { runCatching { Json.decodeFromString<String>(it) }.getOrNull() }
+        onResult(result)
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/WebViewImageFetcher.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/WebViewImageFetcher.kt
@@ -1,0 +1,79 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import android.content.Context
+import android.util.Base64
+import android.webkit.CookieManager
+import android.webkit.WebView
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+import kotlin.time.Duration
+
+/**
+ * Downloads an image in an off-screen [WebView] — see [RenderedImageFetcher]'s KDoc for why.
+ *
+ * Structurally a sibling of [WebViewHtmlFetcher]: same off-screen, never-attached WebView, same
+ * main-thread requirement, same shared process-wide [CookieManager] (a clearance cookie earned
+ * loading the page carries over to its images), same hardening. The one difference is what's polled
+ * for — [readImageDataUrl] reports a definitive `"error"` state, so this can give up as soon as the
+ * fetch actually fails rather than waiting out the full [Duration] budget.
+ */
+@Singleton
+class WebViewImageFetcher @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : RenderedImageFetcher {
+
+    override suspend fun fetchImageBytes(imageUrl: String, budget: Duration): ByteArray? =
+        withContext(Dispatchers.Main) {
+            val webView = WebView(context).apply {
+                applyScraperHardening()
+                webViewClient = ScraperWebViewClient()
+            }
+
+            try {
+                withTimeoutOrNull(budget) {
+                    webView.loadUrl(imageUrl)
+                    var result: ByteArray? = null
+                    var failed = false
+                    while (result == null && !failed) {
+                        delay(SNAPSHOT_INTERVAL)
+                        when (val state = webView.awaitImageDataUrl()) {
+                            null, "pending" -> Unit
+                            "error" -> failed = true
+                            else -> result = state.toImageBytesOrNull()
+                        }
+                    }
+                    result
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "Rendered image fetch failed for %s", imageUrl)
+                null
+            } finally {
+                webView.stopLoading()
+                webView.destroy()
+                CookieManager.getInstance().flush()
+            }
+        }
+}
+
+/** Suspending wrapper around [readImageDataUrl]'s callback. */
+private suspend fun WebView.awaitImageDataUrl(): String? = suspendCancellableCoroutine { continuation ->
+    readImageDataUrl { result ->
+        if (continuation.isActive) continuation.resume(result)
+    }
+}
+
+/** Decodes the base64 payload of a `data:<mime>;base64,<payload>` URL, or `null` if malformed. */
+private fun String.toImageBytesOrNull(): ByteArray? {
+    val base64 = substringAfter(delimiter = ",", missingDelimiterValue = "")
+    if (base64.isEmpty()) return null
+    return runCatching { Base64.decode(base64, Base64.DEFAULT) }.getOrNull()
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
@@ -5,6 +5,7 @@ import com.tenmilelabs.chefai.core.di.IoDispatcher
 import com.tenmilelabs.chefai.core.di.ScraperHttpClient
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraft
+import com.tenmilelabs.chefai.recipes.data.network.BOT_WALL_STATUSES
 import com.tenmilelabs.chefai.recipes.data.network.decodeHtml
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
@@ -17,7 +18,6 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.charset
 import io.ktor.http.contentType
 import io.ktor.utils.io.readAvailable
@@ -42,18 +42,6 @@ private const val MAX_BODY_BYTES = 3 * 1024 * 1024
  * which simply isn't a recipe doesn't leave the user watching a spinner. Tune from real use.
  */
 private val RENDER_BUDGET = 8.seconds
-
-/**
- * Statuses a bot manager returns to a client it doesn't like. Akamai and Cloudflare both answer
- * 403; 401, 429 and 503 cover the rate-limit and "under attack mode" variants. A 404 is
- * deliberately absent — that page really is missing, and a browser won't find it either.
- */
-private val BOT_WALL_STATUSES = setOf(
-    HttpStatusCode.Unauthorized,
-    HttpStatusCode.Forbidden,
-    HttpStatusCode.TooManyRequests,
-    HttpStatusCode.ServiceUnavailable,
-)
 
 @Singleton
 class DefaultRecipeImporter @Inject constructor(

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RenderedImageFetcher.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/RenderedImageFetcher.kt
@@ -1,0 +1,19 @@
+package com.tenmilelabs.chefai.recipes.domain.repository
+
+import kotlin.time.Duration
+
+/**
+ * Downloads an image through a browser engine, for CDNs that 403 a plain HTTP client.
+ *
+ * Sibling to [RenderedHtmlFetcher]: the same TLS/IP fingerprinting that blocks the Ktor client's
+ * page fetch (see [RenderedHtmlFetcher]'s KDoc) blocks its image fetches too, on exactly the sites
+ * that motivated that fallback. Headers cannot fix this — only a real browser engine gets through.
+ */
+interface RenderedImageFetcher {
+
+    /**
+     * Loads [imageUrl] and returns its decoded bytes, or `null` if [budget] elapses first or the
+     * load fails.
+     */
+    suspend fun fetchImageBytes(imageUrl: String, budget: Duration): ByteArray?
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImage.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImage.kt
@@ -1,0 +1,132 @@
+package com.tenmilelabs.chefai.recipes.domain.usecase
+
+import com.tenmilelabs.chefai.core.di.IoDispatcher
+import com.tenmilelabs.chefai.core.di.ScraperHttpClient
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
+import com.tenmilelabs.chefai.recipes.data.network.BOT_WALL_STATUSES
+import com.tenmilelabs.chefai.recipes.data.network.MAX_IMAGE_BYTES
+import com.tenmilelabs.chefai.recipes.data.repository.normalizeAndValidateUrl
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.contentType
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.seconds
+
+/** Overrides the scraper client's default HTML `Accept` for this one request. */
+private const val IMAGE_ACCEPT_HEADER = "image/avif,image/webp,image/*,*/*;q=0.8"
+
+/**
+ * Budget for the WebView tier — matches
+ * [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter]'s `RENDER_BUDGET` for the
+ * HTML fetch.
+ */
+private val IMAGE_RENDER_BUDGET = 8.seconds
+
+/**
+ * Downloads a recipe's hero image and caches it on-device.
+ *
+ * Mirrors [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter]'s two-tier ladder
+ * one tier lower: a plain HTTP GET first, escalating to an off-screen WebView only when the response
+ * looks like a bot wall refusing a non-browser client (see [BOT_WALL_STATUSES]). The same CDNs that
+ * block the HTML fetch — Akamai on Food Network, Cloudflare on Serious Eats — block their own
+ * images the same way; see ADR-010 Decision 6.
+ *
+ * Never fails the caller: any error, including a genuinely missing or unreachable image, returns
+ * `null` rather than throwing. A recipe without a cached image is a normal outcome — the remote
+ * `imageUrl` scraped into the draft is still there to fall back on — not a broken import, so every
+ * failure path here is swallowed and logged rather than propagated.
+ */
+class CacheRecipeImage @Inject constructor(
+    @ScraperHttpClient private val httpClient: HttpClient,
+    private val renderedImageFetcher: RenderedImageFetcher,
+    private val recipeImageStore: RecipeImageStore,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    suspend operator fun invoke(recipeId: UUID, imageUrl: String): String? = withContext(ioDispatcher) {
+        // The URL was scraped out of a third party's HTML, not typed by the user — the same SSRF
+        // guard normalizeAndValidateUrl applies to a pasted page URL applies here too.
+        val url = normalizeAndValidateUrl(imageUrl) ?: return@withContext null
+
+        val bytes = fetchBytes(url) ?: return@withContext null
+        recipeImageStore.write(recipeId, bytes)
+    }
+
+    private suspend fun fetchBytes(url: String): ByteArray? {
+        val outcome = fetchOverHttp(url)
+        return when (outcome) {
+            is FetchOutcome.Bytes -> outcome.bytes
+            is FetchOutcome.Failure -> {
+                if (!outcome.looksLikeBotWall) return null
+                Timber.i("HTTP image fetch fell short for %s, retrying with a rendered fetch", url)
+                renderedImageFetcher.fetchImageBytes(url, IMAGE_RENDER_BUDGET)
+            }
+        }
+    }
+
+    private suspend fun fetchOverHttp(url: String): FetchOutcome = try {
+        val response = httpClient.get(url) {
+            headers { set(HttpHeaders.Accept, IMAGE_ACCEPT_HEADER) }
+        }
+        val mimeType = response.contentType()?.withoutParameters()?.toString().orEmpty()
+        if (!mimeType.startsWith("image/")) {
+            FetchOutcome.Failure(looksLikeBotWall = false)
+        } else {
+            val bytes = response.readImageBodyCapped()
+            if (bytes != null) FetchOutcome.Bytes(bytes) else FetchOutcome.Failure(looksLikeBotWall = false)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: ResponseException) {
+        Timber.w(e, "Recipe image fetch received an error response")
+        FetchOutcome.Failure(looksLikeBotWall = e.response.status in BOT_WALL_STATUSES)
+    } catch (e: Exception) {
+        // Deliberately broader than DefaultRecipeImporter.fetchHtml's catch list: unlike the HTML
+        // fetch (whose caller branches on a sealed RecipeImportResult), nothing upstream of this use
+        // case handles a thrown exception — SaveImportedDraft has no try/catch around it — so an
+        // uncaught type here would crash the import instead of just leaving it imageless.
+        Timber.w(e, "Recipe image fetch failed for %s", url)
+        FetchOutcome.Failure(looksLikeBotWall = false)
+    }
+
+    private sealed interface FetchOutcome {
+        data class Bytes(val bytes: ByteArray) : FetchOutcome
+        data class Failure(val looksLikeBotWall: Boolean) : FetchOutcome
+    }
+}
+
+/**
+ * Reads at most [MAX_IMAGE_BYTES], returning `null` — rather than a truncated image — if the body
+ * is larger, whether or not a (possibly absent or wrong) `Content-Length` header said so.
+ */
+private suspend fun HttpResponse.readImageBodyCapped(): ByteArray? {
+    val declaredLength = contentLength()
+    if (declaredLength != null && declaredLength > MAX_IMAGE_BYTES) return null
+
+    val channel = bodyAsChannel()
+    val buffer = ByteArray(MAX_IMAGE_BYTES)
+    var offset = 0
+    while (offset < buffer.size) {
+        val read = channel.readAvailable(buffer, offset, buffer.size - offset)
+        if (read == -1) break
+        offset += read
+    }
+    if (offset == buffer.size) {
+        val probe = ByteArray(1)
+        if (channel.readAvailable(probe, 0, 1) > 0) return null
+    }
+    return buffer.copyOf(offset)
+}

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -10,4 +10,6 @@
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>
 -->
+    <!-- Re-downloadable recipe images cached from third-party CDNs — no reason to back these up. -->
+    <exclude domain="file" path="recipe_images/"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -9,6 +9,8 @@
         <include .../>
         <exclude .../>
         -->
+        <!-- Re-downloadable recipe images cached from third-party CDNs — no reason to back these up. -->
+        <exclude domain="file" path="recipe_images/"/>
     </cloud-backup>
     <!--
     <device-transfer>

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapperTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapperTest.kt
@@ -64,6 +64,42 @@ class ScrapedRecipeMapperTest {
     }
 
     @Test
+    fun `a root-relative imageUrl is resolved against the source origin`() {
+        val draft = minimalScrapedRecipe(imageUrl = "/img/x.jpg", sourceUrl = "https://example.com/recipes/pie")
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("https://example.com/img/x.jpg", draft.imageUrl)
+    }
+
+    @Test
+    fun `a protocol-relative imageUrl inherits the source scheme`() {
+        val draft = minimalScrapedRecipe(imageUrl = "//cdn.example.com/x.jpg", sourceUrl = "https://example.com/recipe")
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("https://cdn.example.com/x.jpg", draft.imageUrl)
+    }
+
+    @Test
+    fun `an already-absolute imageUrl is left as the caller published it`() {
+        val draft = minimalScrapedRecipe(
+            imageUrl = "https://cdn.other.com/y.jpg",
+            sourceUrl = "https://example.com/recipe",
+        ).toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("https://cdn.other.com/y.jpg", draft.imageUrl)
+    }
+
+    @Test
+    fun `an imageUrl that cannot be resolved falls back to the raw scraped value`() {
+        // An unescaped space makes this an invalid URI reference; resolution must not throw or
+        // silently drop the value — the raw string is still better than nothing.
+        val draft = minimalScrapedRecipe(imageUrl = "/img/has space.jpg", sourceUrl = "https://example.com/recipe")
+            .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals("/img/has space.jpg", draft.imageUrl)
+    }
+
+    @Test
     fun `null description and imageUrl become blank, not omitted`() {
         val draft = minimalScrapedRecipe(description = null, imageUrl = null)
             .toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRenderedImageFetcher.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeRenderedImageFetcher.kt
@@ -1,0 +1,22 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
+import kotlin.time.Duration
+
+/**
+ * Stands in for the off-screen WebView so [com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage]'s
+ * tiering can be tested on plain JVM.
+ */
+class FakeRenderedImageFetcher(private val bytes: ByteArray? = null) : RenderedImageFetcher {
+
+    var callCount: Int = 0
+        private set
+    var lastUrl: String? = null
+        private set
+
+    override suspend fun fetchImageBytes(imageUrl: String, budget: Duration): ByteArray? {
+        callCount++
+        lastUrl = imageUrl
+        return bytes
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImageTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImageTest.kt
@@ -1,0 +1,151 @@
+package com.tenmilelabs.chefai.recipes.domain.usecase
+
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
+import com.tenmilelabs.chefai.recipes.data.network.MAX_IMAGE_BYTES
+import com.tenmilelabs.chefai.recipes.data.repository.FakeRenderedImageFetcher
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.util.UUID
+
+private val IMAGE_BYTES = byteArrayOf(1, 2, 3, 4)
+private const val STORED_PATH = "/files/recipe_images/stored"
+
+class CacheRecipeImageTest {
+
+    private fun useCase(
+        engine: MockEngine,
+        renderedImageFetcher: FakeRenderedImageFetcher = FakeRenderedImageFetcher(),
+        recipeImageStore: RecipeImageStore = mockk { coEvery { write(any(), any()) } returns STORED_PATH },
+    ) = CacheRecipeImage(
+        httpClient = HttpClient(engine) { expectSuccess = true },
+        renderedImageFetcher = renderedImageFetcher,
+        recipeImageStore = recipeImageStore,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    private fun imageEngine(bytes: ByteArray, contentType: String = "image/jpeg") = MockEngine { _ ->
+        respond(
+            content = ByteReadChannel(bytes),
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, contentType),
+        )
+    }
+
+    @Test
+    fun `caches bytes from a plain HTTP fetch without escalating`() = runTest {
+        val fetcher = FakeRenderedImageFetcher()
+        val store = mockk<RecipeImageStore> { coEvery { write(any(), any()) } returns STORED_PATH }
+        val recipeId = UUID.randomUUID()
+
+        val result = useCase(imageEngine(IMAGE_BYTES), fetcher, store)
+            .invoke(recipeId, "https://example.com/img.jpg")
+
+        assertThat(result).isEqualTo(STORED_PATH)
+        assertThat(fetcher.callCount).isEqualTo(0)
+        coVerify(exactly = 1) { store.write(recipeId, IMAGE_BYTES) }
+    }
+
+    @Test
+    fun `escalates to the rendered fetcher on a 403 and caches its bytes`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.Forbidden) }
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+        val store = mockk<RecipeImageStore> { coEvery { write(any(), any()) } returns STORED_PATH }
+        val recipeId = UUID.randomUUID()
+
+        val result = useCase(engine, fetcher, store)
+            .invoke(recipeId, "https://blocked.example.com/img.jpg")
+
+        assertThat(result).isEqualTo(STORED_PATH)
+        assertThat(fetcher.callCount).isEqualTo(1)
+        assertThat(fetcher.lastUrl).isEqualTo("https://blocked.example.com/img.jpg")
+        coVerify(exactly = 1) { store.write(recipeId, IMAGE_BYTES) }
+    }
+
+    @Test
+    fun `returns null when the rendered fetcher also fails to produce bytes`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.Forbidden) }
+        val fetcher = FakeRenderedImageFetcher(bytes = null)
+        val store = mockk<RecipeImageStore>(relaxed = true)
+
+        val result = useCase(engine, fetcher, store)
+            .invoke(UUID.randomUUID(), "https://blocked.example.com/img.jpg")
+
+        assertThat(result).isNull()
+        coVerify(exactly = 0) { store.write(any(), any()) }
+    }
+
+    @Test
+    fun `does not escalate on a 404 — a browser would not find the image either`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.NotFound) }
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+
+        val result = useCase(engine, fetcher).invoke(UUID.randomUUID(), "https://example.com/missing.jpg")
+
+        assertThat(result).isNull()
+        assertThat(fetcher.callCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `rejects a non-image content type without escalating`() = runTest {
+        val engine = imageEngine(IMAGE_BYTES, contentType = "text/html")
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+
+        val result = useCase(engine, fetcher).invoke(UUID.randomUUID(), "https://example.com/img.jpg")
+
+        assertThat(result).isNull()
+        assertThat(fetcher.callCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `a blank image url is a no-op`() = runTest {
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+        val store = mockk<RecipeImageStore>(relaxed = true)
+
+        val result = useCase(imageEngine(IMAGE_BYTES), fetcher, store).invoke(UUID.randomUUID(), "")
+
+        assertThat(result).isNull()
+        assertThat(fetcher.callCount).isEqualTo(0)
+        coVerify(exactly = 0) { store.write(any(), any()) }
+    }
+
+    @Test
+    fun `a private-network image url is rejected without any network call`() = runTest {
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+        val store = mockk<RecipeImageStore>(relaxed = true)
+        // The engine would throw if reached — its handler is never installed.
+        val engine = MockEngine { respondError(HttpStatusCode.InternalServerError) }
+
+        val result = useCase(engine, fetcher, store).invoke(UUID.randomUUID(), "http://169.254.169.254/latest/meta-data/")
+
+        assertThat(result).isNull()
+        assertThat(fetcher.callCount).isEqualTo(0)
+        coVerify(exactly = 0) { store.write(any(), any()) }
+    }
+
+    @Test
+    fun `a body larger than the cap is rejected rather than cached truncated`() = runTest {
+        val oversized = ByteArray(MAX_IMAGE_BYTES + 1024)
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+        val store = mockk<RecipeImageStore>(relaxed = true)
+
+        val result = useCase(imageEngine(oversized), fetcher, store)
+            .invoke(UUID.randomUUID(), "https://example.com/huge.jpg")
+
+        assertThat(result).isNull()
+        assertThat(fetcher.callCount).isEqualTo(0)
+        coVerify(exactly = 0) { store.write(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Summary
First of 4 stacked PRs fixing #130 (imported recipe images 403 from Food Network / Serious Eats CDNs). See the ADR (landing in PR 4/4) for full design rationale — short version here.

Adds the capability to download and cache a recipe's hero image on-device, mirroring `DefaultRecipeImporter`'s existing HTML fetch ladder one tier lower: a plain GET through `@ScraperHttpClient` first, escalating to an off-screen `WebView` only when the response looks like a bot wall (401/403/429/503). This is the same class of failure ADR-010 Decision 5 already handles for the HTML fetch — Coil's plain OkHttp fetcher gets the same 403 from Food Network's and Serious Eats' image CDNs that the Ktor client got from the pages themselves.

- **`CacheRecipeImage`** — the two-tier orchestrator (HTTP → WebView), with an SSRF guard reusing the existing pasted-URL validator (`normalizeAndValidateUrl`), since the image URL comes from untrusted third-party HTML.
- **`RecipeImageStore`** — writes bytes to `filesDir/recipe_images`, excluded from Auto Backup / cloud device transfer.
- **`WebViewImageFetcher`** — navigates a fresh off-screen WebView *directly to the image URL*, rather than fetching from the page's own already-loaded WebView. Food Network serves images from a different origin than the page (`food.fnr.sndimg.com` vs `www.foodnetwork.com`), so an in-page fetch would be CORS-blocked; navigating to the image itself makes the fetch same-origin.
- **Adjacent fix**: `ScrapedRecipeMapper` now resolves a relative scraped `imageUrl` against `sourceUrl`, which nothing did before — the scraper's own KDoc flagged the gap ("may be relative to sourceUrl") but nothing closed it.

**Nothing calls `CacheRecipeImage` yet** — this PR only adds the capability. Wiring lands in PR 3/4.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — 422 passed, 0 failed
- [x] `./gradlew :recipe-scraper:jvmTest` — 64 passed, 0 failed
- [x] `./gradlew :app:connectedDebugAndroidTest` — new `WebViewImageFetcherTest` (real WebView, `data:` URLs + unroutable-address timeout) passes on an emulator
- [x] Full `:app`/`:recipe-scraper` compile including Hilt DI graph validation for `main`, `test`, and `androidTest` source sets

Stacked on `main`. Next: #130-2 (Room v2 schema), #130-3 (wire it together), #130-4 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)