### PR TITLE
Recipe images: configurable API base URL + Stage 2 plan docs (#132)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,16 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+/**
+ * Base URL the release build talks to. Supply the deployed host via `-PchefaiApiBaseUrl=https://…`
+ * or a `chefaiApiBaseUrl` entry in `~/.gradle/gradle.properties`.
+ *
+ * The placeholder default is intentional: a release build that silently pointed at a stale or
+ * someone else's host would be worse than one that fails its first request loudly.
+ */
+val releaseApiBaseUrl: String =
+    (project.findProperty("chefaiApiBaseUrl") as String?) ?: "https://api.invalid"
+
 android {
     namespace = "com.tenmilelabs.chefai"
     compileSdk = 36
@@ -31,10 +41,15 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Overridable from ~/.gradle/gradle.properties or -PchefaiApiBaseUrl=... so the deployed
+            // host never has to be committed. Must be https: the release build permits no cleartext.
+            buildConfigField("String", "API_BASE_URL", "\"${releaseApiBaseUrl}\"")
         }
         debug {
             isMinifyEnabled = false
             isDebuggable = true
+            // 10.0.2.2 is the host loopback as seen from the Android emulator.
+            buildConfigField("String", "API_BASE_URL", "\"http://10.0.2.2:8080\"")
         }
     }
     compileOptions {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/app/src/debug/res/xml/network_security_config.xml
+++ b/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Debug-only. Permits cleartext to the emulator's view of the host machine so a locally-run
+  ktor-chefai can be talked to over plain HTTP.
+
+  This lives in src/debug precisely so it cannot reach a release build: release keeps the platform
+  default for API 28+, which denies cleartext outright.
+
+  Without this the app happens to work anyway, because Ktor's CIO engine opens raw sockets and never
+  consults NetworkSecurityPolicy. Anything built on OkHttp — Coil, notably — does consult it and
+  would fail. Stating the permission explicitly means switching HTTP engines, or pointing Coil at a
+  local backend, doesn't break in a way that looks like a server fault.
+-->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/main/java/com/tenmilelabs/chefai/auth/data/network/AuthApiService.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/auth/data/network/AuthApiService.kt
@@ -1,5 +1,6 @@
 package com.tenmilelabs.chefai.auth.data.network
 
+import com.tenmilelabs.chefai.BuildConfig
 import com.tenmilelabs.chefai.auth.data.network.dto.ApiErrorResponse
 import com.tenmilelabs.chefai.auth.data.network.dto.AuthResponse
 import com.tenmilelabs.chefai.auth.data.network.dto.LoginRequest
@@ -16,10 +17,12 @@ import io.ktor.http.isSuccess
 import javax.inject.Inject
 import javax.inject.Singleton
 
-const val AUTH_BASE_URL = "http://10.0.2.2:8080" // Use 10.0.2.2 for Android emulator to access localhost
-const val REGISTER_ENDPOINT = "$AUTH_BASE_URL/auth/register"
-const val LOGIN_ENDPOINT = "$AUTH_BASE_URL/auth/login"
-const val REFRESH_ENDPOINT = "$AUTH_BASE_URL/auth/refresh"
+// `val`, not `const val`: BuildConfig fields are Java statics, which Kotlin won't accept as
+// compile-time constants. Every usage here is a plain string reference, so nothing needs one.
+val AUTH_BASE_URL: String = BuildConfig.API_BASE_URL
+val REGISTER_ENDPOINT = "$AUTH_BASE_URL/auth/register"
+val LOGIN_ENDPOINT = "$AUTH_BASE_URL/auth/login"
+val REFRESH_ENDPOINT = "$AUTH_BASE_URL/auth/refresh"
 
 /**
  * Implementation of AuthNetworkDataSource using Ktor HTTP client.

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/network/SyncApiService.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/network/SyncApiService.kt
@@ -1,5 +1,6 @@
 package com.tenmilelabs.chefai.core.data.sync.network
 
+import com.tenmilelabs.chefai.BuildConfig
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPullResponse
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPushRequest
 import com.tenmilelabs.chefai.core.data.sync.network.dto.SyncPushResponse
@@ -22,9 +23,9 @@ class SyncApiService @Inject constructor(
 ) : SyncNetworkDataSource {
 
     companion object {
-        private const val SYNC_BASE_URL = "http://10.0.2.2:8080"
-        private const val PUSH_ENDPOINT = "$SYNC_BASE_URL/sync/push"
-        private const val PULL_ENDPOINT = "$SYNC_BASE_URL/sync/pull"
+        private val SYNC_BASE_URL = BuildConfig.API_BASE_URL
+        private val PUSH_ENDPOINT = "$SYNC_BASE_URL/sync/push"
+        private val PULL_ENDPOINT = "$SYNC_BASE_URL/sync/pull"
     }
 
     override suspend fun pushRecipes(request: SyncPushRequest): SyncPushResponse {

--- a/app/src/main/java/com/tenmilelabs/chefai/home/data/network/HomeLayoutApiService.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/home/data/network/HomeLayoutApiService.kt
@@ -1,5 +1,6 @@
 package com.tenmilelabs.chefai.home.data.network
 
+import com.tenmilelabs.chefai.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.get
@@ -11,8 +12,7 @@ import io.ktor.http.isSuccess
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val HOME_BASE_URL = "http://10.0.2.2:8080"
-private const val HOME_LAYOUT_ENDPOINT = "$HOME_BASE_URL/api/v1/home/layout"
+private val HOME_LAYOUT_ENDPOINT = "${BuildConfig.API_BASE_URL}/api/v1/home/layout"
 
 @Singleton
 class HomeLayoutApiService @Inject constructor(

--- a/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/network/MealPlanApiService.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/mealplans/data/network/MealPlanApiService.kt
@@ -1,5 +1,6 @@
 package com.tenmilelabs.chefai.mealplans.data.network
 
+import com.tenmilelabs.chefai.BuildConfig
 import com.tenmilelabs.chefai.core.data.sync.network.dto.GenerateMealPlanResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -17,7 +18,7 @@ class MealPlanApiService @Inject constructor(
 ) : MealPlanNetworkDataSource {
 
     companion object {
-        private const val BASE_URL = "http://10.0.2.2:8080"
+        private val BASE_URL = BuildConfig.API_BASE_URL
     }
 
     override suspend fun generateMealPlan(mealPlanId: String): GenerateMealPlanResponse {

--- a/docs/prompts/recipe-image-sync-stage2-plan.md
+++ b/docs/prompts/recipe-image-sync-stage2-plan.md
@@ -1,0 +1,384 @@
+# Plan: Recipe Image Sync — Stage 2 (backend upload + cross-device download)
+
+> Drafted: August 2026
+> Tracking issue: [#94](https://github.com/jmuci/ChefAI/issues/94) (pre-existing; supersedes the
+> "Stage 2" section of [ADR-011](../adrs/adr-011-cross-device-recipe-images.md))
+> Prerequisite: Stage 1, merged as #140 / #141 / #142 / #143
+> Backend counterpart: [recipe-image-upload-backend-prompt.md](recipe-image-upload-backend-prompt.md)
+
+---
+
+## 1. Where Stage 1 left things
+
+Stage 1 unified both image sources under a single device-local file:
+
+| Source | `imageUrl` | `localImagePath` | Re-derivable elsewhere? |
+|---|---|---|---|
+| Scraped at import | the source CDN URL | set by `CacheRecipeImage` | Yes — replay the HTTP→WebView ladder |
+| User-picked photo | **`""` (blank)** | set by `CachePickedImage` | **No. The device holds the only copy.** |
+
+`RecipeImageBackfillWorker` re-derives the first kind on a second device. The second kind has no
+recovery path at all: a reinstall, a soft delete, or simply a new phone destroys the photo. That is
+the loss Stage 2 exists to close.
+
+Two Stage 1 decisions are load-bearing here and must survive:
+
+- **ADR-011 Decision 2** — bytes never ride the JSON sync payload. Uploads get their own channel.
+- **ADR-011 Decision 3** — a blank `imageUrl` means "user's own image". The backfill's SQL predicate
+  is literally `imageUrl != ''`.
+
+### Why issue #94's original sketch cannot be implemented as written
+
+#94 says: *"Update Room `imageUri` → `imageUrl` (remote URL)"*. Overwriting `imageUrl` with a
+ChefAI-hosted URL destroys Decision 3's invariant — a user photo would stop being identifiable as
+user-authored, and `RecipeImageBackfillWorker` would then try to re-derive it by pointing the
+**unauthenticated** `@ScraperHttpClient` at our own authenticated host, collect three 401s, and give
+up permanently. `imageUrl` must keep meaning *"third-party source URL"*. The blob pointer needs its
+own field.
+
+---
+
+## 2. Decisions
+
+### D1 — A new synced field, `imageBlobId`, carries the pointer; `imageUrl` is never rewritten
+
+`imageBlobId: String?` is added to `RecipeEntity`, the domain `Recipe`, and `SyncRecipeDto`. It holds
+the blob's content hash and is **server-owned**: only the upload endpoint sets it, push ignores
+whatever the client sends, pull echoes the server's value.
+
+Server-ownership removes `imageBlobId` from last-writer-wins entirely (a client can't point its
+recipe at a blob it didn't upload) and answers #132's *"conflicts — LWW doesn't describe a blob"*
+question: blobs are immutable and content-addressed, so they never conflict. Which blob a recipe
+points at is decided by the same LWW that already governs the row.
+
+The two flags stay orthogonal, which is what makes D5 possible later:
+
+- `imageUrl` blank ⟺ user-authored (unchanged from Stage 1)
+- `imageBlobId` non-null ⟺ the bytes are on our server
+
+### D2 — Resolution ladder: a new preferred tier, inserted above the existing two
+
+```
+1. localImagePath, if the file is on disk        → render it            (Stage 1, unchanged)
+2. else imageBlobId != null                      → authenticated GET from ChefAI   (NEW)
+3. else imageUrl non-blank                       → HTTP → WebView scrape ladder    (Stage 1, unchanged)
+4. else no image
+```
+
+Tier 2 downloads into `RecipeImageStore` exactly as tier 3 does, so once it lands the recipe is back
+on tier 1 and works offline. This is a strict extension — no Stage 1 code path changes behaviour.
+
+**Consequence worth stating: Coil never talks to our backend.** The alternative (rewrite `imageUrl`
+to a ChefAI URL and let Coil fetch it) would require teaching Coil's OkHttp stack to attach the JWT,
+and then carefully scoping that interceptor by host so the token is never sent to Food Network. That
+is exactly the leak `@ScraperHttpClient` exists to prevent (ADR-010), and doing it in the image
+loader would put the token one misconfiguration away from every third-party CDN we hotlink. Fetching
+through the worker with the already-authenticated `HttpClient` avoids inventing that surface.
+
+**Invariant to enforce in review:** the backend image URL is built only from
+`BuildConfig.API_BASE_URL` + the recipe id. It is never derived from `imageUrl`, and
+`@ScraperHttpClient` is never pointed at our host.
+
+### D3 — Upload state lives on `recipe_image_state`, download state stays separate
+
+Per ADR-011 Decision 5, blob bookkeeping goes on the sibling table, never on `recipes`. It gains
+three columns, kept distinct from the existing download counters so the two ladders can't starve each
+other:
+
+```
+recipeId (PK), attempts, lastAttemptAt,                                   -- download (existing)
+uploadAttempts, lastUploadAttemptAt, uploadedFileModifiedAt               -- upload (new)
+```
+
+`uploadedFileModifiedAt` is the cheap change-detector for a **replaced** photo. `RecipeImageStore`
+keys files by recipe id, so picking a new photo overwrites the same path in place: `imageBlobId`
+would still be non-null and the sweep would skip a recipe whose bytes had changed. Comparing the
+file's `lastModified()` against the value recorded at upload catches that without hashing 200 files
+per sweep — `write()` renames a temp file into place, so the mtime always moves.
+
+### D4 — Upload is a post-sync sweep, gated on the recipe already existing server-side
+
+`RecipeImageUploadWorker`, mirroring `RecipeImageBackfillWorker`'s shape (bounded scan, batch cap,
+attempts recorded *before* the attempt, self-re-enqueue when more remain), enqueued by `SyncWorker`
+after a successful sync alongside `scheduleImageBackfill()`.
+
+Candidate query:
+
+```sql
+SELECT r.uuid AS recipeId, r.imageUrl, r.localImagePath, r.imageBlobId
+FROM recipes r
+LEFT JOIN recipe_image_state s ON s.recipeId = r.uuid
+WHERE r.deletedAt IS NULL
+  AND r.localImagePath IS NOT NULL
+  AND r.syncState = 'SYNCED'                      -- the recipe must exist on the server first
+  AND COALESCE(s.uploadAttempts, 0) < :maxAttempts
+ORDER BY (r.imageUrl = '') DESC,                  -- user photos first: they are the irreplaceable ones
+         r.updatedAt DESC
+LIMIT :scanLimit
+```
+
+Kotlin then drops rows where `imageBlobId != null && file.lastModified() == uploadedFileModifiedAt`
+— the same "SQL over-selects, Kotlin narrows" split the backfill already uses, and testable without
+WorkManager for the same reason.
+
+`syncState = 'SYNCED'` is what makes ordering work: the recipe row is on the server before its image
+is, so the upload can never 404, and #132's *"a pulled `imageUrl` pointing at our storage is useless
+if the upload hasn't landed"* problem never arises — the pointer is only ever created **by** a
+completed upload.
+
+**Constraints: `NetworkType.UNMETERED`, but not `setRequiresCharging(true)`** — deliberately weaker
+than backfill. Backfill waits for a charger because a WebView spin-up per image is expensive and
+nothing is lost by waiting. Upload is a single ~300 KB POST, and every hour it waits is an hour the
+user's only copy of a photo lives on one device. Different work request, different unique name, both
+cancelled by `cancelAllSync()`.
+
+### D5 — Every image is stored server-side and served to anyone who can see the recipe
+
+**Decided (Jose, Aug 2026). This supersedes [ADR-011](../adrs/adr-011-cross-device-recipe-images.md)
+Decision 1**, which said user-authored images are the only upload candidates.
+
+An image is worth persisting whatever its origin: a CDN URL may be unreachable from the app and
+therefore never render at all, and a URL that renders today can be pulled tomorrow. Both failures
+apply equally to a scraped image and a user's own photo, so both get stored.
+
+**Serving turns on recipe visibility alone, not on where the image came from:**
+
+| | Owner | Another user |
+|---|---|---|
+| `PRIVATE` recipe | serve | **404** |
+| `PUBLIC` recipe | serve | serve |
+
+The `PRIVATE` restriction is a plain access-control requirement and is not negotiable. Provenance
+does **not** branch the serving rule.
+
+**The rights question, and why it isn't blocking.** Re-hosting a third party's photograph and serving
+it publicly is a real posture — EU case law (*Renckhoff*) treats re-publishing a freely-available
+photo as a new communication to the public, and the US "server test" that protects hotlinking
+(*Perfect 10*, *Hunley*) protects it precisely because the linker doesn't serve the bytes. But it is
+a *compliance* posture, not a prohibition: Pinterest does exactly this at scale under DMCA §512(c) —
+uploads at users' direction, a registered agent, notice-and-takedown, a repeat-infringer policy. At
+zero users none of that machinery is worth building, and food publishers ship Open Graph tags
+specifically so other services display their hero image.
+
+The judgement recorded here is therefore **"not now, deliberately"**, not "never" and not "no risk".
+Revisit at the 50-user mark — tracked as [#144](https://github.com/jmuci/ChefAI/issues/144) — with the DMCA to-do list in hand.
+
+**What keeps the door open**, all of it cheap and none of it in the way:
+
+- `image_blobs.provenance` (`USER | SCRAPED`) is still stored, derived server-side from
+  `recipes.image_url = ''` rather than trusted from the client. Nothing reads it today. It is the
+  discriminator needed to re-impose an owner-only rule, or to execute a takedown by source, and
+  recording it now costs one column while reconstructing it later would be impossible.
+- `imageUrl` is never overwritten, so the source and its attribution survive.
+- Two backend config flags make both retreats a config change rather than a release:
+  `allowScrapedImageUpload = false` stops accepting them, and
+  `serveScrapedBlobsToNonOwners = false` re-imposes exactly the owner-only rule this decision drops.
+- Blobs stay keyed `(user_id, content_hash)` — **no cross-user dedup.** That is now a storage
+  decision rather than a rights one: it keeps deletion, quota accounting, and takedown per-user and
+  refcount-free. It is also the obvious storage optimisation to reach for later, at the same 50-user
+  threshold, since many users importing the same Food Network recipe store identical bytes today.
+
+**What it buys:** the bot-walled case is the one that actually hurts. Coil uses OkHttp, so Akamai and
+Cloudflare 403 the *hotlink fallback* too — on a second device a Food Network recipe is simply
+pictureless until a charging + unmetered WebView sweep runs, which for some users is never. Serving
+publicly extends that fix to anyone viewing a `PUBLIC` recipe, who today sees the same broken image.
+
+**What it costs:** storage and egress scale with recipes × users; the per-user quota in §6 is the
+only lever on that bill; and uploaded blobs are user-visible, so unwinding this later means deleting
+something people can see.
+
+**What this leaves in place:** the WebView scrape ladder stays as tier 3, but stops being
+load-bearing. Once device A has uploaded, device B takes tier 2 and never spins up a WebView; the
+ladder is only reached in the window before the upload lands, or if it was refused.
+
+### D6 — Anonymous users need no special handling
+
+`SyncWorker` already returns early for anonymous sessions, so no upload is attempted and behaviour is
+unchanged from today. On account upgrade, `AccountUpgradeUseCase` re-parents recipes and marks them
+`PENDING`; they push, become `SYNCED`, and the next sweep picks them up because `imageBlobId IS
+NULL`. #132's *"queue blobs locally and drain on upgrade, or don't upload until there's an
+account?"* resolves to the second answer, for free, with no queue.
+
+### D7 — Deletion: the local file still goes immediately, the blob gets a retention window
+
+Stage 1 reclaims the local file at soft-delete time and that does not change. Server-side, a
+soft-deleted recipe marks its blob unreferenced; a sweep hard-deletes blobs unreferenced for 30 days.
+
+Be precise about what this does and does not fix: **Stage 2 does not make deletion undoable** — there
+is still no undo UI (#129) and the local bytes are still gone at once. What it changes is that for 30
+days the bytes still exist server-side, so a future undo becomes *possible* rather than
+*impossible*. The reinstall / second-device / lost-phone losses are the ones actually closed here.
+
+### D8 — Out of scope, deliberately
+
+- **Thumbnails.** `imageUrlThumbnail` stays a lie. Server-side derivatives are the right fix and the
+  natural place for it, but they mean an image-processing dependency on the backend; that deserves
+  its own decision. Tracked separately.
+- **Resumable / chunked upload.** Images are ≤5 MB after Stage 1's 2048px + JPEG-85 downscale
+  (typically 200–600 KB). One-shot with retry is correct; resumability is machinery for a problem we
+  don't have.
+- **A CDN, signed URLs, or presigned direct-to-storage upload.** All are swaps behind the endpoint
+  shape in §3, none change the client. See the backend prompt's "Later, not now".
+- **Cross-user deduplication**, and the refcounting it would need. Storage optimisation for a
+  problem that starts at scale, not at zero users. See D5.
+- **DMCA plumbing** — a registered agent, a takedown route, a repeat-infringer policy. Deliberately
+  deferred with D5; the `provenance` column and the two config flags are what make it addable later
+  rather than retrofittable.
+
+---
+
+## 3. API contract (client's view; the backend prompt is authoritative)
+
+```
+PUT  /recipes/{recipeId}/image      Authorization: Bearer <jwt>
+                                    Content-Type: image/jpeg
+                                    X-Content-SHA256: <64 hex>
+                                    body: raw bytes, ≤ 5 MiB
+     → 200 {"imageBlobId": "<sha256 hex>", "updatedAt": 1755100000000}
+     → 403 {"error": "SCRAPED_UPLOAD_DISABLED" | "QUOTA_EXCEEDED"}     (permanent — stop retrying)
+     → 404 recipe unknown or not owned                                 (permanent — stop retrying)
+     → 413 / 415 / 422                                                 (permanent — stop retrying)
+
+GET  /recipes/{recipeId}/image      Authorization: Bearer <jwt>
+     → 200 bytes, ETag: "<hash>", Cache-Control: private, immutable
+     → 404 no blob, or not visible to caller
+
+DELETE /recipes/{recipeId}/image    → 204, clears the pointer
+```
+
+Client-side error handling turns on **permanent vs. transient**: 4xx (other than 408/429) burns the
+attempt counter straight to the cap so a rejected upload is never retried; 5xx / IO errors increment
+by one and retry up to three times.
+
+---
+
+## 4. PR breakdown
+
+Same shape as Stage 1 — small, independently reviewable, each green on its own.
+
+### PR 0 — `BuildConfig.API_BASE_URL` (prerequisite, no behaviour change)
+
+`http://10.0.2.2:8080` is currently hardcoded in five services: `SyncApiService`, `AuthApiService`,
+`HomeLayoutApiService`, `MealPlanApiService`, `ChefAIApiService`. Stage 2 is definitionally "there is
+now a real backend", so this has to become configurable before anything else lands, and a sixth
+duplicate would be indefensible.
+
+- `buildConfigField("String", "API_BASE_URL", ...)` per build type (`buildConfig = true` is already
+  enabled in `app/build.gradle.kts:52`). Debug keeps the emulator loopback; release takes an HTTPS
+  host.
+- Replace all five constants.
+- Cleartext: the debug default is `http://`, which needs a `networkSecurityConfig` limiting cleartext
+  to `10.0.2.2` on debug only. There is no such file today (`app/src/main/res/xml/` has only backup
+  rules), so it stays working purely because release has never pointed anywhere real.
+
+### PR 1 — Schema: `imageBlobId` + upload bookkeeping (Room v4)
+
+- `RecipeEntity.imageBlobId: String? = null`; `SyncRecipeDto.imageBlobId: String? = null`.
+- `SyncMapper`: `toSyncDto` carries it; `toRecipeEntity(localImagePath)` takes it from the DTO — it
+  is server-owned, so it arrives on the wire and gotcha #24's threading problem doesn't apply.
+- `RecipeImageStateEntity` += the three columns from D3.
+- `MIGRATION_3_4` — plain `ALTER TABLE ... ADD COLUMN` on both tables (only `DROP COLUMN` needs the
+  API-34 SQLite), commit `app/schemas/.../4.json`, add the `MigrationTestHelper` case.
+- **Thread `imageBlobId` through `Recipe.toRoomEntity()`
+  ([RoomDomainMap.kt:136](../../app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/RoomDomainMap.kt))**
+  — that mapper already hardcodes `deletedAt = null, // or appropriate value`, which is
+  [#128](https://github.com/jmuci/ChefAI/issues/128). Adding a field to the entity without adding it
+  there means every save through the domain path silently wipes the blob pointer. Worth fixing #128
+  in the same PR while the mapper is open.
+
+### PR 2 — Upload
+
+- `RecipeImageStore.read(recipeId): ByteArray?` and `lastModified(recipeId): Long?` (no read accessor
+  exists today).
+- `RecipeImageUploader` — `PUT`, raw body, `X-Content-SHA256`, using the **default authenticated**
+  `HttpClient`. Maps status codes to a sealed `UploadOutcome { Success(blobId), Permanent, Transient }`.
+- `UploadRecipeImage` use case — hash, upload, and on success
+  `recipeDao.updateImageBlobId(uuid, blobId)` (a targeted `@Query UPDATE`, so no `updatedAt` bump, no
+  `PENDING` mark, no full-row rewrite — the server already holds the same value), then record
+  `uploadedFileModifiedAt` and clear the state row.
+- `RecipeDao.getImageUploadCandidates(...)` + the `RecipeImageUploadCandidate` projection.
+- `RecipeImageUploadWorker` + `SyncScheduler.scheduleImageUpload()` + `SyncManager` impl + the three
+  fakes (`test/.../sync/FakeSyncManager.kt`, `test/.../testutil/FakeSessionManager.kt`,
+  `androidTest/.../sync/FakeSyncScheduler.kt`), + `cancelAllSync()`, + the `SyncWorker` enqueue.
+
+### PR 3 — Download (extend the backfill to tier 2)
+
+- `FetchRecipeImageFromBackend` use case — authenticated `GET`, reusing the capped body reader
+  currently private to `CacheRecipeImage` (extract it to a shared `internal` helper), writes through
+  `RecipeImageStore`.
+- `RecipeImageBackfillWorker` tries tier 2 first when `imageBlobId != null`, falling through to the
+  existing ladder.
+- Candidate query predicate relaxes from `r.imageUrl != ''` to
+  `(r.imageUrl != '' OR r.imageBlobId IS NOT NULL)` — this is what finally lets a **user photo** be
+  restored on a second device, which the Stage 1 predicate deliberately excluded.
+- Reset `attempts` when a pull changes a recipe's `imageBlobId`, so three strikes collected before
+  the blob existed don't permanently blind the device to it.
+
+### PR 4 — Docs
+
+- **ADR-012 — Recipe image upload** (or an amendment block on ADR-011): D1–D7 above, with D5's
+  supersession of ADR-011 Decision 1 stated as a reversal-with-reasons rather than slipped in,
+  including the rights posture it consciously accepts and the 50-user revisit.
+- Update ADR-011's "Stage 2 (not decided here)" section to point at it, and its Consequences bullet
+  about irreversible photo loss.
+- `docs/claude/decisions.md`, the `CLAUDE.md` gaps table, `.claude/session-context.md`.
+- Close [#94](https://github.com/jmuci/ChefAI/issues/94) and [#132](https://github.com/jmuci/ChefAI/issues/132).
+
+---
+
+## 5. Tests
+
+**JVM unit** (fakes over mocks, Given/When/Then):
+
+- `RecipeImageUploadCandidatesTest` — user photos ordered first; a recipe whose file mtime matches
+  `uploadedFileModifiedAt` is skipped; a **replaced** photo (mtime moved, `imageBlobId` still set) is
+  selected; `syncState != SYNCED` skipped; attempts at cap skipped; batch cap respected.
+- `UploadRecipeImageTest` — success writes `imageBlobId` and clears the state row; a 403 burns
+  attempts to the cap in one go; a 500 increments by one; a missing local file is a no-op, not a
+  crash.
+- `RecipeImageUploaderTest` — Ktor `MockEngine`: the request carries `Authorization`, the correct
+  `X-Content-SHA256`, and the raw bytes; each status maps to the right `UploadOutcome`.
+- `RecipeImageBackfillTest` — tier 2 preferred when `imageBlobId != null`; falls through to the
+  scrape ladder when it fails; a blank-`imageUrl` recipe with a blob is now a candidate (it was not
+  in Stage 1).
+- `SyncMapperTest` — `imageBlobId` survives a pull round-trip and `localImagePath` still does.
+
+**Instrumented:**
+
+- `MigrationTestHelper` v3 → v4: existing rows survive, both new column sets present, defaults right.
+- In-memory DAO test for the upload candidate query, including the `LEFT JOIN` and the ordering.
+
+**Manual, once the backend is deployed** — the two cases that justify the work:
+
+1. *Photo cross-device:* device A, pick a photo, save, sync. Device B pulls → recipe initially has no
+   image → after an unmetered sweep the photo appears. Verify with
+   `adb shell run-as com.tenmilelabs.chefai ls -l files/recipe_images`.
+2. *Bot-walled scrape cross-device:* import a Food Network recipe on A, sync. On B confirm the
+   hotlink fallback is **broken** (Akamai 403s Coil too), then that tier 2 restores it without a
+   WebView.
+3. *Replacement:* change the photo on A → B gets the new one, not the old.
+4. *Privacy:* a second account must 404 on `GET /recipes/{id}/image` for another user's `PRIVATE`
+   recipe, and must succeed for a `PUBLIC` one regardless of the image's provenance.
+
+## 6. Still to settle (numbers, not directions)
+
+Both are backend config values with defaults already in the prompt — neither blocks starting.
+
+1. **Retention window** — 30 days for unreferenced blobs is a guess; it interacts with
+   [#55](https://github.com/jmuci/ChefAI/issues/55) (account deletion & data retention).
+2. **Per-user quota** — the backend prompt proposes 500 MB. With D5 decided, this is the only thing
+   standing between the endpoint and free image hosting, and the only lever on the storage bill.
+
+## 7. Revisit at 50 users — [#144](https://github.com/jmuci/ChefAI/issues/144)
+
+D5 accepts a rights posture on the grounds that the app has no users, and that judgement expires
+when it does. Three things come due together at roughly the 50-user mark:
+
+1. **DMCA §512(c) plumbing** — a registered agent, a takedown route, a repeat-infringer policy. This
+   is what makes public serving of scraped images a supported posture rather than an accepted risk.
+   If the answer turns out to be "not worth it", `serveScrapedBlobsToNonOwners = false` retreats to
+   owner-only serving with no release and no data migration.
+2. **Cross-user deduplication** — many users importing the same recipe store byte-identical copies
+   under D5's per-user keying. This is the first real storage lever after the quota.
+3. **Object storage and a CDN** — `LocalDiskBlobStore` is a deliberate placeholder; egress from the
+   app server is fine at 50 users and not at 5,000.

--- a/docs/prompts/recipe-image-upload-backend-prompt.md
+++ b/docs/prompts/recipe-image-upload-backend-prompt.md
@@ -1,0 +1,342 @@
+# Backend Prompt: Recipe Image Blobs — Upload, Serving & Reclamation
+
+> Generated: August 2026
+> Related issues: [#94](https://github.com/jmuci/ChefAI/issues/94), [#132](https://github.com/jmuci/ChefAI/issues/132)
+> Android counterpart: `docs/prompts/recipe-image-sync-stage2-plan.md` in the
+> [ChefAI Android repo](https://github.com/jmuci/ChefAI/blob/main/docs/prompts/recipe-image-sync-stage2-plan.md)
+> Background, if useful: [ADR-006 (sync protocol)](https://github.com/jmuci/ChefAI/blob/main/docs/adrs/adr-006-sync-protocol.md),
+> [ADR-011 (cross-device images)](https://github.com/jmuci/ChefAI/blob/main/docs/adrs/adr-011-cross-device-recipe-images.md)
+>
+> **This document is self-contained — it can be handed to a session in `ktor-chefai` as-is.** All
+> issue references point at the Android repo, not this one.
+
+---
+
+## Before you start: two things to verify against the real schema
+
+This prompt was written from the Android client's side of the contract, so its assumptions about
+existing backend tables are inferences, not facts. Check both and adapt the SQL below:
+
+1. **The owner column on `recipes`.** Written here as `recipes.user_id`. The Android entity calls the
+   field `creatorId`, so the backend column may well be `creator_id`. Whichever it is, it is the
+   column every ownership check in §3 and §6 keys on.
+2. **How `image_url` is stored for a user-picked photo.** §3a derives `provenance` from
+   `recipes.image_url = ''` — an **empty string**, not `NULL`. If the column is nullable and the
+   client's blank string arrives as `NULL`, that check must become `coalesce(image_url, '') = ''`, or
+   every user photo is misclassified as `SCRAPED` and refused whenever the kill switch is on.
+
+## Context
+
+The Android client stores every recipe hero image as a file on the device. Two sources feed it:
+
+| Source | `recipes.image_url` | Can another device re-derive it? |
+|---|---|---|
+| Scraped from the recipe's source page at import | the third-party CDN URL | Yes, but only by driving an off-screen WebView — several CDNs (Akamai/Food Network, Cloudflare/Serious Eats) 403 every plain HTTP client, including the app's image loader |
+| A photo the user picked from their gallery | **empty string** | **No. That device holds the only copy in existence.** |
+
+A blank `image_url` is therefore a meaningful, load-bearing signal on the server too: **it means the
+image is the user's own and cannot be recovered from anywhere else.**
+
+The backend needs to accept those bytes, serve them back to the same user's other devices, and
+reclaim them when they stop being referenced. Stack is **Kotlin + Ktor + PostgreSQL + Exposed DSL +
+JWT** — same patterns as the existing recipe/bookmark sync endpoints.
+
+**The client never sends image bytes through `/sync/push`.** That payload is JSON, batched fifty
+recipes at a time. Images get their own endpoint, and the recipe row only ever carries a *pointer*.
+
+---
+
+## 1. Database Schema
+
+```sql
+CREATE TABLE image_blobs (
+    id                  UUID    PRIMARY KEY,
+    user_id             UUID    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    content_hash        TEXT    NOT NULL,          -- lowercase sha256 hex of the stored bytes
+    provenance          TEXT    NOT NULL,          -- USER | SCRAPED
+    mime_type           TEXT    NOT NULL,          -- image/jpeg | image/png | image/webp
+    byte_size           BIGINT  NOT NULL,
+    storage_key         TEXT    NOT NULL,          -- opaque to callers; see §2
+    created_at          BIGINT  NOT NULL,
+    unreferenced_since  BIGINT  NULL,              -- set when no live recipe points here; see §6
+
+    UNIQUE (user_id, content_hash)
+);
+
+CREATE INDEX idx_image_blobs_user_id            ON image_blobs(user_id);
+CREATE INDEX idx_image_blobs_unreferenced_since ON image_blobs(unreferenced_since)
+    WHERE unreferenced_since IS NOT NULL;
+
+ALTER TABLE recipes ADD COLUMN image_blob_id TEXT NULL;   -- the content hash, not a FK
+```
+
+Three schema choices that are deliberate, not accidental:
+
+- **`UNIQUE (user_id, content_hash)`, not `UNIQUE (content_hash)`.** Blobs are not deduplicated
+  across users, so deletion, quota accounting, and any future takedown stay per-user and
+  refcount-free. It also removes an existence oracle: without it, user B could probe whether user A
+  has a given image by uploading a candidate and observing a dedup hit. Cross-user dedup is the
+  obvious storage optimisation later — see §8 — but it is not worth its refcounting at this scale.
+- **`provenance` is recorded but nothing reads it.** Serving (§3b) turns on recipe visibility alone.
+  The column exists so that an owner-only serving rule can be re-imposed by config, and so a takedown
+  can be executed by source, without a backfill that would be impossible to reconstruct after the
+  fact. Derive it server-side; never accept it from the client.
+- **`recipes.image_blob_id` stores the hash, not a surrogate FK.** The client treats it as an opaque
+  change-token — "the image behind this recipe is different from the one I have" — and comparing
+  hashes is exactly that test. A join to resolve a UUID would buy nothing.
+
+---
+
+## 2. Blob storage abstraction
+
+Do **not** reach for an S3 SDK in this pass. Define the seam and implement the boring side of it:
+
+```kotlin
+interface BlobStore {
+    suspend fun put(key: String, bytes: ByteArray, mimeType: String)
+    suspend fun openRead(key: String): InputStream?
+    suspend fun delete(key: String)
+}
+
+class LocalDiskBlobStore(private val root: Path) : BlobStore { /* … */ }
+```
+
+`storage_key` is generated as `"${userId}/${contentHash}"` and is opaque outside this interface.
+
+Adding `aws-sdk-kotlin` / an R2 client is a dependency decision for whoever owns the deploy — flag it
+and get sign-off rather than adding it here. The whole point of the seam is that swapping
+`LocalDiskBlobStore` for an object-store implementation later touches one class, no endpoint, and no
+client code.
+
+---
+
+## 3. Endpoints
+
+### 3a. `PUT /recipes/{recipeId}/image` — upload
+
+```
+Authorization: Bearer <jwt>
+Content-Type: image/jpeg            (or image/png, image/webp)
+X-Content-SHA256: <64 lowercase hex chars>
+Body: raw image bytes, ≤ 5 MiB      (NOT multipart — exactly one file, no form fields)
+```
+
+**Validation, in this order.** Every rejection must be cheap and must happen before the bytes are
+written anywhere:
+
+| # | Check | Failure |
+|---|---|---|
+| 1 | Valid JWT | `401` |
+| 2 | Recipe exists **and** `recipes.user_id = caller` | `404` — same response for "doesn't exist" and "not yours", so the endpoint is not a recipe-existence oracle |
+| 3 | `Content-Type` starts with `image/` and is one of jpeg/png/webp | `415` |
+| 4 | Body ≤ 5 MiB, enforced **while streaming** | `413` — abort the read; never buffer an unbounded body to find out how big it was |
+| 5 | `sha256(body)` equals `X-Content-SHA256` | `422` |
+| 6 | Magic bytes match the declared type (`FF D8 FF` jpeg, `89 50 4E 47` png, `RIFF….WEBP` webp) | `415` — **do not trust `Content-Type`**; without this the endpoint is an authenticated arbitrary-file host |
+| 7 | `provenance == SCRAPED` and `config.allowScrapedImageUpload == false` | `403 {"error":"SCRAPED_UPLOAD_DISABLED"}` |
+| 8 | User's total `byte_size` + this upload ≤ quota | `403 {"error":"QUOTA_EXCEEDED"}` |
+
+**Provenance is derived server-side, never taken from the client:**
+
+```kotlin
+val provenance = if (recipe.imageUrl.isBlank()) Provenance.USER else Provenance.SCRAPED
+```
+
+**Success path:**
+
+1. If `(user_id, hash)` already exists **and** `recipes.image_blob_id == hash` → return `200` with the
+   existing values and **do not touch `updated_at`**. This matters: bumping `updated_at` on a no-op
+   re-upload makes the recipe appear in every subsequent pull delta, and a client retrying a
+   misclassified error would churn forever.
+2. Otherwise `BlobStore.put`, insert the `image_blobs` row (or reuse an existing one for the same
+   `(user_id, hash)`), set `recipes.image_blob_id = hash`, set `recipes.updated_at = now()`.
+3. If the recipe previously pointed at a different blob, run the dereference check from §6 on the old
+   one.
+
+**Response `200`:**
+
+```json
+{"imageBlobId": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+ "updatedAt": 1755100000000}
+```
+
+Do all of this in one transaction, with the `BlobStore.put` before the commit so a crash leaves an
+orphaned object (reclaimable by the §6 sweep) rather than a row pointing at nothing.
+
+### 3b. `GET /recipes/{recipeId}/image` — serve
+
+```
+Authorization: Bearer <jwt>
+If-None-Match: "<hash>"          (optional)
+```
+
+**Visibility follows the recipe, not the image's provenance:**
+
+| | Caller is owner | Caller is another user |
+|---|---|---|
+| `PRIVATE` recipe | serve | **`404`** |
+| `PUBLIC` recipe | serve | serve |
+
+In other words: if the caller is allowed to see the recipe, they are allowed to see its image,
+whether the image was scraped or photographed by the owner. Every "not visible" case returns `404`,
+not `403`, for the same non-oracle reason as §3a check 2.
+
+Gate the non-owner branch on `config.serveScrapedBlobsToNonOwners` (§5) when
+`provenance = SCRAPED`. It ships `true`; the flag exists so the owner-only rule can be re-imposed
+without a deploy of new code, not because it is expected to be flipped soon. See §8.
+
+**Responses:**
+
+```
+200  Content-Type: <mime_type>
+     Content-Length: <byte_size>
+     ETag: "<content_hash>"
+     Cache-Control: private, max-age=31536000, immutable
+     <bytes, streamed — do not load into memory>
+
+304  when If-None-Match matches (blobs are immutable, so this is always safe)
+404  no blob, recipe unknown, or not visible to the caller
+```
+
+### 3c. `DELETE /recipes/{recipeId}/image` — clear the pointer
+
+Owner only. Sets `recipes.image_blob_id = NULL`, bumps `updated_at`, runs the §6 dereference check.
+Returns `204`. Needed because the client's editor lets a user replace a photo with a source URL.
+
+---
+
+## 4. Sync protocol extension
+
+Extend the existing `SyncRecipeDto` — **do not add a new sync endpoint.**
+
+```diff
+  data class SyncRecipeDto(
+      val uuid: String,
+      …
+      val imageUrl: String,
+      val imageUrlThumbnail: String,
++     val imageBlobId: String? = null,
+      …
+  )
+```
+
+**Push: ignore whatever the client sends in `imageBlobId`.** Persist the server's own value and echo
+it back. The pointer is set exclusively by §3a and cleared exclusively by §3c.
+
+This is not defensive pedantry — it is what keeps blobs out of last-writer-wins. A client cannot
+point its recipe at a blob it never uploaded, and because blobs are immutable and content-addressed,
+two devices can never disagree about a blob's *contents*. Which blob a recipe points at is settled by
+the same `updated_at` LWW that already governs the row, with no new conflict class.
+
+**Pull: include `imageBlobId`** in every recipe, including soft-deleted ones.
+
+Nullable with a default, so an older client that doesn't send or understand the field keeps working.
+
+---
+
+## 5. Config
+
+```kotlin
+data class ImageBlobConfig(
+    val allowScrapedImageUpload: Boolean = true,        // false → 403 SCRAPED_UPLOAD_DISABLED on §3a
+    val serveScrapedBlobsToNonOwners: Boolean = true,   // false → §3b serves scraped blobs to the owner only
+    val maxUploadBytes: Long = 5 * 1024 * 1024,
+    val perUserQuotaBytes: Long = 500L * 1024 * 1024,
+    val unreferencedRetentionDays: Int = 30,
+)
+```
+
+The first two are kill switches, not tuning knobs. Hosting and publicly serving third-party images is
+a deliberate, revisitable decision made while the app has no users (see §8); these flags are what
+make retreating from it a config change instead of a release. `allowScrapedImageUpload = false` stops
+accepting new scraped blobs — the Android client treats `403 SCRAPED_UPLOAD_DISABLED` as permanent
+and stops retrying that recipe. `serveScrapedBlobsToNonOwners = false` narrows serving to the
+uploading user, with existing blobs untouched and no data migration.
+
+Add a per-user upload rate limit (suggested: 60/minute) on §3a.
+
+---
+
+## 6. Reclamation
+
+A blob becomes **unreferenced** when no live recipe points at it:
+
+```sql
+SELECT NOT EXISTS (
+    SELECT 1 FROM recipes
+    WHERE image_blob_id = :hash AND user_id = :userId AND deleted_at IS NULL
+);
+```
+
+Run that check whenever a recipe is soft-deleted through `/sync/push`, repointed by §3a, or cleared by
+§3c. When it comes back true, set `unreferenced_since = now()`; when a blob is referenced again, clear
+it back to `NULL`.
+
+A scheduled job then hard-deletes blobs where
+`unreferenced_since < now() - unreferencedRetentionDays`, removing the storage object first and the
+row second (an orphaned row is recoverable; an orphaned object is only findable by a full scan).
+
+The retention window exists because the client's delete is a **soft** delete with no undo
+([ChefAI#129](https://github.com/jmuci/ChefAI/issues/129)), and
+it deletes the local file immediately. The window is the only thing that would make a future "undo
+delete" feature possible at all. Coordinate the number with
+[#55](https://github.com/jmuci/ChefAI/issues/55) (account deletion & data retention) — account
+deletion should cascade blobs immediately, not wait out the window.
+
+The same job should sweep storage objects with no `image_blobs` row (crash-orphans from §3a).
+
+---
+
+## 7. Client-side wiring (Android, for alignment — not this task)
+
+- `RecipeEntity` / `Recipe` / `SyncRecipeDto` gain `imageBlobId: String?` (Room v4).
+- `RecipeImageUploadWorker` sweeps recipes with a local file and no matching blob pointer, uploads via
+  §3a, and writes the returned hash back with a targeted `UPDATE` that does **not** bump `updated_at`.
+  It only considers recipes already `SYNCED`, so the recipe always exists server-side before its
+  image does.
+- `RecipeImageBackfillWorker` gains a preferred tier: when `imageBlobId != null`, fetch §3b with the
+  authenticated client and store it locally, only falling back to the scrape ladder otherwise.
+- The image loader (Coil) never calls these endpoints — bytes are fetched by the worker and rendered
+  from the local file, so no auth token is ever handed to the image-loading stack.
+
+## 8. Later, not now — the 50-user checkpoint ([#144](https://github.com/jmuci/ChefAI/issues/144))
+
+Each of these swaps in behind the endpoints above **without a client change** — worth preserving that
+property when implementing:
+
+- **DMCA §512(c) plumbing** — a registered agent, a takedown route keyed on `provenance` and the
+  recipe's `image_url`, a repeat-infringer policy. Publicly serving scraped third-party images
+  (§3b) is a real posture, consciously accepted here because the app has no users; that reasoning
+  expires when it gets some. This is the item that makes the posture supported rather than merely
+  accepted, and `serveScrapedBlobsToNonOwners = false` is the retreat if it isn't worth building.
+- **Object storage / CDN** — replace `LocalDiskBlobStore`; §3b may then `302` to a short-lived signed
+  URL instead of streaming. Egress from the app server is fine at 50 users and not at 5,000.
+- **Cross-user dedup** — under §1's per-user keying, many users importing the same recipe store
+  byte-identical copies. The first real storage lever after the quota, at the cost of refcounting on
+  delete and a more careful takedown story.
+- **Thumbnails** — `imageUrlThumbnail` is currently set to `imageUrl` by the client and is a lie.
+  Server-side derivatives are the right fix; they need an image-processing dependency, so treat that
+  as its own decision.
+
+---
+
+## 9. Definition of Done
+
+- [ ] Migration creating `image_blobs` and adding `recipes.image_blob_id`
+- [ ] `BlobStore` interface + `LocalDiskBlobStore`, no cloud SDK dependency added
+- [ ] `PUT /recipes/{id}/image` with all eight validations from §3a, including magic-byte sniffing and
+      the streaming size cap
+- [ ] Re-uploading identical bytes for an unchanged recipe is a no-op that does **not** move
+      `updated_at`
+- [ ] `GET /recipes/{id}/image` honouring the §3b visibility table, with `ETag` / `304`
+- [ ] `DELETE /recipes/{id}/image`
+- [ ] `imageBlobId` returned on pull; client-supplied values on push ignored
+- [ ] Reclamation job + dereference checks on soft-delete, repoint, and clear
+- [ ] Quota and rate limit enforced
+- [ ] Tests: hash mismatch → 422; a PNG body declared as `image/jpeg` → 415; oversized body → 413 with
+      nothing written; a second user → 404 on another user's `PRIVATE` recipe image, 200 on a
+      `PUBLIC` one regardless of provenance; `allowScrapedImageUpload = false` → 403 for a scraped
+      image and 200 for a user photo; `serveScrapedBlobsToNonOwners = false` → that same second user
+      now 404s on a `PUBLIC` recipe's scraped image but still 200s on its owner's photo
+- [ ] Integration test: push recipe → upload image → pull → `imageBlobId` present → GET returns the
+      exact bytes → soft-delete the recipe → blob marked unreferenced → sweep after the window
+      deletes both row and object


### PR DESCRIPTION
First of five PRs completing Stage 2 of #132 — the client half of cross-device recipe images. The backend half is deployed.

## What this does

Four services each carried their own `http://10.0.2.2:8080`: `SyncApiService`, `AuthApiService`, `HomeLayoutApiService`, `MealPlanApiService`. They now read `BuildConfig.API_BASE_URL`.

- **debug** → the emulator host loopback, unchanged behaviour
- **release** → `-PchefaiApiBaseUrl=https://…`, or a `chefaiApiBaseUrl` entry in `~/.gradle/gradle.properties`

The release default is `https://api.invalid`, deliberately. A build silently pointing at a stale host fails far less legibly than one whose first request won't resolve, and it keeps the deployed hostname out of the repo.

`ChefAIApiService` is untouched — it points at a static GitHub Pages fixture, not the backend.

## Two things worth a look

**`const val` → `val`.** BuildConfig fields are Java statics, which Kotlin won't accept as compile-time constants. Every usage is a plain string reference, so none needed one.

**A debug-only network security config.** The app talks to a plain-HTTP backend today only because Ktor's CIO engine opens raw sockets and never consults `NetworkSecurityPolicy` — at API 28+ the platform default denies cleartext, and anything built on OkHttp (Coil, notably) *does* consult it and would be blocked. Making the permission explicit means switching HTTP engine, or pointing Coil at a local backend, won't fail in a way that looks like a server fault. It lives in `src/debug`, so release keeps the deny-by-default.

## Also included

The two Stage 2 design docs, which had no home yet:

- `docs/prompts/recipe-image-sync-stage2-plan.md` — the client plan these five PRs implement
- `docs/prompts/recipe-image-upload-backend-prompt.md` — the spec the deployed backend was built from

## Verification

- `:app:testDebugUnitTest` — green
- `:app:assembleRelease` — builds; BuildConfig carries the placeholder
- `-PchefaiApiBaseUrl=https://chefai.example.com` verified to reach the generated BuildConfig
- No `10.0.2.2` remains in Kotlin source

🤖 Generated with [Claude Code](https://claude.com/claude-code)