### PR TITLE
Recipe import: preserve cached image path across sync pulls

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
@@ -350,7 +350,10 @@ class SyncOrchestrator @Inject constructor(
     private suspend fun upsertRecipeAggregate(syncRecipe: SyncRecipeDto) {
         val recipeId = UUID.fromString(syncRecipe.uuid)
 
-        recipeDao.upsertRecipe(syncRecipe.toRecipeEntity())
+        // The DTO never carries the device-local cached-image path (see SyncMapper.toRecipeEntity) —
+        // read back whatever this device already has so this upsert doesn't wipe it.
+        val existingLocalImagePath = recipeDao.getRecipeById(recipeId)?.localImagePath
+        recipeDao.upsertRecipe(syncRecipe.toRecipeEntity(existingLocalImagePath))
 
         recipeStepDao.deleteAllForRecipe(recipeId)
         recipeStepDao.upsertAll(syncRecipe.toStepEntities())

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapper.kt
@@ -97,12 +97,19 @@ fun SyncIngredientDto.toIngredientEntity(): IngredientEntity = IngredientEntity(
     syncState = SyncState.SYNCED
 )
 
-fun SyncRecipeDto.toRecipeEntity(): RecipeEntity = RecipeEntity(
+/**
+ * [localImagePath] isn't part of [SyncRecipeDto] — it's device-local and never travels through
+ * sync (see ADR-010 Decision 6) — so the caller must pass through whatever this device already had
+ * for the row, or a pull immediately after caching an image (e.g. the post-mutation push/pull that
+ * follows every import) overwrites it back to null via this entity's full-row upsert.
+ */
+fun SyncRecipeDto.toRecipeEntity(localImagePath: String?): RecipeEntity = RecipeEntity(
     uuid = UUID.fromString(uuid),
     title = title,
     description = description,
     imageUrl = imageUrl,
     imageUrlThumbnail = imageUrlThumbnail,
+    localImagePath = localImagePath,
     prepTimeMinutes = prepTimeMinutes,
     cookTimeMinutes = cookTimeMinutes,
     servings = servings,

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
@@ -424,6 +424,27 @@ class SyncOrchestratorTest {
     }
 
     @Test
+    fun `pull preserves the device-local cached image path, which the server never sends`() = runTest(testDispatcher) {
+        val existingRecipe = createDirtyRecipe(uuid = recipeId1, syncState = SyncState.SYNCED)
+            .copy(localImagePath = "/data/user/0/com.tenmilelabs.chefai/files/recipe_images/$recipeId1")
+        recipeDao.upsertRecipe(existingRecipe)
+
+        // The DTO has no localImagePath field at all — this is what the server sends back for
+        // every recipe, cached or not.
+        val serverRecipe = createSyncRecipeDto(uuid = recipeId1, title = "Updated Title", updatedAt = 5000L)
+        syncNetworkDataSource.pullResponses.addLast(
+            SyncPullResponse(recipes = listOf(serverRecipe), serverTimestamp = 5000L, hasMore = false)
+        )
+
+        syncOrchestrator.sync()
+
+        val updatedRecipe = recipeDao.getRecipeById(recipeId1)!!
+        assertThat(updatedRecipe.title).isEqualTo("Updated Title")
+        assertThat(updatedRecipe.localImagePath)
+            .isEqualTo("/data/user/0/com.tenmilelabs.chefai/files/recipe_images/$recipeId1")
+    }
+
+    @Test
     fun `pull server wins when local is PENDING and server is newer`() = runTest(testDispatcher) {
         val localRecipe = createDirtyRecipe(uuid = recipeId1, title = "Local Edit", updatedAt = 1000L)
         recipeDao.upsertRecipe(localRecipe)

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapperTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapperTest.kt
@@ -214,7 +214,7 @@ class SyncMapperTest {
 
     @Test
     fun `toRecipeEntity maps DTO fields correctly and sets syncState to SYNCED`() {
-        val entity = syncRecipeDto.toRecipeEntity()
+        val entity = syncRecipeDto.toRecipeEntity(localImagePath = null)
 
         assertThat(entity.uuid).isEqualTo(recipeId)
         assertThat(entity.title).isEqualTo("Server Recipe")
@@ -230,6 +230,13 @@ class SyncMapperTest {
         assertThat(entity.updatedAt).isEqualTo(2000000L)
         assertThat(entity.deletedAt).isNull()
         assertThat(entity.syncState).isEqualTo(SyncState.SYNCED)
+    }
+
+    @Test
+    fun `toRecipeEntity passes the given localImagePath through untouched`() {
+        val entity = syncRecipeDto.toRecipeEntity(localImagePath = "/data/user/0/com.tenmilelabs.chefai/files/recipe_images/abc")
+
+        assertThat(entity.localImagePath).isEqualTo("/data/user/0/com.tenmilelabs.chefai/files/recipe_images/abc")
     }
 
     @Test
@@ -292,7 +299,7 @@ class SyncMapperTest {
     fun `round-trip preserves recipe data`() {
         // Entity -> DTO -> Entity
         val dto = recipeEntity.toSyncDto(stepEntities, ingredientEntities, tagCrossRefs, labelCrossRefs)
-        val roundTrippedEntity = dto.toRecipeEntity()
+        val roundTrippedEntity = dto.toRecipeEntity(localImagePath = null)
 
         assertThat(roundTrippedEntity.uuid).isEqualTo(recipeEntity.uuid)
         assertThat(roundTrippedEntity.title).isEqualTo(recipeEntity.title)
@@ -340,7 +347,7 @@ class SyncMapperTest {
     @Test
     fun `toRecipeEntity with deletedAt preserves the value`() {
         val deletedDto = syncRecipeDto.copy(deletedAt = 3000000L)
-        val entity = deletedDto.toRecipeEntity()
+        val entity = deletedDto.toRecipeEntity(localImagePath = null)
 
         assertThat(entity.deletedAt).isEqualTo(3000000L)
     }
@@ -350,7 +357,7 @@ class SyncMapperTest {
         RecipePrivacy.entries.forEach { privacy ->
             val entityWithPrivacy = recipeEntity.copy(privacy = privacy)
             val dto = entityWithPrivacy.toSyncDto(emptyList(), emptyList(), emptyList(), emptyList())
-            val roundTripped = dto.toRecipeEntity()
+            val roundTripped = dto.toRecipeEntity(localImagePath = null)
 
             assertThat(dto.privacy).isEqualTo(privacy.name)
             assertThat(roundTripped.privacy).isEqualTo(privacy)


### PR DESCRIPTION
## Summary
- Fixes a live regression found while manually re-testing #130: the post-mutation sync debounce pushes a newly-saved recipe and pulls it back within ~5 seconds, and the pull's full-row `@Upsert` was silently wiping the just-cached `localImagePath` back to `null` — because `SyncRecipeDto` never carries that field (it's device-local, per ADR-010 Decision 6).
- Confirmed live via logcat on a real import: `localImagePath` was correctly written at save time, then clobbered to `null` exactly 5 seconds later by the pull that follows every push.
- `SyncRecipeDto.toRecipeEntity()` now takes `localImagePath` as an explicit parameter instead of silently defaulting it, and `SyncOrchestrator.upsertRecipeAggregate` reads back the row's current value before upserting so a pull can no longer erase it.

## Test plan
- [x] New regression test `pull preserves the device-local cached image path, which the server never sends` in `SyncOrchestratorTest`, reproducing the exact scenario through the real orchestration path (existing recipe with a local image path → pull response without one → path survives).
- [x] Updated the 4 existing `SyncMapperTest` call sites for the new required parameter, plus a dedicated `toRecipeEntity passes the given localImagePath through untouched` test.
- [x] `./gradlew :app:testDebugUnitTest` — 428/428 passing.
- [x] Verified live: rebuilt, reinstalled on-device, re-imported a bot-walled recipe (Serious Eats), confirmed the image now survives the sync cycle and renders on the details screen after navigating away and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)