### PR TITLE
Recipe images: Room v4 — imageBlobId and upload bookkeeping (#132)

### DIFF
--- a/app/schemas/com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase/4.json
+++ b/app/schemas/com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase/4.json
@@ -1,0 +1,1354 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "3b013a153863691dabc7b1b9dfc6e62c",
+    "entities": [
+      {
+        "tableName": "allergens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_allergens_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_allergens_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarked_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` BLOB NOT NULL, `recipeId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`userId`, `recipeId`), FOREIGN KEY(`userId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "recipeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarked_recipes_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarked_recipes_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_bookmarked_recipes_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarked_recipes_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ingredients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `allergenId` BLOB, `sourcePrimaryId` BLOB, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`allergenId`) REFERENCES `allergens`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT , FOREIGN KEY(`sourcePrimaryId`) REFERENCES `source_classifications`(`uuid`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allergenId",
+            "columnName": "allergenId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "sourcePrimaryId",
+            "columnName": "sourcePrimaryId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ingredients_allergenId",
+            "unique": false,
+            "columnNames": [
+              "allergenId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_allergenId` ON `${TABLE_NAME}` (`allergenId`)"
+          },
+          {
+            "name": "index_ingredients_sourcePrimaryId",
+            "unique": false,
+            "columnNames": [
+              "sourcePrimaryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_sourcePrimaryId` ON `${TABLE_NAME}` (`sourcePrimaryId`)"
+          },
+          {
+            "name": "index_ingredients_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "allergens",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "allergenId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "source_classifications",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourcePrimaryId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "labels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_labels_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_labels_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `userId` BLOB NOT NULL, `name` TEXT NOT NULL, `status` TEXT NOT NULL, `preferencesJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`userId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preferencesJson",
+            "columnName": "preferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plans_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plans_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_meal_plans_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plans_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `mealPlanId` BLOB NOT NULL, `dayIndex` INTEGER NOT NULL, `dinnerRecipeId` BLOB, `lunchRecipeId` BLOB, PRIMARY KEY(`uuid`), FOREIGN KEY(`mealPlanId`) REFERENCES `meal_plans`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanId",
+            "columnName": "mealPlanId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dinnerRecipeId",
+            "columnName": "dinnerRecipeId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "lunchRecipeId",
+            "columnName": "lunchRecipeId",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanId` ON `${TABLE_NAME}` (`mealPlanId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plans",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `isNewRecipe` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `localImagePath` TEXT, `prepTimeMinutes` TEXT NOT NULL, `cookTimeMinutes` TEXT NOT NULL, `servings` TEXT NOT NULL, `externalUrl` TEXT NOT NULL, `ingredientsJson` TEXT NOT NULL, `stepsJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `labelsJson` TEXT NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`recipeId`))",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNewRecipe",
+            "columnName": "isNewRecipe",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "localImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "prepTimeMinutes",
+            "columnName": "prepTimeMinutes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cookTimeMinutes",
+            "columnName": "cookTimeMinutes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalUrl",
+            "columnName": "externalUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelsJson",
+            "columnName": "labelsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId"
+          ]
+        }
+      },
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `imageUrlThumbnail` TEXT NOT NULL, `localImagePath` TEXT, `imageBlobId` TEXT, `prepTimeMinutes` INTEGER NOT NULL, `cookTimeMinutes` INTEGER NOT NULL, `servings` INTEGER NOT NULL, `creatorId` BLOB NOT NULL, `recipeExternalUrl` TEXT, `privacy` TEXT NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`creatorId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrlThumbnail",
+            "columnName": "imageUrlThumbnail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "localImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlobId",
+            "columnName": "imageBlobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "prepTimeMinutes",
+            "columnName": "prepTimeMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cookTimeMinutes",
+            "columnName": "cookTimeMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorId",
+            "columnName": "creatorId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeExternalUrl",
+            "columnName": "recipeExternalUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "privacy",
+            "columnName": "privacy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipes_creatorId",
+            "unique": false,
+            "columnNames": [
+              "creatorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipes_creatorId` ON `${TABLE_NAME}` (`creatorId`)"
+          },
+          {
+            "name": "index_recipes_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipes_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "creatorId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_image_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER NOT NULL, `uploadAttempts` INTEGER NOT NULL, `lastUploadAttemptAt` INTEGER NOT NULL, `uploadedFileModifiedAt` INTEGER, PRIMARY KEY(`recipeId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadAttempts",
+            "columnName": "uploadAttempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUploadAttemptAt",
+            "columnName": "lastUploadAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadedFileModifiedAt",
+            "columnName": "uploadedFileModifiedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_ingredients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `ingredientId` BLOB NOT NULL, `quantity` REAL NOT NULL, `unit` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `ingredientId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`ingredientId`) REFERENCES `ingredients`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientId",
+            "columnName": "ingredientId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "ingredientId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_ingredients_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_recipe_ingredients_ingredientId",
+            "unique": false,
+            "columnNames": [
+              "ingredientId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_ingredientId` ON `${TABLE_NAME}` (`ingredientId`)"
+          },
+          {
+            "name": "index_recipe_ingredients_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "ingredients",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ingredientId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_labels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `labelId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `labelId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`labelId`) REFERENCES `labels`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelId",
+            "columnName": "labelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "labelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_labels_labelId",
+            "unique": false,
+            "columnNames": [
+              "labelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_labels_labelId` ON `${TABLE_NAME}` (`labelId`)"
+          },
+          {
+            "name": "index_recipe_labels_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_labels_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "labels",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "labelId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `recipeId` BLOB NOT NULL, `orderIndex` INTEGER NOT NULL, `instruction` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instruction",
+            "columnName": "instruction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_steps_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_steps_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_recipe_steps_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_steps_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `tagId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `tagId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_recipe_tags_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_tags_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_classifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `category` TEXT NOT NULL, `subcategory` TEXT, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcategory",
+            "columnName": "subcategory",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_classifications_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_source_classifications_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityType` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`entityType`))",
+        "fields": [
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityType"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `email` TEXT NOT NULL, `avatarUrl` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3b013a153863691dabc7b1b9dfc6e62c')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/ChefAIDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/ChefAIDatabaseMigrationTest.kt
@@ -6,6 +6,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_1_2
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_2_3
+import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_3_4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -82,9 +83,58 @@ class ChefAIDatabaseMigrationTest {
     }
 
     @Test
-    fun migrateAll1To3_succeeds() {
+    fun migrate3To4_addsBlobColumnsAndKeepsExistingRows() {
+        val recipeId = UUID.randomUUID()
+
+        helper.createDatabase(TEST_DB, 3).use { db ->
+            db.execSQL(
+                """
+                INSERT INTO recipes (
+                    uuid, title, description, imageUrl, imageUrlThumbnail, localImagePath,
+                    prepTimeMinutes, cookTimeMinutes, servings, creatorId, recipeExternalUrl,
+                    privacy, version, updatedAt, deletedAt, syncState
+                ) VALUES (?, 'Carbonara', 'Classic', 'https://example.com/x.jpg',
+                    'https://example.com/x.jpg', '/files/recipe_images/x', 10, 20, 2, ?, NULL,
+                    'PUBLIC', 1, 555, NULL, 'SYNCED')
+                """.trimIndent(),
+                arrayOf(recipeId.toBlob(), UUID.randomUUID().toBlob())
+            )
+            db.execSQL(
+                "INSERT INTO recipe_image_state (recipeId, attempts, lastAttemptAt) VALUES (?, 2, 999)",
+                arrayOf(recipeId.toBlob())
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 4, true, MIGRATION_3_4)
+
+        db.query("SELECT title, localImagePath, imageBlobId FROM recipes").use { cursor ->
+            assertTrue("the recipe row should survive", cursor.moveToFirst())
+            assertEquals("Carbonara", cursor.getString(0))
+            assertEquals("/files/recipe_images/x", cursor.getString(1))
+            assertTrue("a pre-existing recipe has never been uploaded", cursor.isNull(2))
+        }
+
+        // The download counters must come through untouched: an in-flight backfill that has already
+        // burned two of its three attempts must not silently get them back.
+        db.query(
+            "SELECT attempts, lastAttemptAt, uploadAttempts, lastUploadAttemptAt, " +
+                "uploadedFileModifiedAt FROM recipe_image_state"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(2, cursor.getInt(0))
+            assertEquals(999L, cursor.getLong(1))
+            assertEquals("upload attempts start at the NOT NULL default", 0, cursor.getInt(2))
+            assertEquals(0L, cursor.getLong(3))
+            assertTrue("nothing has been uploaded yet", cursor.isNull(4))
+        }
+    }
+
+    @Test
+    fun migrateAll1To4_succeeds() {
         helper.createDatabase(TEST_DB, 1).close()
 
-        helper.runMigrationsAndValidate(TEST_DB, 3, true, MIGRATION_1_2, MIGRATION_2_3)
+        helper.runMigrationsAndValidate(
+            TEST_DB, 4, true, MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4
+        )
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/RecipeEntity.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/RecipeEntity.kt
@@ -33,6 +33,15 @@ data class RecipeEntity(
     val imageUrlThumbnail: String,
     /** Device-local only — deliberately absent from [com.tenmilelabs.chefai.core.data.sync.network.dto.SyncRecipeDto]. */
     val localImagePath: String? = null,
+    /**
+     * Content hash of this recipe's image as stored on the backend, or `null` if it has never been
+     * uploaded. Server-owned: only the image upload endpoint sets it, and a push never changes it.
+     *
+     * Unlike [localImagePath] this *does* ride the sync payload, because it is exactly the pointer a
+     * second device needs to fetch bytes it cannot re-derive. It is a hash, not an image — ADR-011
+     * Decision 2's rule that bytes never travel in the JSON payload is intact.
+     */
+    val imageBlobId: String? = null,
     val prepTimeMinutes: Int,
     val cookTimeMinutes: Int,
     val servings: Int,

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/RecipeImageStateEntity.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/RecipeImageStateEntity.kt
@@ -31,6 +31,25 @@ import java.util.UUID
 )
 data class RecipeImageStateEntity(
     @PrimaryKey val recipeId: UUID,
+    /** Download attempts, by [com.tenmilelabs.chefai.recipes.data.worker.RecipeImageBackfillWorker]. */
     val attempts: Int,
     val lastAttemptAt: Long,
+    /**
+     * Upload attempts, by [com.tenmilelabs.chefai.recipes.data.worker.RecipeImageUploadWorker].
+     *
+     * Counted separately from [attempts] so the two ladders cannot starve one another: a recipe
+     * whose upload keeps failing must still be eligible for a download, and vice versa.
+     */
+    val uploadAttempts: Int = 0,
+    val lastUploadAttemptAt: Long = 0,
+    /**
+     * `lastModified()` of the local image file at the moment it was last uploaded successfully.
+     *
+     * This is how a *replaced* photo is noticed. Files are keyed by recipe id, so picking a new
+     * photo overwrites the same path in place and `imageBlobId` stays non-null — without this the
+     * upload sweep would skip a recipe whose bytes had changed. Comparing mtime is what avoids
+     * hashing every candidate file on every sweep; `RecipeImageStore.write` renames a temp file into
+     * place, so the timestamp always moves.
+     */
+    val uploadedFileModifiedAt: Long? = null,
 )

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/ChefAIDataBase.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/ChefAIDataBase.kt
@@ -44,7 +44,7 @@ import com.tenmilelabs.chefai.core.data.local.room.UuidConverters
         TagEntity::class,
         UserEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(UuidConverters::class)
@@ -132,5 +132,28 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
             )
             """.trimIndent()
         )
+    }
+}
+
+/**
+ * Adds the columns Stage 2 of #132 needs to upload a recipe's image to the backend and fetch it back
+ * on another device.
+ *
+ * `recipes.imageBlobId` is the content hash of the uploaded image, and is the one image-related
+ * field that *does* travel through sync — it is the pointer a second device needs for bytes it
+ * cannot re-derive. It is server-owned; see ADR-011 and the Stage 2 plan.
+ *
+ * The three `recipe_image_state` columns track the upload half of the ladder, deliberately separate
+ * from the existing download counters so a recipe stuck on one cannot block the other.
+ *
+ * Plain `ADD COLUMN` throughout — unlike [MIGRATION_2_3] nothing is being removed, so none of the
+ * table-rebuild dance is needed.
+ */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE recipes ADD COLUMN imageBlobId TEXT")
+        db.execSQL("ALTER TABLE recipe_image_state ADD COLUMN uploadAttempts INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE recipe_image_state ADD COLUMN lastUploadAttemptAt INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE recipe_image_state ADD COLUMN uploadedFileModifiedAt INTEGER")
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapper.kt
@@ -41,6 +41,7 @@ fun RecipeEntity.toSyncDto(
     description = description,
     imageUrl = imageUrl,
     imageUrlThumbnail = imageUrlThumbnail,
+    imageBlobId = imageBlobId,
     prepTimeMinutes = prepTimeMinutes,
     cookTimeMinutes = cookTimeMinutes,
     servings = servings,
@@ -102,6 +103,9 @@ fun SyncIngredientDto.toIngredientEntity(): IngredientEntity = IngredientEntity(
  * sync (see ADR-010 Decision 6) — so the caller must pass through whatever this device already had
  * for the row, or a pull immediately after caching an image (e.g. the post-mutation push/pull that
  * follows every import) overwrites it back to null via this entity's full-row upsert.
+ *
+ * `imageBlobId` needs no such threading: it is server-owned, so the DTO's value is by definition
+ * the authoritative one (ADR-011 / Stage 2 D1).
  */
 fun SyncRecipeDto.toRecipeEntity(localImagePath: String?): RecipeEntity = RecipeEntity(
     uuid = UUID.fromString(uuid),
@@ -110,6 +114,7 @@ fun SyncRecipeDto.toRecipeEntity(localImagePath: String?): RecipeEntity = Recipe
     imageUrl = imageUrl,
     imageUrlThumbnail = imageUrlThumbnail,
     localImagePath = localImagePath,
+    imageBlobId = imageBlobId,
     prepTimeMinutes = prepTimeMinutes,
     cookTimeMinutes = cookTimeMinutes,
     servings = servings,

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/network/dto/SyncDtos.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/network/dto/SyncDtos.kt
@@ -24,6 +24,14 @@ data class SyncRecipeDto(
     val description: String,
     val imageUrl: String,
     val imageUrlThumbnail: String,
+    /**
+     * Content hash of the recipe's image on the backend, or `null` if none was ever uploaded.
+     *
+     * Server-owned. The server ignores whatever a push carries here and echoes its own value, so a
+     * client cannot point a recipe at a blob it did not upload, and the field takes no part in
+     * last-writer-wins. Defaulted so a server that predates image upload still deserialises.
+     */
+    val imageBlobId: String? = null,
     val prepTimeMinutes: Int,
     val cookTimeMinutes: Int,
     val servings: Int,

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -15,6 +15,7 @@ import com.tenmilelabs.chefai.core.data.local.room.TransactionRunner
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_1_2
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_2_3
+import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_3_4
 import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
@@ -86,7 +87,7 @@ object DatabaseModules {
             ChefAIDataBase::class.java,
             "ChefAI.db"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/domain/model/Recipe.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/domain/model/Recipe.kt
@@ -20,6 +20,14 @@ data class Recipe(
      * Device-local, so it is never synced — see https://github.com/jmuci/ChefAI/issues/132.
      */
     val localImagePath: String? = null,
+    /**
+     * Content hash of this recipe's image on the backend, or `null` if it was never uploaded.
+     *
+     * Carried on the domain model only so it survives a round trip through
+     * [com.tenmilelabs.chefai.recipes.data.mapper.toRoomEntity], whose full-row write would
+     * otherwise reset it. Nothing in the UI reads it.
+     */
+    val imageBlobId: String? = null,
     val prepTimeMinutes: Int,
     val cookTimeMinutes: Int,
     val servings: Int,

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/RoomDomainMap.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/RoomDomainMap.kt
@@ -35,6 +35,7 @@ fun RecipeWithDetails.toDomain(ingredients: List<RecipeIngredient> = emptyList()
         imageUrl = recipe.imageUrl,
         imageUrlThumbnail = recipe.imageUrlThumbnail,
         localImagePath = recipe.localImagePath,
+        imageBlobId = recipe.imageBlobId,
         prepTimeMinutes = recipe.prepTimeMinutes,
         cookTimeMinutes = recipe.cookTimeMinutes,
         servings = recipe.servings,
@@ -140,6 +141,10 @@ fun Recipe.toRoomEntity(): RecipeEntity = RecipeEntity(
     imageUrl = imageUrl,
     imageUrlThumbnail = imageUrlThumbnail,
     localImagePath = localImagePath,
+    // Threaded, not defaulted. This is a full-row write, so a field left out here is silently reset
+    // on every save that goes through the domain model — the same class of bug as #128's
+    // hardcoded `deletedAt` two lines below.
+    imageBlobId = imageBlobId,
     prepTimeMinutes = prepTimeMinutes,
     cookTimeMinutes = cookTimeMinutes,
     servings = servings,

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapperTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/mapper/SyncMapperTest.kt
@@ -134,6 +134,40 @@ class SyncMapperTest {
     }
 
     @Test
+    fun `toSyncDto carries imageBlobId — the pointer does travel, unlike the bytes`() {
+        val uploaded = recipeEntity.copy(
+            localImagePath = "/files/recipe_images/$recipeId",
+            imageBlobId = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        )
+
+        val dto = uploaded.toSyncDto(stepEntities, ingredientEntities, tagCrossRefs, labelCrossRefs)
+
+        assertThat(dto.imageBlobId)
+            .isEqualTo("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+        // Still no bytes and no device-local path — ADR-011 Decision 2 holds.
+        assertThat(Json.encodeToString(dto)).doesNotContain("recipe_images")
+    }
+
+    @Test
+    fun `toRecipeEntity takes imageBlobId from the wire — the server owns it`() {
+        val entity = syncRecipeDto
+            .copy(imageBlobId = "abc123")
+            .toRecipeEntity(localImagePath = "/files/recipe_images/$recipeId")
+
+        assertThat(entity.imageBlobId).isEqualTo("abc123")
+        assertThat(entity.localImagePath).isEqualTo("/files/recipe_images/$recipeId")
+    }
+
+    @Test
+    fun `a pull that clears imageBlobId clears it locally too`() {
+        // The server dropping the pointer (the image was deleted, or a blob was reclaimed) has to
+        // reach the client, or the download tier keeps chasing bytes that are no longer there.
+        val entity = syncRecipeDto.copy(imageBlobId = null).toRecipeEntity(localImagePath = null)
+
+        assertThat(entity.imageBlobId).isNull()
+    }
+
+    @Test
     fun `toSyncDto maps steps correctly`() {
         val dto = recipeEntity.toSyncDto(stepEntities, ingredientEntities, tagCrossRefs, labelCrossRefs)
 

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/RoomDomainMapTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/RoomDomainMapTest.kt
@@ -1,0 +1,72 @@
+package com.tenmilelabs.chefai.recipes.data.mapper
+
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.domain.model.Recipe
+import com.tenmilelabs.chefai.core.domain.model.User
+import org.junit.Test
+
+/**
+ * Guards the image fields across the domain↔entity boundary.
+ *
+ * [toRoomEntity] builds a whole [com.tenmilelabs.chefai.core.data.local.room.RecipeEntity] and is fed
+ * straight into a full-row `@Upsert`, so any column it forgets is silently reset on every save that
+ * goes through the domain model. That is not hypothetical: the same shape of bug wiped a freshly
+ * cached `localImagePath` on the sync path (#139), and `deletedAt` is hardcoded to null here today
+ * (#128). These tests pin the two image pointers so a third instance can't land quietly.
+ */
+class RoomDomainMapTest {
+
+    private val creator = User(
+        uuid = UuidV7Generator.newId(),
+        displayName = "Tester",
+        email = "tester@example.com",
+        avatarUrl = "",
+    )
+
+    private fun recipe(
+        localImagePath: String? = null,
+        imageBlobId: String? = null,
+    ) = Recipe(
+        uuid = UuidV7Generator.newId(),
+        title = "Carbonara",
+        description = "Classic",
+        imageUrl = "https://example.com/x.jpg",
+        imageUrlThumbnail = "https://example.com/x.jpg",
+        localImagePath = localImagePath,
+        imageBlobId = imageBlobId,
+        prepTimeMinutes = 10,
+        cookTimeMinutes = 20,
+        servings = 2,
+        creator = creator,
+        recipeExternalUrl = null,
+        ingredients = emptyList(),
+        steps = emptyList(),
+        tags = emptyList(),
+        labels = emptyList(),
+        updatedAt = 555L,
+    )
+
+    @Test
+    fun `toRoomEntity carries imageBlobId, so saving does not orphan an uploaded image`() {
+        val entity = recipe(imageBlobId = "abc123").toRoomEntity()
+
+        assertThat(entity.imageBlobId).isEqualTo("abc123")
+    }
+
+    @Test
+    fun `toRoomEntity carries localImagePath`() {
+        val entity = recipe(localImagePath = "/files/recipe_images/x").toRoomEntity()
+
+        assertThat(entity.localImagePath).isEqualTo("/files/recipe_images/x")
+    }
+
+    @Test
+    fun `a recipe with neither pointer maps to nulls, not empty strings`() {
+        // recipeImageModel treats "" and null differently — Coil throws on an empty model.
+        val entity = recipe().toRoomEntity()
+
+        assertThat(entity.imageBlobId).isNull()
+        assertThat(entity.localImagePath).isNull()
+    }
+}


### PR DESCRIPTION
Second of five PRs completing Stage 2 of #132. Schema only — **no behaviour change**: nothing writes `imageBlobId` yet and nothing reads the new upload columns. Split out so the migration lands ahead of the workers that need it.

Independent of [#145](https://github.com/jmuci/ChefAI/pull/145); shares no files, based on `main`.

## `recipes.imageBlobId`

The content hash of the recipe's image as stored on the backend, and the one image-related field that **does** ride the sync payload — it's exactly the pointer a second device needs for bytes it can't re-derive. A hash, not bytes, so ADR-011 Decision 2 is intact.

It's **server-owned**: only the upload endpoint sets it, a push never changes it. That keeps it out of last-writer-wins entirely — a client can't point a recipe at a blob it didn't upload, and blobs are immutable, so two devices can never disagree about one's contents. `toRecipeEntity` takes it straight off the wire and needs none of the threading `localImagePath` requires.

## The part worth reviewing: `Recipe.toRoomEntity()`

That mapper builds a whole entity for a full-row `@Upsert`, so **a field omitted there is silently reset on every save through the domain model.** That's the bug that ate a freshly-cached `localImagePath` in #139, and the one `deletedAt` still has in [#128](https://github.com/jmuci/ChefAI/issues/128) (`deletedAt = null, // or appropriate value`).

`imageBlobId` is threaded explicitly, and `RoomDomainMapTest` now pins both pointers so a third instance can't land quietly. #128 itself is left alone — its fix changes delete semantics and wants its own PR.

## `recipe_image_state`

Three columns for the upload half of the ladder, counted separately from the existing download attempts so a recipe stuck on one can't block the other.

`uploadedFileModifiedAt` is how a **replaced** photo gets noticed: files are keyed by recipe id, so picking a new photo overwrites the same path in place and `imageBlobId` stays non-null. Comparing the file's mtime against the value recorded at upload catches that without hashing every candidate on every sweep.

## Migration

`MIGRATION_3_4` is plain `ADD COLUMN` throughout — nothing is removed, so none of `MIGRATION_2_3`'s table-rebuild dance is needed.

## Verification

- `:app:testDebugUnitTest` — **451 tests, 0 failures** (+6: 3 sync-mapper, 3 domain-mapper)
- `:app:connectedDebugAndroidTest` for `ChefAIDatabaseMigrationTest` — **3 tests green** on a Pixel 6 Pro AVD, covering v2→v3, the new v3→v4, and a full v1→v4 chain
- v3→v4 asserts in-flight download attempt counts survive, so a backfill that's burned 2 of 3 attempts doesn't silently get them back
- Schema `4.json` exported and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)