### PR TITLE
Recipe images: backfill missing images on a second device (#132)

### DIFF
--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncScheduler.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncScheduler.kt
@@ -28,6 +28,10 @@ class FakeSyncScheduler : SyncScheduler {
         Timber.d("FakeSyncScheduler: schedulePeriodicSync (no-op)")
     }
 
+    override fun scheduleImageBackfill() {
+        Timber.d("FakeSyncScheduler: scheduleImageBackfill (no-op)")
+    }
+
     override fun cancelAllSync() {
         Timber.d("FakeSyncScheduler: cancelAllSync (no-op)")
     }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/di/TestDatabaseModule.kt
@@ -74,6 +74,9 @@ object TestDatabaseModule {
     fun provideRecipeDraftDao(database: ChefAIDataBase) = database.recipeDraftDao()
 
     @Provides
+    fun provideRecipeImageStateDao(database: ChefAIDataBase) = database.recipeImageStateDao()
+
+    @Provides
     fun provideBookmarkedRecipeDao(database: ChefAIDataBase) = database.bookmarkedRecipeDao()
 
     @Provides

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeImageBackfillDaoTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeImageBackfillDaoTest.kt
@@ -1,0 +1,168 @@
+package com.tenmilelabs.chefai.data.source.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
+import com.tenmilelabs.chefai.core.data.local.room.RecipeImageStateEntity
+import com.tenmilelabs.chefai.core.data.local.room.UserEntity
+import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
+import com.tenmilelabs.chefai.recipes.data.worker.MAX_IMAGE_BACKFILL_ATTEMPTS
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+private const val SCAN_LIMIT = 200
+
+/**
+ * Covers the SQL-side half of the image backfill: which rows the sweep is even willing to look at.
+ * The file-existence half lives in `RecipeImageBackfillTest` (JVM).
+ */
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class RecipeImageBackfillDaoTest {
+
+    private lateinit var database: ChefAIDataBase
+
+    private val testUser = UserEntity(
+        uuid = UuidV7Generator.newId(),
+        displayName = "Test User",
+        email = "test@test.com",
+        avatarUrl = "",
+        updatedAt = System.currentTimeMillis(),
+        deletedAt = null
+    )
+
+    private fun recipe(
+        imageUrl: String = "https://food.fnr.sndimg.com/hero.webp",
+        localImagePath: String? = null,
+        deletedAt: Long? = null,
+        updatedAt: Long = System.currentTimeMillis(),
+    ) = RecipeEntity(
+        uuid = UuidV7Generator.newId(),
+        title = "Recipe",
+        description = "",
+        imageUrl = imageUrl,
+        imageUrlThumbnail = imageUrl,
+        localImagePath = localImagePath,
+        prepTimeMinutes = 5,
+        cookTimeMinutes = 5,
+        servings = 1,
+        creatorId = testUser.uuid,
+        recipeExternalUrl = null,
+        updatedAt = updatedAt,
+        deletedAt = deletedAt,
+    )
+
+    private suspend fun candidates(): List<UUID> = database.recipeDao()
+        .getImageBackfillCandidates(MAX_IMAGE_BACKFILL_ATTEMPTS, SCAN_LIMIT)
+        .map { it.recipeId }
+
+    @Before
+    fun setup() = runTest {
+        database = Room.inMemoryDatabaseBuilder(getApplicationContext(), ChefAIDataBase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        database.userDao().upsertUser(testUser)
+    }
+
+    @After
+    fun tearDown() = database.close()
+
+    @Test
+    fun selectsARecipeThatHasNeverCachedItsImage() = runTest {
+        val recipe = recipe()
+        database.recipeDao().upsertRecipe(recipe)
+
+        assertEquals(listOf(recipe.uuid), candidates())
+    }
+
+    @Test
+    fun stillSelectsARecipeThatAlreadyHasAPath_soAMissingFileCanBeRepaired() = runTest {
+        // The query can't stat the filesystem, so it deliberately over-selects and the worker filters.
+        val recipe = recipe(localImagePath = "/files/recipe_images/whatever")
+        database.recipeDao().upsertRecipe(recipe)
+
+        assertEquals(listOf(recipe.uuid), candidates())
+    }
+
+    @Test
+    fun skipsAUserPickedPhoto() = runTest {
+        // No imageUrl means the image is the user's own: there is nothing to re-derive it from, and
+        // re-deriving would be wrong even if there were.
+        database.recipeDao().upsertRecipe(recipe(imageUrl = ""))
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun skipsASoftDeletedRecipe() = runTest {
+        database.recipeDao().upsertRecipe(recipe(deletedAt = System.currentTimeMillis()))
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun skipsARecipeThatHasExhaustedItsAttempts() = runTest {
+        val recipe = recipe()
+        database.recipeDao().upsertRecipe(recipe)
+        database.recipeImageStateDao().upsert(
+            RecipeImageStateEntity(recipe.uuid, MAX_IMAGE_BACKFILL_ATTEMPTS, 1L)
+        )
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun stillSelectsARecipeWithAttemptsRemaining() = runTest {
+        val recipe = recipe()
+        database.recipeDao().upsertRecipe(recipe)
+        database.recipeImageStateDao().upsert(
+            RecipeImageStateEntity(recipe.uuid, MAX_IMAGE_BACKFILL_ATTEMPTS - 1, 1L)
+        )
+
+        assertEquals(listOf(recipe.uuid), candidates())
+    }
+
+    @Test
+    fun returnsTheMostRecentlyUpdatedRecipesFirst() = runTest {
+        val older = recipe(updatedAt = 1_000L)
+        val newer = recipe(updatedAt = 2_000L)
+        database.recipeDao().upsertRecipe(older)
+        database.recipeDao().upsertRecipe(newer)
+
+        assertEquals(listOf(newer.uuid, older.uuid), candidates())
+    }
+
+    @Test
+    fun scanLimitBoundsTheNumberOfRowsExamined() = runTest {
+        repeat(5) { database.recipeDao().upsertRecipe(recipe()) }
+
+        val limited = database.recipeDao().getImageBackfillCandidates(
+            maxAttempts = MAX_IMAGE_BACKFILL_ATTEMPTS,
+            scanLimit = 2,
+        )
+
+        assertEquals(2, limited.size)
+    }
+
+    @Test
+    fun deletingARecipeCascadesToItsImageState() = runTest {
+        val recipe = recipe()
+        database.recipeDao().upsertRecipe(recipe)
+        database.recipeImageStateDao().upsert(RecipeImageStateEntity(recipe.uuid, 1, 1L))
+
+        database.recipeDao().deleteRecipe(recipe.uuid)
+
+        assertEquals(null, database.recipeImageStateDao().getByRecipeId(recipe.uuid))
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageCandidate
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithDetails
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithLabels
@@ -107,6 +108,36 @@ interface RecipeDao {
 
     @Query("UPDATE recipes SET deletedAt = :deletedAt, syncState = 'DELETED', updatedAt = :deletedAt WHERE uuid = :uuid")
     suspend fun softDelete(uuid: UUID, deletedAt: Long)
+
+    // --- Image backfill ---
+
+    /**
+     * Recipes that could still be missing their on-device image, newest first.
+     *
+     * `imageUrl != ''` is what keeps a user's own photo out of the sweep: a picked image has no
+     * source URL and so can never be re-derived, and the editor clears `imageUrl` when one is stored
+     * precisely so this predicate can tell the two apart (see ADR-011). Recipes that have already
+     * failed [maxAttempts] times are excluded so a permanently dead URL stops costing work.
+     *
+     * Whether the file is actually *present* isn't expressible in SQL, so this deliberately
+     * over-selects and the caller filters — see `RecipeImageBackfillWorker`.
+     */
+    @Query(
+        """
+        SELECT r.uuid AS recipeId, r.imageUrl AS imageUrl, r.localImagePath AS localImagePath
+        FROM recipes r
+        LEFT JOIN recipe_image_state s ON s.recipeId = r.uuid
+        WHERE r.deletedAt IS NULL
+          AND r.imageUrl != ''
+          AND COALESCE(s.attempts, 0) < :maxAttempts
+        ORDER BY r.updatedAt DESC
+        LIMIT :scanLimit
+        """
+    )
+    suspend fun getImageBackfillCandidates(maxAttempts: Int, scanLimit: Int): List<RecipeImageCandidate>
+
+    @Query("UPDATE recipes SET localImagePath = :localImagePath WHERE uuid = :uuid")
+    suspend fun updateLocalImagePath(uuid: UUID, localImagePath: String?)
 
     // --- Account upgrade queries ---
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/relations/RecipeImageCandidate.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/relations/RecipeImageCandidate.kt
@@ -1,0 +1,14 @@
+package com.tenmilelabs.chefai.core.data.local.room.relations
+
+import java.util.UUID
+
+/**
+ * The three columns the image backfill needs to decide whether a recipe's picture is missing and
+ * where to get it — a projection rather than the whole entity, since the sweep reads far more rows
+ * than it acts on.
+ */
+data class RecipeImageCandidate(
+    val recipeId: UUID,
+    val imageUrl: String,
+    val localImagePath: String?,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncManager.kt
@@ -10,6 +10,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.tenmilelabs.chefai.core.data.sync.worker.SyncWorker
+import com.tenmilelabs.chefai.recipes.data.worker.RecipeImageBackfillWorker
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.TimeUnit
@@ -28,6 +29,7 @@ class SyncManager @Inject constructor(
     companion object {
         const val SYNC_WORK_NAME = "recipe_sync"
         const val PERIODIC_SYNC_WORK_NAME = "recipe_periodic_sync"
+        const val IMAGE_BACKFILL_WORK_NAME = "recipe_image_backfill"
     }
 
     val syncStatus: StateFlow<SyncStatus> get() = syncStatusHolder.syncStatus
@@ -106,12 +108,26 @@ class SyncManager @Inject constructor(
     }
 
     /**
+     * Enqueue a sweep for recipe images missing on this device.
+     * KEEP, so a sync finishing while a sweep is already queued doesn't stack requests.
+     */
+    override fun scheduleImageBackfill() {
+        val request = OneTimeWorkRequestBuilder<RecipeImageBackfillWorker>()
+            .setConstraints(imageBackfillConstraints())
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_DELAY_SECONDS, TimeUnit.SECONDS)
+            .build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(IMAGE_BACKFILL_WORK_NAME, ExistingWorkPolicy.KEEP, request)
+    }
+
+    /**
      * Cancel all sync work (e.g., on logout).
      */
     override fun cancelAllSync() {
         val wm = WorkManager.getInstance(context)
         wm.cancelUniqueWork(SYNC_WORK_NAME)
         wm.cancelUniqueWork(PERIODIC_SYNC_WORK_NAME)
+        wm.cancelUniqueWork(IMAGE_BACKFILL_WORK_NAME)
     }
 
     private fun connectedConstraints() = Constraints.Builder()
@@ -120,6 +136,16 @@ class SyncManager @Inject constructor(
 
     private fun periodicSyncConstraints() = Constraints.Builder()
         .setRequiredNetworkType(NetworkType.CONNECTED)
+        .setRequiresCharging(true)
+        .build()
+
+    /**
+     * Stricter than every other constraint here. Backfill downloads whole images — up to
+     * `MAX_IMAGE_BYTES` each — and escalates to a `WebView` for the bot-walled ones, so it waits for
+     * a charger and a network the user isn't paying by the megabyte for.
+     */
+    private fun imageBackfillConstraints() = Constraints.Builder()
+        .setRequiredNetworkType(NetworkType.UNMETERED)
         .setRequiresCharging(true)
         .build()
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncScheduler.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncScheduler.kt
@@ -17,5 +17,14 @@ interface SyncScheduler {
     /** Cancels any queued sync and enqueues a new one immediately (user-initiated). */
     fun requestManualSync()
     fun schedulePeriodicSync()
+
+    /**
+     * Enqueues a sweep for recipe images this device is missing but a synced-from device already had.
+     *
+     * Constrained to a charger and unmetered network, unlike every other request here: the work is a
+     * burst of image downloads with an off-screen `WebView` behind some of them, and nobody is
+     * waiting on it.
+     */
+    fun scheduleImageBackfill()
     fun cancelAllSync()
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/worker/SyncWorker.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/worker/SyncWorker.kt
@@ -8,6 +8,7 @@ import com.tenmilelabs.chefai.auth.domain.SessionManager
 import com.tenmilelabs.chefai.auth.domain.model.UserSession
 import com.tenmilelabs.chefai.core.data.sync.SyncOrchestrator
 import com.tenmilelabs.chefai.core.data.sync.SyncStatus
+import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
 import com.tenmilelabs.chefai.core.data.sync.SyncStatusHolder
 import com.tenmilelabs.chefai.core.data.sync.network.SyncHttpException
 import dagger.assisted.Assisted
@@ -20,7 +21,8 @@ class SyncWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val syncOrchestrator: SyncOrchestrator,
     private val sessionManager: SessionManager,
-    private val syncStatusHolder: SyncStatusHolder
+    private val syncStatusHolder: SyncStatusHolder,
+    private val syncScheduler: SyncScheduler
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -41,6 +43,10 @@ class SyncWorker @AssistedInject constructor(
             val result = syncOrchestrator.sync()
             Timber.d("SyncWorker: Sync completed — $result")
             syncStatusHolder.emitStatus(SyncStatus.Synced(System.currentTimeMillis()))
+            // A pull can bring in recipes whose image only exists on the device that imported them.
+            // Enqueued rather than chained: backfill waits for a charger and unmetered data, and a
+            // chain would hold this sync's slot until those were satisfied.
+            syncScheduler.scheduleImageBackfill()
             Result.success()
         } catch (e: SyncHttpException) {
             if (e.statusCode == 401) {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageBackfillWorker.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageBackfillWorker.kt
@@ -1,0 +1,116 @@
+package com.tenmilelabs.chefai.recipes.data.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.tenmilelabs.chefai.core.data.local.room.RecipeImageStateEntity
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeImageStateDao
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageCandidate
+import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
+import com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+import java.io.File
+
+/** How many times a single recipe's image is retried before it is given up on for good. */
+internal const val MAX_IMAGE_BACKFILL_ATTEMPTS = 3
+
+/** Rows examined per run. Bounds the query, not the work — most rows are already resolved. */
+internal const val IMAGE_BACKFILL_SCAN_LIMIT = 200
+
+/** Images actually fetched per run, so one sweep can't pull tens of megabytes in a burst. */
+internal const val IMAGE_BACKFILL_BATCH = 10
+
+/**
+ * Fetches recipe images this device is missing but another one already has.
+ *
+ * A recipe arriving over sync carries only its remote `imageUrl`, never the importing device's
+ * cached copy — a local file path is meaningless on the wire (ADR-011). For most sources the URL is
+ * enough and the UI just hotlinks it, but the CDNs that made on-device caching necessary in the
+ * first place (Akamai on Food Network, Cloudflare on Serious Eats) refuse a plain HTTP client
+ * wherever it runs. So the second device re-derives the image the same way the first one did, with
+ * [CacheRecipeImage]'s HTTP-then-WebView ladder.
+ *
+ * Deliberately not on the pull path: spinning up a `WebView` inside the sync transaction would
+ * stretch every sync by seconds for something no one is waiting on. Deliberately not on the render
+ * path either — that would land the same spin-up mid-scroll. It runs on its own schedule, on a
+ * charger and off metered data, and until it does the UI degrades to hotlinking, which already works
+ * everywhere except the bot-walled minority.
+ */
+@HiltWorker
+class RecipeImageBackfillWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val recipeDao: RecipeDao,
+    private val recipeImageStateDao: RecipeImageStateDao,
+    private val cacheRecipeImage: CacheRecipeImage,
+    private val syncScheduler: SyncScheduler,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val candidates = recipeDao
+            .getImageBackfillCandidates(MAX_IMAGE_BACKFILL_ATTEMPTS, IMAGE_BACKFILL_SCAN_LIMIT)
+            .needingBackfill()
+
+        if (candidates.isEmpty()) {
+            Timber.d("Image backfill: nothing to do")
+            return Result.success()
+        }
+
+        val batch = candidates.take(IMAGE_BACKFILL_BATCH)
+        Timber.i("Image backfill: fetching %d of %d missing images", batch.size, candidates.size)
+
+        var restored = 0
+        for (candidate in batch) {
+            // Recorded before the fetch, not after: a run killed mid-WebView (the budget expiring,
+            // the charger unplugged, the process dying) must still count, or a URL that reliably
+            // hangs would be retried forever.
+            recordAttempt(candidate)
+
+            val storedPath = cacheRecipeImage(candidate.recipeId, candidate.imageUrl)
+            if (storedPath != null) {
+                recipeDao.updateLocalImagePath(candidate.recipeId, storedPath)
+                recipeImageStateDao.delete(candidate.recipeId)
+                restored++
+            }
+        }
+
+        Timber.i("Image backfill: restored %d of %d", restored, batch.size)
+
+        // More than one batch's worth outstanding — come back for the rest rather than waiting for
+        // the next sync, which might be a day away.
+        if (candidates.size > batch.size) {
+            syncScheduler.scheduleImageBackfill()
+        }
+        return Result.success()
+    }
+
+    private suspend fun recordAttempt(candidate: RecipeImageCandidate) {
+        val previous = recipeImageStateDao.getByRecipeId(candidate.recipeId)
+        recipeImageStateDao.upsert(
+            RecipeImageStateEntity(
+                recipeId = candidate.recipeId,
+                attempts = (previous?.attempts ?: 0) + 1,
+                lastAttemptAt = System.currentTimeMillis(),
+            )
+        )
+    }
+}
+
+/**
+ * Narrows the over-selected candidates from
+ * [RecipeDao.getImageBackfillCandidates] to those whose image is genuinely absent.
+ *
+ * A null [RecipeImageCandidate.localImagePath] is the never-cached case; a non-null path pointing at
+ * nothing is a file that has since been deleted, which this repairs. Split out from the worker so it
+ * is testable without WorkManager.
+ */
+internal fun List<RecipeImageCandidate>.needingBackfill(
+    fileExists: (String) -> Boolean = { File(it).exists() },
+): List<RecipeImageCandidate> = filter { candidate ->
+    val path = candidate.localImagePath
+    path == null || !fileExists(path)
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
@@ -11,6 +11,7 @@ import com.tenmilelabs.chefai.core.data.local.room.RecipeTagCrossRef
 import com.tenmilelabs.chefai.core.data.local.room.SourceClassificationEntity
 import com.tenmilelabs.chefai.core.data.local.room.TagEntity
 import com.tenmilelabs.chefai.core.data.local.room.UserEntity
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageCandidate
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithDetails
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithLabels
@@ -248,6 +249,22 @@ class FakeRecipeDao : RecipeDao {
                 updatedAt = deletedAt
             )
         }
+        triggerUpdate()
+    }
+
+    // --- Image backfill ---
+
+    override suspend fun getImageBackfillCandidates(
+        maxAttempts: Int,
+        scanLimit: Int
+    ): List<RecipeImageCandidate> = recipes.values
+        .filter { it.deletedAt == null && it.imageUrl.isNotEmpty() }
+        .sortedByDescending { it.updatedAt }
+        .take(scanLimit)
+        .map { RecipeImageCandidate(it.uuid, it.imageUrl, it.localImagePath) }
+
+    override suspend fun updateLocalImagePath(uuid: UUID, localImagePath: String?) {
+        recipes[uuid]?.let { recipes[uuid] = it.copy(localImagePath = localImagePath) }
         triggerUpdate()
     }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncManager.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncManager.kt
@@ -22,6 +22,9 @@ class FakeSyncManager : SyncScheduler {
     var periodicSyncCount = 0
         private set
 
+    var imageBackfillCount = 0
+        private set
+
     var cancelAllCount = 0
         private set
 
@@ -45,6 +48,10 @@ class FakeSyncManager : SyncScheduler {
         periodicSyncCount++
     }
 
+    override fun scheduleImageBackfill() {
+        imageBackfillCount++
+    }
+
     override fun cancelAllSync() {
         cancelAllCount++
     }
@@ -55,6 +62,7 @@ class FakeSyncManager : SyncScheduler {
         bookmarkSyncCount = 0
         manualSyncCount = 0
         periodicSyncCount = 0
+        imageBackfillCount = 0
         cancelAllCount = 0
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
@@ -33,6 +33,7 @@ class FakeSyncScheduler : SyncScheduler {
     override fun requestBookmarkSync() {}
     override fun requestManualSync() {}
     override fun schedulePeriodicSync() {}
+    override fun scheduleImageBackfill() {}
     override fun cancelAllSync() {}
 }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageBackfillTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageBackfillTest.kt
@@ -1,0 +1,83 @@
+package com.tenmilelabs.chefai.recipes.data.worker
+
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageCandidate
+import org.junit.Test
+import java.util.UUID
+
+private const val REMOTE_URL = "https://food.fnr.sndimg.com/hero.webp"
+
+/**
+ * Covers the half of the backfill the DAO query can't express — whether the file a row points at is
+ * actually on disk. The SQL-side predicates (dead URLs, user photos, soft-deleted rows) are covered
+ * by the DAO test in androidTest.
+ */
+class RecipeImageBackfillTest {
+
+    private fun candidate(
+        localImagePath: String? = null,
+        imageUrl: String = REMOTE_URL,
+    ) = RecipeImageCandidate(
+        recipeId = UUID.randomUUID(),
+        imageUrl = imageUrl,
+        localImagePath = localImagePath,
+    )
+
+    /** Stands in for the filesystem: every listed path exists, nothing else does. */
+    private fun existing(vararg paths: String): (String) -> Boolean = { it in paths }
+
+    @Test
+    fun `a recipe that has never been cached needs backfill`() {
+        val candidates = listOf(candidate(localImagePath = null))
+
+        val result = candidates.needingBackfill(existing())
+
+        assertThat(result).isEqualTo(candidates)
+    }
+
+    @Test
+    fun `a recipe whose image is on disk is left alone`() {
+        val candidates = listOf(candidate(localImagePath = "/files/recipe_images/a"))
+
+        val result = candidates.needingBackfill(existing("/files/recipe_images/a"))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `a recipe whose file was deleted underneath it is repaired`() {
+        // The row still points somewhere, but the bytes are gone — an account switch or a manual
+        // clear. Trusting the column alone would leave this recipe permanently pictureless.
+        val candidates = listOf(candidate(localImagePath = "/files/recipe_images/vanished"))
+
+        val result = candidates.needingBackfill(existing())
+
+        assertThat(result).isEqualTo(candidates)
+    }
+
+    @Test
+    fun `only the rows actually missing an image are returned`() {
+        val cached = candidate(localImagePath = "/files/recipe_images/present")
+        val neverCached = candidate(localImagePath = null)
+        val stale = candidate(localImagePath = "/files/recipe_images/gone")
+
+        val result = listOf(cached, neverCached, stale)
+            .needingBackfill(existing("/files/recipe_images/present"))
+
+        assertThat(result).containsExactly(neverCached, stale).inOrder()
+    }
+
+    @Test
+    fun `an empty candidate list yields no work`() {
+        assertThat(emptyList<RecipeImageCandidate>().needingBackfill(existing())).isEmpty()
+    }
+
+    @Test
+    fun `the batch cap bounds how many images one run downloads`() {
+        val candidates = List(IMAGE_BACKFILL_BATCH * 3) { candidate() }
+
+        val batch = candidates.needingBackfill(existing()).take(IMAGE_BACKFILL_BATCH)
+
+        assertThat(batch).hasSize(IMAGE_BACKFILL_BATCH)
+    }
+}


### PR DESCRIPTION
Second of four PRs for Stage 1 of #132. **Stacked on #140** — review that first; this PR's base is `claude/132-1-user-picked-images` so the diff shows only the backfill work.

## Why

A recipe arriving over sync carries only its remote `imageUrl` — the importing device's cached copy is a local file path, meaningless on the wire. For most sources that's fine and the UI hotlinks it. But the CDNs that made on-device caching necessary in the first place (Akamai on Food Network, Cloudflare on Serious Eats) refuse a plain HTTP client *wherever it runs*, so today the second device shows a broken image forever.

This is #132's Option C, on a proper channel: re-derive with the same `CacheRecipeImage` HTTP→WebView ladder the importing device already used.

## Placement

**Not on the pull path** — a `WebView` spin-up inside the sync transaction would stretch every sync by seconds for something nobody is waiting on. **Not on the render path** either, which lands the same spin-up mid-scroll.

It gets its own work request, constrained to **charger + unmetered**. That's stricter than anything else in `SyncManager`, because it's the only work that downloads whole images in a burst. Until it runs the UI degrades to hotlinking, which already works everywhere except the bot-walled minority.

## Bounding the cost

- **`imageUrl != ''` excludes user-picked photos entirely.** They have no source to re-derive from — which is exactly why #140 made the editor clear `imageUrl` when it stores one.
- **Attempts are recorded before the fetch, not after.** A run killed mid-WebView (budget expiring, charger unplugged, process death) still counts. Otherwise a URL that reliably hangs is retried forever. Three strikes and the recipe is left alone for good.
- **10 images per run** from a 200-row scan; the worker re-enqueues if more remain rather than waiting for a sync that might be a day away.

## A deliberate over-select

The DAO query returns rows that *already* have a `localImagePath`. Whether the file is on disk isn't expressible in SQL, so `needingBackfill` filters in Kotlin. That's what repairs a row whose bytes were deleted underneath it — trusting the column alone would leave such a recipe permanently pictureless.

## Notes

- `SyncScheduler` gains `scheduleImageBackfill()`; `cancelAllSync` cancels it too, so logout stops it. All three existing fakes are updated.
- Anonymous users never pull and `SyncWorker` already returns early for them, so backfill correctly never fires with nothing to do.
- Per gotcha #21, `TestDatabaseModule` needed the new DAO mirrored or every instrumented test fails to compile — which is exactly what happened mid-development.

## Test plan

- 442 unit tests pass (`:app:testDebugUnitTest`) — 6 new covering the file-existence filter, including the deleted-file repair case and the batch cap.
- 9 new instrumented DAO tests pass on a Pixel 6 Pro / API 36 emulator, covering every SQL-side predicate (user photos, soft-deleted rows, exhausted attempts, ordering, scan limit) plus the `recipes` → `recipe_image_state` FK cascade.

Manual: import a bot-walled recipe on device A and sync; on device B clear `files/recipe_images`, force a pull, then run the worker with the emulator on charge + Wi-Fi.