### PR TITLE
Recipe import: wire image caching into save + display (3/4, #130)

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandler.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandler.kt
@@ -4,6 +4,7 @@ import com.tenmilelabs.chefai.auth.data.local.SecurePreferencesInterface
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.UserDao
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import java.util.UUID
@@ -24,7 +25,8 @@ class AccountSwitchHandler @Inject constructor(
     private val securePreferences: SecurePreferencesInterface,
     private val database: ChefAIDataBase,
     private val recipeDao: RecipeDao,
-    private val userDao: UserDao
+    private val userDao: UserDao,
+    private val recipeImageStore: RecipeImageStore,
 ) {
 
     /**
@@ -52,6 +54,7 @@ class AccountSwitchHandler @Inject constructor(
             else -> {
             Timber.i("Authenticated account changed from $previousUserId to $newUserId, clearing local database")
             database.clearAllTables()
+                recipeImageStore.deleteAll()
                 AccountSwitchOutcome.CLEARED_DATABASE
             }
         }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/RecipeImageModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/RecipeImageModel.kt
@@ -1,0 +1,13 @@
+package com.tenmilelabs.chefai.core.ui
+
+/**
+ * Resolves what Coil should load for a recipe image: an on-device copy if one was cached at import
+ * time (see [com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage]), falling back to the
+ * remote URL, or `null` if neither exists.
+ *
+ * The `null` fallback matters on its own, independent of local caching: Coil 3 throws
+ * `Unable to create a fetcher that supports:` given an empty-string model rather than treating it
+ * as "no image" — see docs/claude/gotchas.md #1.
+ */
+fun recipeImageModel(localImagePath: String?, remoteUrl: String): String? =
+    localImagePath?.let { "file://$it" } ?: remoteUrl.ifEmpty { null }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/LargeCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/LargeCard.kt
@@ -46,6 +46,7 @@ import coil3.request.crossfade
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.domain.model.RecipePreview
 import com.tenmilelabs.chefai.core.ui.preview.PreviewData
+import com.tenmilelabs.chefai.core.ui.recipeImageModel
 import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
 import java.util.UUID
 
@@ -70,7 +71,6 @@ fun LargeCard(
     onClick: (UUID) -> Unit = {},
     onSaveToCollection: (UUID) -> Unit = {}
 ) {
-    timber.log.Timber.d("LargeCard composing for recipe: ${recipe.title}, imageUrl: ${recipe.imageUrlThumbnail}")
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
@@ -83,20 +83,9 @@ fun LargeCard(
             modifier = Modifier.fillMaxSize()
         ) {
             // Background Image
-            timber.log.Timber.tag("LargeCard").d(
-                "🖼️ LargeCard building ImageRequest:\n" +
-                "  Recipe: ${recipe.title}\n" +
-                "  Image URL: ${recipe.imageUrlThumbnail}\n" +
-                "  URL is null/empty: ${recipe.imageUrlThumbnail.isEmpty()}"
-            )
             val imageRequest = ImageRequest.Builder(LocalContext.current)
-                .data(recipe.imageUrlThumbnail)
+                .data(recipeImageModel(recipe.localImagePath, recipe.imageUrlThumbnail))
                 .crossfade(true)
-                .listener(
-                    onSuccess = { _, result -> timber.log.Timber.tag("LargeCard").d("✅ Image loading SUCCESS: ${recipe.imageUrlThumbnail}") },
-                    onError = { _, result -> timber.log.Timber.tag("LargeCard").e("❌ Image loading ERROR: ${recipe.imageUrlThumbnail}, error: ${result.throwable}") },
-                    onCancel = { timber.log.Timber.tag("LargeCard").d("⏸️ Image loading CANCELLED: ${recipe.imageUrlThumbnail}") }
-                )
                 .build()
 
             AsyncImage(

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipeListCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipeListCard.kt
@@ -37,8 +37,8 @@ import coil3.request.crossfade
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.domain.model.RecipePreview
 import com.tenmilelabs.chefai.core.ui.preview.RecipePreviewProvider
+import com.tenmilelabs.chefai.core.ui.recipeImageModel
 import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
-import timber.log.Timber
 import java.util.UUID
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -62,17 +62,9 @@ fun RecipeListCard(
             modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_small)),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Log image loading attempt
-            Timber.tag("RecipeListCard").d(
-                "🖼️ RecipeListCard loading image:\n" +
-                "  Recipe: ${recipe.title}\n" +
-                "  Image URL: ${recipe.imageUrlThumbnail}\n" +
-                "  URL is null: ${recipe.imageUrlThumbnail.isEmpty()}"
-            )
-
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(recipe.imageUrlThumbnail)
+                    .data(recipeImageModel(recipe.localImagePath, recipe.imageUrlThumbnail))
                     .crossfade(true)
                     .build(),
                 placeholder = painterResource(R.drawable.ic_img_placeholder),

--- a/app/src/main/java/com/tenmilelabs/chefai/home/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/home/ui/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.auth.domain.SessionManager
 import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
 import com.tenmilelabs.chefai.core.domain.model.RecipePreview
+import com.tenmilelabs.chefai.core.ui.recipeImageModel
 import com.tenmilelabs.chefai.core.util.WhileUiSubscribed
 import com.tenmilelabs.chefai.home.data.model.ComponentModel
 import com.tenmilelabs.chefai.home.domain.repository.HomeLayoutRepository
@@ -175,9 +176,8 @@ class HomeViewModel @Inject constructor(
      */
     private fun prefetchImages(recipes: List<RecipePreview>) {
         recipes.forEach { recipe ->
-            imageLoader.enqueue(
-                ImageRequest.Builder(appContext).data(recipe.imageUrlThumbnail).build()
-            )
+            val model = recipeImageModel(recipe.localImagePath, recipe.imageUrlThumbnail) ?: return@forEach
+            imageLoader.enqueue(ImageRequest.Builder(appContext).data(model).build())
         }
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/SaveImportedDraft.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/SaveImportedDraft.kt
@@ -12,13 +12,18 @@ import javax.inject.Inject
  * Persists a scraped [RecipeDraft] so the editor can pick it up by id after navigation.
  *
  * Shared by both import entry points — the URL screen and the browser fallback — which must hand
- * off to the editor identically.
+ * off to the editor identically. Also where the draft's hero image is downloaded and cached
+ * on-device (see [CacheRecipeImage]) — the editor loads the draft once on init rather than
+ * observing it, so the image has to be in place *before* the draft is written, not raced in
+ * afterward.
  */
 class SaveImportedDraft @Inject constructor(
     private val recipeDraftDao: RecipeDraftDao,
+    private val cacheRecipeImage: CacheRecipeImage,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend operator fun invoke(draft: RecipeDraft) = withContext(ioDispatcher) {
-        recipeDraftDao.saveDraft(draft.toRecipeDraftEntity())
+        val localImagePath = cacheRecipeImage(draft.recipeId, draft.imageUrl)
+        recipeDraftDao.saveDraft(draft.copy(localImagePath = localImagePath).toRecipeDraftEntity())
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
@@ -62,6 +62,7 @@ import com.tenmilelabs.chefai.core.ui.components.InfoChip
 import com.tenmilelabs.chefai.core.ui.components.InfoChipType
 import com.tenmilelabs.chefai.core.ui.components.RecipeTimeRow
 import com.tenmilelabs.chefai.core.ui.preview.RecipeData
+import com.tenmilelabs.chefai.core.ui.recipeImageModel
 import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
 import com.tenmilelabs.chefai.core.util.EmptyContent
 import com.tenmilelabs.chefai.core.util.LoadingContent
@@ -209,18 +210,8 @@ fun RecipeDetailsContent(
                 }
             }
 
-            // Log image loading attempt
-            Timber.tag("RecipeDetailsScreen").d(
-                "🖼️ RecipeDetailsScreen loading image:\n" +
-                "  Recipe: ${recipe.title}\n" +
-                "  Main Image URL: ${recipe.imageUrl}\n" +
-                "  Thumbnail URL: ${recipe.imageUrlThumbnail}\n" +
-                "  Main URL is null/empty: ${recipe.imageUrl.isEmpty()}\n" +
-                "  Thumbnail URL is null/empty: ${recipe.imageUrlThumbnail.isEmpty()}"
-            )
-
             AsyncImage(
-                model = recipe.imageUrl,
+                model = recipeImageModel(recipe.localImagePath, recipe.imageUrl),
                 placeholder = painterResource(R.drawable.ic_img_placeholder),
                 error = painterResource(R.drawable.ic_img_error),
                 contentDescription = stringResource(R.string.recipe_image_content_description),

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/EditorFieldModels.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/EditorFieldModels.kt
@@ -10,6 +10,8 @@ data class RecipeFields(
     val description: String = "",
     val imageUrl: String = "",
     val selectedImageUri: String? = null,
+    /** On-device copy of [imageUrl], if cached at import time; cleared when the user edits [imageUrl]. */
+    val localImagePath: String? = null,
     val prepTimeMinutes: String = "",
     val cookTimeMinutes: String = "",
     val servings: String = "",

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorReducer.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorReducer.kt
@@ -53,16 +53,18 @@ object RecipeEditorReducer {
             recipeFields = state.recipeFields.copy(externalUrl = action.url)
         ).markDirty()
 
+        // localImagePath is cleared alongside the field it was cached for — otherwise the user
+        // keeps seeing the stale on-device copy from before their edit.
         is EditorAction.ImageUrlChanged -> state.copy(
-            recipeFields = state.recipeFields.copy(imageUrl = action.url)
+            recipeFields = state.recipeFields.copy(imageUrl = action.url, localImagePath = null)
         ).markDirty()
 
         is EditorAction.ImageSelected -> state.copy(
-            recipeFields = state.recipeFields.copy(selectedImageUri = action.uri)
+            recipeFields = state.recipeFields.copy(selectedImageUri = action.uri, localImagePath = null)
         ).markDirty()
 
         is EditorAction.ClearImage -> state.copy(
-            recipeFields = state.recipeFields.copy(selectedImageUri = null)
+            recipeFields = state.recipeFields.copy(selectedImageUri = null, localImagePath = null)
         ).markDirty()
 
         // --- Ingredients ---
@@ -277,6 +279,7 @@ fun RecipeEditorState.toRecipeDraft(): RecipeDraft = RecipeDraft(
     description = recipeFields.description,
     imageUrl = recipeFields.imageUrl,
     selectedImageUri = recipeFields.selectedImageUri,
+    localImagePath = recipeFields.localImagePath,
     prepTimeMinutes = recipeFields.prepTimeMinutes,
     cookTimeMinutes = recipeFields.cookTimeMinutes,
     servings = recipeFields.servings,

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModel.kt
@@ -187,6 +187,7 @@ class RecipeEditorViewModel @Inject constructor(
                         description = draft.description,
                         imageUrl = draft.imageUrl,
                         selectedImageUri = draft.selectedImageUri,
+                        localImagePath = draft.localImagePath,
                         prepTimeMinutes = draft.prepTimeMinutes,
                         cookTimeMinutes = draft.cookTimeMinutes,
                         servings = draft.servings,

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandlerTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandlerTest.kt
@@ -6,6 +6,7 @@ import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +22,7 @@ class AccountSwitchHandlerTest {
     private lateinit var database: ChefAIDataBase
     private lateinit var recipeDao: FakeRecipeDao
     private lateinit var userDao: FakeUserDao
+    private lateinit var recipeImageStore: RecipeImageStore
     private lateinit var handler: AccountSwitchHandler
 
     @Before
@@ -29,11 +31,13 @@ class AccountSwitchHandlerTest {
         database = mockk(relaxed = true)
         recipeDao = FakeRecipeDao()
         userDao = FakeUserDao()
+        recipeImageStore = mockk(relaxed = true)
         handler = AccountSwitchHandler(
             securePreferences = securePreferences,
             database = database,
             recipeDao = recipeDao,
-            userDao = userDao
+            userDao = userDao,
+            recipeImageStore = recipeImageStore,
         )
     }
 
@@ -69,6 +73,7 @@ class AccountSwitchHandlerTest {
         assertThat(cleared).isEqualTo(AccountSwitchOutcome.CLEARED_DATABASE)
         assertThat(securePreferences.getStoredCurrentUserId().first()).isEqualTo(newUserId)
         coVerify(exactly = 1) { database.clearAllTables() }
+        coVerify(exactly = 1) { recipeImageStore.deleteAll() }
     }
 
     @Test
@@ -85,5 +90,6 @@ class AccountSwitchHandlerTest {
         assertThat(outcome).isEqualTo(AccountSwitchOutcome.PRESERVED_ANONYMOUS_DATA)
         assertThat(securePreferences.getStoredCurrentUserId().first()).isEqualTo(newUserId)
         coVerify(exactly = 0) { database.clearAllTables() }
+        coVerify(exactly = 0) { recipeImageStore.deleteAll() }
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/domain/SessionManagerTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/domain/SessionManagerTest.kt
@@ -21,6 +21,7 @@ import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.data.local.util.SyncState
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncManager
 import io.mockk.coVerify
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -88,7 +89,8 @@ class SessionManagerTest {
             securePreferences = fakeSecurePreferences,
             database = mockDatabase,
             recipeDao = fakeRecipeDao,
-            userDao = fakeUserDao
+            userDao = fakeUserDao,
+            recipeImageStore = mockk<RecipeImageStore>(relaxed = true),
         )
 
         // Create SessionManager with test scope

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/ui/LoginViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/ui/LoginViewModelTest.kt
@@ -21,6 +21,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeMealPlanDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncManager
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,7 +65,8 @@ class LoginViewModelTest {
                 securePreferences = fakeSecurePreferences,
                 database = mockk<ChefAIDataBase>(relaxed = true),
                 recipeDao = fakeRecipeDao,
-                userDao = fakeUserDao
+                userDao = fakeUserDao,
+                recipeImageStore = mockk<RecipeImageStore>(relaxed = true),
             ),
             accountUpgradeUseCaseProvider = {
                 AccountUpgradeUseCase(

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/ui/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/ui/RegisterViewModelTest.kt
@@ -21,6 +21,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncManager
 import com.tenmilelabs.chefai.core.util.MainCoroutineRule
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -63,7 +64,8 @@ class RegisterViewModelTest {
                 securePreferences = fakeSecurePreferences,
                 database = mockk<ChefAIDataBase>(relaxed = true),
                 recipeDao = fakeRecipeDao,
-                userDao = fakeUserDao
+                userDao = fakeUserDao,
+                recipeImageStore = mockk<RecipeImageStore>(relaxed = true),
             ),
             accountUpgradeUseCaseProvider = {
                 AccountUpgradeUseCase(

--- a/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
@@ -18,6 +18,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeTagCrossRefDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.sync.FakeSyncManager
 import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,7 +59,8 @@ fun createTestSessionManager(
             securePreferences = fakeSecurePreferences,
             database = mockk<ChefAIDataBase>(relaxed = true),
             recipeDao = FakeRecipeDao(),
-            userDao = fakeUserDao
+            userDao = fakeUserDao,
+            recipeImageStore = mockk<RecipeImageStore>(relaxed = true),
         ),
         accountUpgradeUseCaseProvider = {
             AccountUpgradeUseCase(
@@ -101,7 +103,8 @@ fun createRealSessionManagerWithFakes(
             securePreferences = fakeSecurePreferences,
             database = mockk<ChefAIDataBase>(relaxed = true),
             recipeDao = FakeRecipeDao(),
-            userDao = fakeUserDao
+            userDao = fakeUserDao,
+            recipeImageStore = mockk<RecipeImageStore>(relaxed = true),
         ),
         accountUpgradeUseCaseProvider = {
             AccountUpgradeUseCase(

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
@@ -45,6 +45,7 @@ import com.tenmilelabs.chefai.core.testutil.testSteps3
 import com.tenmilelabs.chefai.core.testutil.testTags
 import com.tenmilelabs.chefai.core.testutil.testUser
 import com.tenmilelabs.chefai.recipes.data.network.FakeApiService
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -107,7 +108,8 @@ class DefaultRecipeRepositoryTest {
                 securePreferences = fakeSecurePreferences,
                 database = mockk<ChefAIDataBase>(relaxed = true),
                 recipeDao = accountSwitchRecipeDao,
-                userDao = fakeUserDao
+                userDao = fakeUserDao,
+                recipeImageStore = mockk<RecipeImageStore>(relaxed = true),
             ),
             accountUpgradeUseCaseProvider = {
                 AccountUpgradeUseCase(

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/ImportRecipeViewModelTest.kt
@@ -10,7 +10,9 @@ import com.tenmilelabs.chefai.core.util.MainCoroutineRule
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage
 import com.tenmilelabs.chefai.recipes.domain.usecase.SaveImportedDraft
+import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -45,7 +47,11 @@ class ImportRecipeViewModelTest {
         }
         return ImportRecipeViewModel(
             recipeImporter = recipeImporter,
-            saveImportedDraft = SaveImportedDraft(recipeDraftDao, mainCoroutineRule.testDispatcher),
+            saveImportedDraft = SaveImportedDraft(
+                recipeDraftDao,
+                mockk<CacheRecipeImage>(relaxed = true),
+                mainCoroutineRule.testDispatcher,
+            ),
             savedStateHandle = savedStateHandle,
         )
     }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/urlimport/browser/BrowserImportViewModelTest.kt
@@ -10,7 +10,9 @@ import com.tenmilelabs.chefai.core.util.MainCoroutineRule
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeDraft
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage
 import com.tenmilelabs.chefai.recipes.domain.usecase.SaveImportedDraft
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -44,7 +46,11 @@ class BrowserImportViewModelTest {
         }
         return BrowserImportViewModel(
             recipeImporter = recipeImporter,
-            saveImportedDraft = SaveImportedDraft(recipeDraftDao, mainCoroutineRule.testDispatcher),
+            saveImportedDraft = SaveImportedDraft(
+                recipeDraftDao,
+                mockk<CacheRecipeImage>(relaxed = true),
+                mainCoroutineRule.testDispatcher,
+            ),
             savedStateHandle = savedStateHandle,
         )
     }


### PR DESCRIPTION
## Summary
Third of 4 stacked PRs fixing #130. Based on #134 (2/4) — review that first (and #133, 1/4); this PR's diff is only what's new on top of them.

This is the PR where the feature actually starts working end-to-end — it connects PR 1/4's fetch capability to PR 2/4's storage column.

- **`SaveImportedDraft`** now calls `CacheRecipeImage` and persists the resulting `localImagePath` on the draft. This happens synchronously, before the draft is written — the editor loads a draft once on init rather than observing it, so the image has to be in place before that read, not raced in afterward.
- **New `recipeImageModel(localImagePath, remoteUrl)`** helper: prefers the on-device copy, falls back to the remote URL, returns `null` instead of an empty string (which fixes a pre-existing Coil 3 crash on `""` for the three render call sites that weren't already guarding it — gotcha #1). Wired into `RecipeListCard`, `LargeCard`, `RecipeDetailsScreen`, and `HomeViewModel`'s prefetch. Also removes the ad-hoc emoji `Timber` debug logging that was scaffolding for diagnosing #130.
- **`RecipeEditorReducer`** nulls `localImagePath` whenever the user changes the image URL, picks their own photo, or clears the image — so they never keep seeing a stale cached file after editing it away.
- **`AccountSwitchHandler`** now wipes the on-device image cache alongside the local DB wipe on account switch.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — 426 passed, 0 failed
- [x] `./gradlew :app:connectedDebugAndroidTest` — 37 passed, 0 failed (full instrumented suite, confirming no regressions with the feature actually wired live)
- [x] Full compile including Hilt DI graph validation
- [ ] Manual E2E (Food Network + Serious Eats import, image renders on list card and details screen, survives airplane mode) — recommend doing this after this PR lands, since it's the first point the feature is observable in the running app

Stacked on #134. Next: #130-4 (docs — ADR-010 Decision 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)