### PR TITLE
Recipe import: log the WebView image tier's timeout/failure outcome

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/WebViewImageFetcher.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/WebViewImageFetcher.kt
@@ -37,22 +37,34 @@ class WebViewImageFetcher @Inject constructor(
                 applyScraperHardening()
                 webViewClient = ScraperWebViewClient()
             }
+            // Hoisted out of the timeout block so the log after it can tell an explicit JS-side
+            // failure apart from simply running out of budget — both silently returned `null`
+            // before, which made this tier's failures invisible in the field.
+            var jsReportedError = false
 
             try {
-                withTimeoutOrNull(budget) {
+                val bytes = withTimeoutOrNull(budget) {
                     webView.loadUrl(imageUrl)
                     var result: ByteArray? = null
-                    var failed = false
-                    while (result == null && !failed) {
+                    while (result == null && !jsReportedError) {
                         delay(SNAPSHOT_INTERVAL)
                         when (val state = webView.awaitImageDataUrl()) {
                             null, "pending" -> Unit
-                            "error" -> failed = true
+                            "error" -> jsReportedError = true
                             else -> result = state.toImageBytesOrNull()
                         }
                     }
                     result
                 }
+                when {
+                    bytes != null ->
+                        Timber.d("Rendered image fetch succeeded for %s (%d bytes)", imageUrl, bytes.size)
+                    jsReportedError ->
+                        Timber.w("Rendered image fetch's in-page script reported failure for %s", imageUrl)
+                    else ->
+                        Timber.w("Rendered image fetch timed out after %s for %s", budget, imageUrl)
+                }
+                bytes
             } catch (e: Exception) {
                 Timber.w(e, "Rendered image fetch failed for %s", imageUrl)
                 null


### PR DESCRIPTION
## Summary
Small follow-up, based cleanly on `main` (not stacked). Pushed to `claude/130-2-3-catchup` while investigating a user-reported bug (imported image shows on the recipe list but not the details screen) — landed about 20 minutes after #137 was merged, so it never made it into `main`. Cherry-picked here rather than left orphaned on a post-merge branch.

Couldn't reproduce the original report after several attempts (fresh view, navigate-away-and-back, cold restart all rendered correctly, verified directly against the on-device DB row and file), but found a real observability gap along the way: `withTimeoutOrNull` silently returns `null` on budget expiry, so a WebView-tier timeout was indistinguishable from an explicit JS-side failure — both were completely unlogged. Next time this reproduces, logcat will say which one happened.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — compiles clean
- [x] `./gradlew :app:connectedDebugAndroidTest` (WebViewImageFetcherTest) — 3 passed, 0 failed
- [x] Diff verified clean against current `main` (1 file, this file only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)