### PR TITLE
Recipe images: reclaim cached files on delete and account switch (#132)

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandler.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandler.kt
@@ -48,7 +48,15 @@ class AccountSwitchHandler @Inject constructor(
                 // We intentionally keep the UserEntity and its meal plans: all queries
                 // filter by userId so they're invisible to other users, and when the
                 // original user logs back in their local plans will still be there.
+                //
+                // Ids are collected first because deleteRecipesForUser is a bulk SQL delete — after
+                // it runs there is no way to tell which images belonged to the departing account.
+                // Without this the previous user's photos stay readable on a shared device: the rows
+                // go but the files in recipe_images/ do not. deleteAll() would be wrong here, since
+                // this branch exists precisely to preserve the anonymous session's own images.
+                val departingRecipeIds = recipeDao.getRecipeIdsForUser(previousUserId)
                 recipeDao.deleteRecipesForUser(previousUserId)
+                departingRecipeIds.forEach { recipeImageStore.delete(it) }
                 AccountSwitchOutcome.PRESERVED_ANONYMOUS_DATA
             }
             else -> {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepository.kt
@@ -15,6 +15,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.TagDao
 import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
 import com.tenmilelabs.chefai.core.domain.model.Recipe
 import com.tenmilelabs.chefai.core.domain.model.RecipePreview
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import com.tenmilelabs.chefai.recipes.data.mapper.toCrossRef
 import com.tenmilelabs.chefai.recipes.data.mapper.toDomain
 import com.tenmilelabs.chefai.recipes.data.mapper.toRecipePreviewDomain
@@ -49,6 +50,7 @@ class DefaultRecipeRepository @Inject constructor(
     private val recipeLabelDao: RecipeLabelCrossRefDao,
     private val networkDataSource: RecipeNetworkDataSource,
     private val sessionManager: SessionManager,
+    private val recipeImageStore: RecipeImageStore,
     private val syncManager: SyncScheduler) : RecipesRepository {
 
     override fun getRecipesPreviewStream(): Flow<List<RecipePreview>> {
@@ -261,11 +263,26 @@ class DefaultRecipeRepository @Inject constructor(
 
     override suspend fun deleteRecipe(recipeId: UUID) {
         recipeDao.deleteRecipe(recipeId)
+        recipeImageStore.delete(recipeId)
         syncManager.requestMutationSync()
     }
 
+    /**
+     * Marks the recipe deleted and reclaims its cached image.
+     *
+     * The image goes now rather than on some later hard delete because there is no later hard delete:
+     * nothing in the app ever removes a soft-deleted row, so waiting would mean keeping up to
+     * `MAX_IMAGE_BYTES` per deleted recipe forever. Deletion has no undo (#129), and the row is gone
+     * from every query the moment `deletedAt` is set.
+     *
+     * For a scraped image this costs nothing — the backfill can re-derive it from `imageUrl` if the
+     * recipe ever comes back. For a user-picked photo it is irreversible, since there is no source to
+     * re-derive from. That asymmetry is the clearest argument for uploading user-authored images,
+     * which is Stage 2 of #132; see ADR-011.
+     */
     override suspend fun softDeleteRecipe(recipeId: UUID) {
         recipeDao.softDelete(recipeId, System.currentTimeMillis())
+        recipeImageStore.delete(recipeId)
         syncManager.requestMutationSync()
     }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandlerTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/auth/domain/AccountSwitchHandlerTest.kt
@@ -3,6 +3,7 @@ package com.tenmilelabs.chefai.auth.domain
 import com.google.common.truth.Truth.assertThat
 import com.tenmilelabs.chefai.auth.data.local.FakeSecurePreferences
 import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDao
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeUserDao
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import java.util.UUID
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AccountSwitchHandlerTest {
@@ -92,4 +94,40 @@ class AccountSwitchHandlerTest {
         coVerify(exactly = 0) { database.clearAllTables() }
         coVerify(exactly = 0) { recipeImageStore.deleteAll() }
     }
+
+    @Test
+    fun `switching away deletes the departing account's images but not the anonymous ones`() = runTest {
+        val previousUserId = UuidV7Generator.newId()
+        val anonymousUserId = UuidV7Generator.newId()
+        val newUserId = UuidV7Generator.newId()
+        securePreferences.setCurrentUserId(previousUserId)
+
+        val departingRecipe = recipeFor(previousUserId)
+        val anonymousRecipe = recipeFor(anonymousUserId)
+        recipeDao.upsertRecipe(departingRecipe)
+        recipeDao.upsertRecipe(anonymousRecipe)
+
+        handler.handleLogin(newUserId = newUserId, anonymousUserId = anonymousUserId)
+
+        // The rows going away must take their image files with them, or the previous account's
+        // photos stay readable on a shared device.
+        coVerify(exactly = 1) { recipeImageStore.delete(departingRecipe.uuid) }
+        coVerify(exactly = 0) { recipeImageStore.delete(anonymousRecipe.uuid) }
+        coVerify(exactly = 0) { recipeImageStore.deleteAll() }
+    }
+
+    private fun recipeFor(creatorId: UUID) = RecipeEntity(
+        uuid = UuidV7Generator.newId(),
+        title = "Recipe",
+        description = "",
+        imageUrl = "",
+        imageUrlThumbnail = "",
+        prepTimeMinutes = 1,
+        cookTimeMinutes = 1,
+        servings = 1,
+        creatorId = creatorId,
+        recipeExternalUrl = null,
+        updatedAt = 1L,
+        deletedAt = null,
+    )
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeRepositoryTest.kt
@@ -46,6 +46,7 @@ import com.tenmilelabs.chefai.core.testutil.testTags
 import com.tenmilelabs.chefai.core.testutil.testUser
 import com.tenmilelabs.chefai.recipes.data.network.FakeApiService
 import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -75,6 +76,7 @@ class DefaultRecipeRepositoryTest {
     private lateinit var remoteDataSource: FakeApiService
     private lateinit var sessionManager: SessionManager
     private lateinit var syncManager: FakeSyncManager
+    private lateinit var recipeImageStore: RecipeImageStore
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var testScope: TestScope
 
@@ -137,6 +139,7 @@ class DefaultRecipeRepositoryTest {
         recipeLabelDao = FakeRecipeLabelCrossRefDao()
         remoteDataSource = FakeApiService()
         syncManager = FakeSyncManager()
+        recipeImageStore = mockk(relaxed = true)
 
         recipeRepository =
             DefaultRecipeRepository(
@@ -150,6 +153,7 @@ class DefaultRecipeRepositoryTest {
                 recipeLabelDao,
                 remoteDataSource,
                 sessionManager,
+                recipeImageStore,
                 syncManager
             )
 
@@ -408,6 +412,22 @@ class DefaultRecipeRepositoryTest {
         // Then: version is preserved
         val savedEntity = recipeDao.getRecipeById(recipeId1)
         assertThat(savedEntity?.version).isEqualTo(1)
+    }
+
+    @Test
+    fun `softDeleteRecipe() reclaims the cached image`() = runTest {
+        // Nothing ever hard-deletes a soft-deleted row, so if the file isn't reclaimed here it never
+        // is — up to MAX_IMAGE_BYTES retained per deleted recipe, forever.
+        recipeRepository.softDeleteRecipe(recipeId1)
+
+        coVerify(exactly = 1) { recipeImageStore.delete(recipeId1) }
+    }
+
+    @Test
+    fun `deleteRecipe() reclaims the cached image`() = runTest {
+        recipeRepository.deleteRecipe(recipeId1)
+
+        coVerify(exactly = 1) { recipeImageStore.delete(recipeId1) }
     }
 
     @Test


### PR DESCRIPTION
Third of four PRs for Stage 1 of #132. **Stacked on #141** (which is stacked on #140).

Two leaks found while mapping the image lifecycle. Both come from [ADR-008](https://github.com/jmuci/ChefAI/blob/main/docs/adrs/adr-008-data-handling-across-sessions.md)'s wipe rules being written purely in terms of Room tables, while the images live on disk.

## 1. Deleted recipes kept their images forever

`RecipeImageStore.delete()` had **zero call sites** — it was written in #130 and never wired up. Soft-deleting a recipe left its bytes behind, and since nothing in the app ever hard-deletes a soft-deleted row, "behind" means permanently: up to `MAX_IMAGE_BYTES` retained per deleted recipe.

Deleting on *soft* delete rather than waiting for a hard delete is deliberate — there is no hard delete to wait for, the row vanishes from every query the moment `deletedAt` is set, and #129 shipped without undo.

For a scraped image this costs nothing: the backfill re-derives it from `imageUrl` if the recipe ever comes back. **For a user-picked photo it is irreversible**, since there's no source to re-derive from. That asymmetry is the clearest argument for uploading user-authored images — Stage 2 of #132. Recorded in the KDoc and in ADR-011 (PR 4).

## 2. Cross-account image leak on a shared device 🔒

The more serious one. `AccountSwitchHandler`'s `PRESERVED_ANONYMOUS_DATA` branch deleted the departing account's recipe *rows* but not their image *files*. On a shared device, the previous user's photos stayed readable after someone else logged in.

```kotlin
val departingRecipeIds = recipeDao.getRecipeIdsForUser(previousUserId)
recipeDao.deleteRecipesForUser(previousUserId)
departingRecipeIds.forEach { recipeImageStore.delete(it) }
```

Ids are collected **before** the bulk delete — `deleteRecipesForUser` is a single SQL statement, and afterwards there's no way to tell which images belonged to whom. `deleteAll()` would be wrong here: that branch exists precisely to preserve the anonymous session's own images.

## Test plan

- 445 unit tests pass (`:app:testDebugUnitTest`).
- New: both delete paths reclaim the file; the account switch deletes exactly the departing account's images and leaves the anonymous ones (asserted both ways, plus `deleteAll()` never called).