### PR TITLE
Recipe images: upload cached images to the backend (#132)

### DIFF
--- a/app/src/androidTest/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncScheduler.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncScheduler.kt
@@ -28,6 +28,10 @@ class FakeSyncScheduler : SyncScheduler {
         Timber.d("FakeSyncScheduler: schedulePeriodicSync (no-op)")
     }
 
+    override fun scheduleImageUpload() {
+        Timber.d("FakeSyncScheduler: scheduleImageUpload (no-op)")
+    }
+
     override fun scheduleImageBackfill() {
         Timber.d("FakeSyncScheduler: scheduleImageBackfill (no-op)")
     }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeImageUploadDaoTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeImageUploadDaoTest.kt
@@ -1,0 +1,216 @@
+package com.tenmilelabs.chefai.data.source.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
+import com.tenmilelabs.chefai.core.data.local.room.UserEntity
+import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
+import com.tenmilelabs.chefai.core.data.local.util.SyncState
+import com.tenmilelabs.chefai.recipes.data.worker.MAX_IMAGE_UPLOAD_ATTEMPTS
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+private const val SCAN_LIMIT = 200
+private const val LOCAL_PATH = "/files/recipe_images/x"
+
+/**
+ * Covers the SQL-side half of the image upload sweep: which rows it is willing to consider at all.
+ * The "are these still the bytes we sent" half lives in `RecipeImageUploadTest` (JVM).
+ */
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class RecipeImageUploadDaoTest {
+
+    private lateinit var database: ChefAIDataBase
+
+    private val testUser = UserEntity(
+        uuid = UuidV7Generator.newId(),
+        displayName = "Test User",
+        email = "test@test.com",
+        avatarUrl = "",
+        updatedAt = System.currentTimeMillis(),
+        deletedAt = null
+    )
+
+    private fun recipe(
+        imageUrl: String = "https://food.fnr.sndimg.com/hero.webp",
+        localImagePath: String? = LOCAL_PATH,
+        imageBlobId: String? = null,
+        deletedAt: Long? = null,
+        syncState: SyncState = SyncState.SYNCED,
+        updatedAt: Long = System.currentTimeMillis(),
+    ) = RecipeEntity(
+        uuid = UuidV7Generator.newId(),
+        title = "Recipe",
+        description = "",
+        imageUrl = imageUrl,
+        imageUrlThumbnail = imageUrl,
+        localImagePath = localImagePath,
+        imageBlobId = imageBlobId,
+        prepTimeMinutes = 5,
+        cookTimeMinutes = 5,
+        servings = 1,
+        creatorId = testUser.uuid,
+        recipeExternalUrl = null,
+        updatedAt = updatedAt,
+        deletedAt = deletedAt,
+        syncState = syncState,
+    )
+
+    private suspend fun candidates(): List<UUID> = database.recipeDao()
+        .getImageUploadCandidates(MAX_IMAGE_UPLOAD_ATTEMPTS, SCAN_LIMIT)
+        .map { it.recipeId }
+
+    @Before
+    fun setup() = runTest {
+        database = Room.inMemoryDatabaseBuilder(getApplicationContext(), ChefAIDataBase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        database.userDao().upsertUser(testUser)
+    }
+
+    @After
+    fun teardown() = database.close()
+
+    @Test
+    fun aSyncedRecipeWithACachedImageIsACandidate() = runTest {
+        val target = recipe()
+        database.recipeDao().upsertRecipe(target)
+
+        assertEquals(listOf(target.uuid), candidates())
+    }
+
+    @Test
+    fun aRecipeWithNoCachedImageIsNotACandidate() = runTest {
+        database.recipeDao().upsertRecipe(recipe(localImagePath = null))
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun anUnsyncedRecipeIsNotACandidate() = runTest {
+        // The recipe row has to reach the server before its image can attach to it. Uploading first
+        // would 404, so PENDING rows wait for the push that is about to happen anyway.
+        database.recipeDao().upsertRecipe(recipe(syncState = SyncState.PENDING))
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun aSoftDeletedRecipeIsNotACandidate() = runTest {
+        database.recipeDao().upsertRecipe(recipe(deletedAt = System.currentTimeMillis()))
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun aRecipeThatHasExhaustedItsUploadAttemptsIsNotACandidate() = runTest {
+        val target = recipe()
+        database.recipeDao().upsertRecipe(target)
+        repeat(MAX_IMAGE_UPLOAD_ATTEMPTS) {
+            database.recipeImageStateDao().recordUploadAttempt(target.uuid, 1L)
+        }
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun aRecipeOneAttemptShortOfTheCapIsStillACandidate() = runTest {
+        val target = recipe()
+        database.recipeDao().upsertRecipe(target)
+        repeat(MAX_IMAGE_UPLOAD_ATTEMPTS - 1) {
+            database.recipeImageStateDao().recordUploadAttempt(target.uuid, 1L)
+        }
+
+        assertEquals(listOf(target.uuid), candidates())
+    }
+
+    @Test
+    fun anAlreadyUploadedRecipeStillComesBack_theFileCheckIsTheCallersJob() = runTest {
+        // SQL can't tell whether the bytes on disk are still the ones that were sent, so the query
+        // deliberately over-selects and the worker narrows on mtime.
+        val target = recipe(imageBlobId = "abc")
+        database.recipeDao().upsertRecipe(target)
+
+        assertEquals(listOf(target.uuid), candidates())
+    }
+
+    @Test
+    fun userPhotosAreOrderedAheadOfScrapedImages() = runTest {
+        // A blank imageUrl means the image cannot be re-derived from anywhere (ADR-011 Decision 3).
+        // If a sweep only gets partway through its batch, those are the bytes worth saving first —
+        // even though this scraped recipe is the more recently updated of the two.
+        val userPhoto = recipe(imageUrl = "", updatedAt = 1_000L)
+        val scraped = recipe(updatedAt = 9_000L)
+        database.recipeDao().upsertRecipe(scraped)
+        database.recipeDao().upsertRecipe(userPhoto)
+
+        assertEquals(listOf(userPhoto.uuid, scraped.uuid), candidates())
+    }
+
+    @Test
+    fun recordUploadSuccessClearsAttemptsAndRemembersTheFile() = runTest {
+        val target = recipe()
+        database.recipeDao().upsertRecipe(target)
+        database.recipeImageStateDao().recordUploadAttempt(target.uuid, 1L)
+
+        database.recipeImageStateDao().recordUploadSuccess(target.uuid, modifiedAt = 4242L)
+
+        val state = database.recipeImageStateDao().getByRecipeId(target.uuid)
+        assertEquals(0, state?.uploadAttempts)
+        assertEquals(4242L, state?.uploadedFileModifiedAt)
+    }
+
+    @Test
+    fun burnUploadAttemptsRemovesTheRecipeFromFutureSweepsInOneGo() = runTest {
+        val target = recipe()
+        database.recipeDao().upsertRecipe(target)
+
+        database.recipeImageStateDao()
+            .burnUploadAttempts(target.uuid, at = 1L, cap = MAX_IMAGE_UPLOAD_ATTEMPTS)
+
+        assertTrue(candidates().isEmpty())
+    }
+
+    @Test
+    fun uploadAndDownloadAttemptCountsDoNotInterfere() = runTest {
+        // The two ladders share a row but must not share a budget: an image the backend keeps
+        // refusing should still be eligible for a download, and vice versa.
+        val target = recipe()
+        database.recipeDao().upsertRecipe(target)
+
+        database.recipeImageStateDao()
+            .burnUploadAttempts(target.uuid, at = 1L, cap = MAX_IMAGE_UPLOAD_ATTEMPTS)
+
+        val state = database.recipeImageStateDao().getByRecipeId(target.uuid)
+        assertEquals(MAX_IMAGE_UPLOAD_ATTEMPTS, state?.uploadAttempts)
+        assertEquals("download attempts untouched", 0, state?.attempts)
+    }
+
+    @Test
+    fun updateImageBlobIdDoesNotDisturbTheRowsSyncStateOrTimestamp() = runTest {
+        // The value came from the server, so pushing it back would churn the pull delta forever.
+        val target = recipe(updatedAt = 777L)
+        database.recipeDao().upsertRecipe(target)
+
+        database.recipeDao().updateImageBlobId(target.uuid, "abc")
+
+        val stored = database.recipeDao().getRecipeById(target.uuid)
+        assertEquals("abc", stored?.imageBlobId)
+        assertEquals(777L, stored?.updatedAt)
+        assertEquals(SyncState.SYNCED, stored?.syncState)
+        assertNull(stored?.deletedAt)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Transaction
 import androidx.room.Upsert
 import com.tenmilelabs.chefai.core.data.local.room.RecipeEntity
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageCandidate
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageUploadCandidate
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithDetails
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithLabels
@@ -138,6 +139,50 @@ interface RecipeDao {
 
     @Query("UPDATE recipes SET localImagePath = :localImagePath WHERE uuid = :uuid")
     suspend fun updateLocalImagePath(uuid: UUID, localImagePath: String?)
+
+    /**
+     * Recipes whose cached image may not be on the backend yet.
+     *
+     * `syncState = 'SYNCED'` is doing real work: the recipe row has to exist server-side before its
+     * image can be attached to it, so this is what makes the upload unable to 404 and removes any
+     * ordering question between the two.
+     *
+     * User photos are ordered first because they are the only images that cannot be re-derived from
+     * anywhere — a blank `imageUrl` means exactly that (ADR-011 Decision 3). If a sweep only gets
+     * through part of its batch, the irreplaceable bytes are the ones that made it.
+     *
+     * Deliberately over-selects rows that already have an `imageBlobId`: whether the file on disk is
+     * still the one that was uploaded isn't expressible in SQL. The caller narrows — see
+     * `RecipeImageUploadWorker`.
+     */
+    @Query(
+        """
+        SELECT r.uuid AS recipeId, r.localImagePath AS localImagePath,
+               r.imageBlobId AS imageBlobId, s.uploadedFileModifiedAt AS uploadedFileModifiedAt
+        FROM recipes r
+        LEFT JOIN recipe_image_state s ON s.recipeId = r.uuid
+        WHERE r.deletedAt IS NULL
+          AND r.localImagePath IS NOT NULL
+          AND r.syncState = 'SYNCED'
+          AND COALESCE(s.uploadAttempts, 0) < :maxAttempts
+        ORDER BY (r.imageUrl = '') DESC, r.updatedAt DESC
+        LIMIT :scanLimit
+        """
+    )
+    suspend fun getImageUploadCandidates(
+        maxAttempts: Int,
+        scanLimit: Int,
+    ): List<RecipeImageUploadCandidate>
+
+    /**
+     * Records the blob the backend stored for this recipe.
+     *
+     * A targeted UPDATE, not a row write: the value came *from* the server, so it must not mark the
+     * row PENDING or move `updatedAt` — doing either would push a change the server already has and
+     * churn the pull delta forever.
+     */
+    @Query("UPDATE recipes SET imageBlobId = :imageBlobId WHERE uuid = :uuid")
+    suspend fun updateImageBlobId(uuid: UUID, imageBlobId: String?)
 
     // --- Account upgrade queries ---
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeImageStateDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeImageStateDao.kt
@@ -17,4 +17,68 @@ interface RecipeImageStateDao {
 
     @Query("DELETE FROM recipe_image_state WHERE recipeId = :recipeId")
     suspend fun delete(recipeId: UUID)
+
+    // --- Upload half of the ladder ---
+    //
+    // Upserts rather than read-modify-write, because the bookkeeping row may not exist: the download
+    // sweep creates one only when a fetch fails, and a recipe whose image uploads on the first try
+    // has never needed one.
+
+    /**
+     * Counts an upload attempt, before it is made.
+     *
+     * Recorded up front for the same reason the download side does it: a run killed mid-request —
+     * the process dying, the network dropping, WorkManager's budget expiring — must still count, or
+     * a request that reliably hangs is retried forever.
+     */
+    @Query(
+        """
+        INSERT INTO recipe_image_state
+            (recipeId, attempts, lastAttemptAt, uploadAttempts, lastUploadAttemptAt, uploadedFileModifiedAt)
+        VALUES (:recipeId, 0, 0, 1, :at, NULL)
+        ON CONFLICT(recipeId) DO UPDATE SET
+            uploadAttempts = uploadAttempts + 1,
+            lastUploadAttemptAt = :at
+        """
+    )
+    suspend fun recordUploadAttempt(recipeId: UUID, at: Long)
+
+    /**
+     * Remembers which bytes are on the backend, and clears the attempt count so a future
+     * replacement of this image starts with a full budget.
+     *
+     * The row is kept rather than deleted — unlike the download side, where a row's absence means
+     * "resolved". Here [RecipeImageStateEntity.uploadedFileModifiedAt] is the only record of *what*
+     * was uploaded, and losing it would make a replaced photo indistinguishable from an unchanged
+     * one.
+     */
+    @Query(
+        """
+        INSERT INTO recipe_image_state
+            (recipeId, attempts, lastAttemptAt, uploadAttempts, lastUploadAttemptAt, uploadedFileModifiedAt)
+        VALUES (:recipeId, 0, 0, 0, 0, :modifiedAt)
+        ON CONFLICT(recipeId) DO UPDATE SET
+            uploadAttempts = 0,
+            uploadedFileModifiedAt = :modifiedAt
+        """
+    )
+    suspend fun recordUploadSuccess(recipeId: UUID, modifiedAt: Long?)
+
+    /**
+     * Spends the whole attempt budget at once, for a rejection that will fail identically forever —
+     * a body the server refuses, a recipe that isn't ours, an exhausted quota.
+     *
+     * Retrying those two more times only produces two more identical rejections.
+     */
+    @Query(
+        """
+        INSERT INTO recipe_image_state
+            (recipeId, attempts, lastAttemptAt, uploadAttempts, lastUploadAttemptAt, uploadedFileModifiedAt)
+        VALUES (:recipeId, 0, 0, :cap, :at, NULL)
+        ON CONFLICT(recipeId) DO UPDATE SET
+            uploadAttempts = :cap,
+            lastUploadAttemptAt = :at
+        """
+    )
+    suspend fun burnUploadAttempts(recipeId: UUID, at: Long, cap: Int)
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/relations/RecipeImageCandidate.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/relations/RecipeImageCandidate.kt
@@ -12,3 +12,18 @@ data class RecipeImageCandidate(
     val imageUrl: String,
     val localImagePath: String?,
 )
+
+/**
+ * What the image *upload* sweep needs to decide whether a recipe's cached bytes are already on the
+ * backend, and to notice when they have been replaced since.
+ *
+ * [imageBlobId] non-null means something was uploaded once; whether it is still the *current* image
+ * is a question about the file on disk, which SQL cannot answer — see
+ * [com.tenmilelabs.chefai.recipes.data.worker.RecipeImageUploadWorker].
+ */
+data class RecipeImageUploadCandidate(
+    val recipeId: UUID,
+    val localImagePath: String,
+    val imageBlobId: String?,
+    val uploadedFileModifiedAt: Long?,
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncManager.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncManager.kt
@@ -11,6 +11,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.tenmilelabs.chefai.core.data.sync.worker.SyncWorker
 import com.tenmilelabs.chefai.recipes.data.worker.RecipeImageBackfillWorker
+import com.tenmilelabs.chefai.recipes.data.worker.RecipeImageUploadWorker
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.TimeUnit
@@ -30,6 +31,7 @@ class SyncManager @Inject constructor(
         const val SYNC_WORK_NAME = "recipe_sync"
         const val PERIODIC_SYNC_WORK_NAME = "recipe_periodic_sync"
         const val IMAGE_BACKFILL_WORK_NAME = "recipe_image_backfill"
+        const val IMAGE_UPLOAD_WORK_NAME = "recipe_image_upload"
     }
 
     val syncStatus: StateFlow<SyncStatus> get() = syncStatusHolder.syncStatus
@@ -121,6 +123,19 @@ class SyncManager @Inject constructor(
     }
 
     /**
+     * Enqueue a sweep sending recipe images the backend doesn't have yet.
+     * KEEP, so a sync finishing while a sweep is already queued doesn't stack requests.
+     */
+    override fun scheduleImageUpload() {
+        val request = OneTimeWorkRequestBuilder<RecipeImageUploadWorker>()
+            .setConstraints(imageUploadConstraints())
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_DELAY_SECONDS, TimeUnit.SECONDS)
+            .build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(IMAGE_UPLOAD_WORK_NAME, ExistingWorkPolicy.KEEP, request)
+    }
+
+    /**
      * Cancel all sync work (e.g., on logout).
      */
     override fun cancelAllSync() {
@@ -128,6 +143,7 @@ class SyncManager @Inject constructor(
         wm.cancelUniqueWork(SYNC_WORK_NAME)
         wm.cancelUniqueWork(PERIODIC_SYNC_WORK_NAME)
         wm.cancelUniqueWork(IMAGE_BACKFILL_WORK_NAME)
+        wm.cancelUniqueWork(IMAGE_UPLOAD_WORK_NAME)
     }
 
     private fun connectedConstraints() = Constraints.Builder()
@@ -147,5 +163,17 @@ class SyncManager @Inject constructor(
     private fun imageBackfillConstraints() = Constraints.Builder()
         .setRequiredNetworkType(NetworkType.UNMETERED)
         .setRequiresCharging(true)
+        .build()
+
+    /**
+     * Unmetered like the backfill, but deliberately *not* charging-only.
+     *
+     * Backfill can afford to wait for a charger — it re-derives images that already exist elsewhere,
+     * some of them behind a `WebView`. An upload is a single request of a few hundred kilobytes, and
+     * a user-taken photo has no copy anywhere until it completes, so making it wait for a charger
+     * would extend exactly the window this feature exists to close.
+     */
+    private fun imageUploadConstraints() = Constraints.Builder()
+        .setRequiredNetworkType(NetworkType.UNMETERED)
         .build()
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncScheduler.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncScheduler.kt
@@ -26,5 +26,13 @@ interface SyncScheduler {
      * waiting on it.
      */
     fun scheduleImageBackfill()
+
+    /**
+     * Enqueues a sweep sending recipe images this device holds and the backend does not.
+     *
+     * Unmetered like the backfill, but without its charging requirement: an upload is one small
+     * request, and until it lands a user-taken photo exists nowhere but this device.
+     */
+    fun scheduleImageUpload()
     fun cancelAllSync()
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/worker/SyncWorker.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/worker/SyncWorker.kt
@@ -47,6 +47,10 @@ class SyncWorker @AssistedInject constructor(
             // Enqueued rather than chained: backfill waits for a charger and unmetered data, and a
             // chain would hold this sync's slot until those were satisfied.
             syncScheduler.scheduleImageBackfill()
+            // The mirror of that: images this device holds that the backend doesn't. Enqueued after
+            // the push specifically, since a recipe row must exist server-side before its image can
+            // attach to it — which is why the upload sweep only considers SYNCED rows.
+            syncScheduler.scheduleImageUpload()
             Result.success()
         } catch (e: SyncHttpException) {
             if (e.statusCode == 401) {

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/local/RecipeImageStore.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/local/RecipeImageStore.kt
@@ -122,6 +122,34 @@ class RecipeImageStore @Inject constructor(
         write(recipeId, bytes)
     }
 
+    /**
+     * Reads the stored image for [recipeId], or `null` if there isn't one.
+     *
+     * Returns the whole file in memory, which is fine here and only here: everything this store
+     * holds has already been bounded — a network fetch by
+     * [com.tenmilelabs.chefai.recipes.data.network.MAX_IMAGE_BYTES], a picked photo by
+     * [PICKED_IMAGE_MAX_EDGE] and JPEG re-encoding.
+     */
+    suspend fun read(recipeId: UUID): ByteArray? = withContext(ioDispatcher) {
+        try {
+            fileFor(recipeId).takeIf { it.exists() }?.readBytes()
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to read recipe image for %s", recipeId)
+            null
+        }
+    }
+
+    /**
+     * Last-modified timestamp of the stored image, or `null` if there isn't one.
+     *
+     * The upload sweep uses this to notice a photo that was *replaced*: files are keyed by recipe
+     * id, so a new pick overwrites the same path and every other signal stays identical. [write]
+     * renames a temp file into place, so this always moves when the bytes do.
+     */
+    suspend fun lastModified(recipeId: UUID): Long? = withContext(ioDispatcher) {
+        fileFor(recipeId).takeIf { it.exists() }?.lastModified()
+    }
+
     /** Removes the stored image for [recipeId], if any. */
     suspend fun delete(recipeId: UUID): Unit = withContext(ioDispatcher) {
         fileFor(recipeId).delete()

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/RecipeImageUploader.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/RecipeImageUploader.kt
@@ -1,0 +1,147 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import com.tenmilelabs.chefai.BuildConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.request.put
+import io.ktor.client.request.header
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+import java.security.MessageDigest
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
+
+/** Header the backend uses to verify the body arrived intact, and to key the stored blob. */
+private const val CONTENT_SHA256_HEADER = "X-Content-SHA256"
+
+/**
+ * Uploaded images are always JPEG: a picked photo is re-encoded by `RecipeImageStore.writeFromUri`,
+ * and a scraped one is whatever the source served. Declaring JPEG for the latter is harmless — the
+ * backend sniffs the magic bytes rather than trusting this header — but see [detectMimeType].
+ */
+private val DEFAULT_IMAGE_TYPE = ContentType.Image.JPEG
+
+@Serializable
+private data class UploadImageResponse(
+    @SerialName("imageBlobId") val imageBlobId: String,
+    @SerialName("updatedAt") val updatedAt: Long = 0,
+)
+
+/**
+ * The three outcomes the upload sweep needs to tell apart.
+ *
+ * The permanent/transient split is what stops a rejected upload being retried forever: a body the
+ * server will never accept (wrong hash, wrong type, too big, quota, a recipe that isn't ours) fails
+ * identically on every attempt, so it burns the attempt counter straight to its cap rather than one
+ * at a time.
+ */
+sealed interface ImageUploadOutcome {
+    data class Success(val imageBlobId: String) : ImageUploadOutcome
+
+    /** The server will never accept these bytes for this recipe. Stop asking. */
+    data class Permanent(val reason: String) : ImageUploadOutcome
+
+    /** Server-side or network trouble. Worth another go later. */
+    data class Transient(val reason: String) : ImageUploadOutcome
+}
+
+/**
+ * Uploads a recipe's cached image to the backend.
+ *
+ * Deliberately uses the **default, authenticated** [HttpClient], never
+ * [com.tenmilelabs.chefai.core.di.ScraperHttpClient] — this is our own host and the request must
+ * carry the JWT. The inverse matters just as much: the URL is built only from
+ * [BuildConfig.API_BASE_URL], never from a recipe's `imageUrl`, so an auth token can never be sent
+ * to a third-party CDN (ADR-010).
+ *
+ * Raw body rather than multipart. There is exactly one file and no form fields, so a multipart
+ * envelope would add a boundary parser on both ends and buy nothing.
+ */
+@Singleton
+class RecipeImageUploader @Inject constructor(
+    private val client: HttpClient,
+    private val json: Json,
+) {
+
+    suspend fun upload(recipeId: UUID, bytes: ByteArray): ImageUploadOutcome = try {
+        val response = client.put("${BuildConfig.API_BASE_URL}/recipes/$recipeId/image") {
+            contentType(detectMimeType(bytes))
+            header(CONTENT_SHA256_HEADER, sha256Hex(bytes))
+            setBody(bytes)
+            expectSuccess = false
+        }
+
+        when {
+            response.status.isSuccess() -> {
+                val body = json.decodeFromString<UploadImageResponse>(response.bodyAsText())
+                Timber.i("Uploaded image for %s as %s", recipeId, body.imageBlobId)
+                ImageUploadOutcome.Success(body.imageBlobId)
+            }
+
+            // 408 and 429 are the two 4xx that say "later", not "never".
+            response.status == HttpStatusCode.RequestTimeout ||
+                response.status == HttpStatusCode.TooManyRequests ->
+                ImageUploadOutcome.Transient("HTTP ${response.status.value}")
+
+            response.status.value in 400..499 -> {
+                Timber.w(
+                    "Image upload for %s permanently rejected: %s", recipeId, response.status
+                )
+                ImageUploadOutcome.Permanent("HTTP ${response.status.value}")
+            }
+
+            else -> ImageUploadOutcome.Transient("HTTP ${response.status.value}")
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // Includes a malformed success body: a 200 we cannot parse leaves us not knowing the blob
+        // id, which is indistinguishable from not having uploaded, so it must be retried.
+        Timber.w(e, "Image upload for %s failed", recipeId)
+        ImageUploadOutcome.Transient(e.message ?: e::class.java.simpleName)
+    }
+}
+
+/** Lowercase hex SHA-256, the form the backend compares against. */
+internal fun sha256Hex(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+
+/**
+ * Picks a `Content-Type` from the bytes themselves rather than from the file name, which these files
+ * do not have — [com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore] stores them extensionless
+ * because Coil sniffs the type anyway.
+ *
+ * The backend re-sniffs and rejects a mismatch, so getting this wrong is a failed upload rather than
+ * a security hole; it is here so that a legitimately-PNG scraped image isn't rejected for claiming
+ * to be a JPEG.
+ */
+internal fun detectMimeType(bytes: ByteArray): ContentType = when {
+    bytes.size >= 3 &&
+        bytes[0] == 0xFF.toByte() &&
+        bytes[1] == 0xD8.toByte() &&
+        bytes[2] == 0xFF.toByte() -> ContentType.Image.JPEG
+
+    bytes.size >= 8 &&
+        bytes[0] == 0x89.toByte() &&
+        bytes[1] == 'P'.code.toByte() &&
+        bytes[2] == 'N'.code.toByte() &&
+        bytes[3] == 'G'.code.toByte() -> ContentType.Image.PNG
+
+    bytes.size >= 12 &&
+        bytes.copyOfRange(0, 4).decodeToString() == "RIFF" &&
+        bytes.copyOfRange(8, 12).decodeToString() == "WEBP" -> ContentType("image", "webp")
+
+    else -> DEFAULT_IMAGE_TYPE
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageUploadWorker.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageUploadWorker.kt
@@ -1,0 +1,104 @@
+package com.tenmilelabs.chefai.recipes.data.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeImageStateDao
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageUploadCandidate
+import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
+import com.tenmilelabs.chefai.recipes.domain.usecase.UploadRecipeImage
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+import java.io.File
+
+/** How many times one recipe's image is offered to the backend before it is given up on. */
+internal const val MAX_IMAGE_UPLOAD_ATTEMPTS = 3
+
+/** Rows examined per run. Bounds the query, not the work — most rows are already uploaded. */
+internal const val IMAGE_UPLOAD_SCAN_LIMIT = 200
+
+/** Images actually sent per run, so one sweep can't push tens of megabytes in a burst. */
+internal const val IMAGE_UPLOAD_BATCH = 10
+
+/**
+ * Sends recipe images this device has and the backend doesn't.
+ *
+ * This is the half of cross-device images that no amount of client cleverness can replace. A scraped
+ * image can, in principle, be re-derived anywhere from its source URL; a photo the user took has no
+ * source at all, so until it is uploaded the device holding it holds the only copy in existence, and
+ * a reinstall or a lost phone destroys it. The candidate query puts those first for exactly that
+ * reason.
+ *
+ * Runs after a successful sync rather than on the mutation path: the recipe row must already exist
+ * server-side for its image to attach to, and nothing is waiting on the bytes.
+ *
+ * Constraints are deliberately weaker than [RecipeImageBackfillWorker]'s — unmetered, but no charging
+ * requirement. Backfill waits for a charger because a `WebView` spin-up per image is genuinely
+ * expensive and costs nothing to defer. An upload is one request of a few hundred kilobytes, and
+ * every hour it waits is another hour a user's only copy of a photo lives on one device.
+ */
+@HiltWorker
+class RecipeImageUploadWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val recipeDao: RecipeDao,
+    private val recipeImageStateDao: RecipeImageStateDao,
+    private val uploadRecipeImage: UploadRecipeImage,
+    private val syncScheduler: SyncScheduler,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val candidates = recipeDao
+            .getImageUploadCandidates(MAX_IMAGE_UPLOAD_ATTEMPTS, IMAGE_UPLOAD_SCAN_LIMIT)
+            .needingUpload()
+
+        if (candidates.isEmpty()) {
+            Timber.d("Image upload: nothing to do")
+            return Result.success()
+        }
+
+        val batch = candidates.take(IMAGE_UPLOAD_BATCH)
+        Timber.i("Image upload: sending %d of %d", batch.size, candidates.size)
+
+        var uploaded = 0
+        for (candidate in batch) {
+            recipeImageStateDao.recordUploadAttempt(candidate.recipeId, System.currentTimeMillis())
+            if (uploadRecipeImage(candidate.recipeId)) uploaded++
+        }
+
+        Timber.i("Image upload: %d of %d landed", uploaded, batch.size)
+
+        if (candidates.size > batch.size) {
+            syncScheduler.scheduleImageUpload()
+        }
+        return Result.success()
+    }
+}
+
+/**
+ * Narrows the over-selected rows from [RecipeDao.getImageUploadCandidates] to those whose bytes are
+ * genuinely not on the backend.
+ *
+ * Two cases qualify. A null [RecipeImageUploadCandidate.imageBlobId] has never been uploaded. A
+ * non-null one whose file's `lastModified()` differs from the timestamp recorded at upload has been
+ * *replaced* since — the picker writes a new photo over the same path, so nothing else about the row
+ * changes and the pointer alone would say the work was already done.
+ *
+ * A row whose file has vanished is skipped rather than uploaded; repairing that is the download
+ * sweep's job, not this one's.
+ *
+ * Split out from the worker so it is JVM-testable without WorkManager.
+ */
+internal fun List<RecipeImageUploadCandidate>.needingUpload(
+    lastModified: (String) -> Long? = { File(it).takeIf(File::exists)?.lastModified() },
+): List<RecipeImageUploadCandidate> = filter { candidate ->
+    val currentMtime = lastModified(candidate.localImagePath)
+    when {
+        currentMtime == null -> false
+        candidate.imageBlobId == null -> true
+        else -> currentMtime != candidate.uploadedFileModifiedAt
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/UploadRecipeImage.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/UploadRecipeImage.kt
@@ -1,0 +1,72 @@
+package com.tenmilelabs.chefai.recipes.domain.usecase
+
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeImageStateDao
+import com.tenmilelabs.chefai.core.di.IoDispatcher
+import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
+import com.tenmilelabs.chefai.recipes.data.network.ImageUploadOutcome
+import com.tenmilelabs.chefai.recipes.data.network.RecipeImageUploader
+import com.tenmilelabs.chefai.recipes.data.worker.MAX_IMAGE_UPLOAD_ATTEMPTS
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Sends one recipe's cached image to the backend and records the result.
+ *
+ * On success the returned blob id is written back with a targeted UPDATE that deliberately does not
+ * touch `updatedAt` or `syncState`: the value came from the server, so pushing it back would churn
+ * the pull delta forever. The bookkeeping row is then cleared, which is also what resets the attempt
+ * counter for a future replacement of the same image.
+ *
+ * Never throws. A failure here leaves the local file exactly where it was, which is still a working
+ * image on this device — the cost is only that other devices don't get it yet.
+ */
+class UploadRecipeImage @Inject constructor(
+    private val recipeImageStore: RecipeImageStore,
+    private val recipeImageUploader: RecipeImageUploader,
+    private val recipeDao: RecipeDao,
+    private val recipeImageStateDao: RecipeImageStateDao,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    /** @return `true` if the bytes are now on the backend. */
+    suspend operator fun invoke(recipeId: UUID): Boolean = withContext(ioDispatcher) {
+        val bytes = recipeImageStore.read(recipeId)
+        if (bytes == null) {
+            // The row claimed a local path but the file is gone. Nothing to upload; the download
+            // sweep is the one that repairs this.
+            Timber.d("No local image to upload for %s", recipeId)
+            return@withContext false
+        }
+
+        // Captured before the upload, not after: if the user replaces the photo mid-flight, the
+        // later mtime must not be recorded against these bytes, or the replacement never uploads.
+        val modifiedAt = recipeImageStore.lastModified(recipeId)
+
+        when (val outcome = recipeImageUploader.upload(recipeId, bytes)) {
+            is ImageUploadOutcome.Success -> {
+                recipeDao.updateImageBlobId(recipeId, outcome.imageBlobId)
+                recipeImageStateDao.recordUploadSuccess(recipeId, modifiedAt)
+                true
+            }
+
+            is ImageUploadOutcome.Permanent -> {
+                Timber.w("Giving up on uploading %s: %s", recipeId, outcome.reason)
+                recipeImageStateDao.burnUploadAttempts(
+                    recipeId = recipeId,
+                    at = System.currentTimeMillis(),
+                    cap = MAX_IMAGE_UPLOAD_ATTEMPTS,
+                )
+                false
+            }
+
+            is ImageUploadOutcome.Transient -> {
+                Timber.d("Will retry uploading %s: %s", recipeId, outcome.reason)
+                false
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
@@ -12,6 +12,7 @@ import com.tenmilelabs.chefai.core.data.local.room.SourceClassificationEntity
 import com.tenmilelabs.chefai.core.data.local.room.TagEntity
 import com.tenmilelabs.chefai.core.data.local.room.UserEntity
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageCandidate
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageUploadCandidate
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithDetails
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeWithLabels
@@ -265,6 +266,31 @@ class FakeRecipeDao : RecipeDao {
 
     override suspend fun updateLocalImagePath(uuid: UUID, localImagePath: String?) {
         recipes[uuid]?.let { recipes[uuid] = it.copy(localImagePath = localImagePath) }
+        triggerUpdate()
+    }
+
+    /**
+     * Mirrors the real query minus the `recipe_image_state` join — the attempt cap isn't modelled
+     * here, so tests that care about it use the in-memory DAO test in androidTest instead.
+     */
+    override suspend fun getImageUploadCandidates(
+        maxAttempts: Int,
+        scanLimit: Int
+    ): List<RecipeImageUploadCandidate> = recipes.values
+        .filter { it.deletedAt == null && it.localImagePath != null && it.syncState == SyncState.SYNCED }
+        .sortedWith(compareByDescending<RecipeEntity> { it.imageUrl.isEmpty() }.thenByDescending { it.updatedAt })
+        .take(scanLimit)
+        .map {
+            RecipeImageUploadCandidate(
+                recipeId = it.uuid,
+                localImagePath = requireNotNull(it.localImagePath),
+                imageBlobId = it.imageBlobId,
+                uploadedFileModifiedAt = null,
+            )
+        }
+
+    override suspend fun updateImageBlobId(uuid: UUID, imageBlobId: String?) {
+        recipes[uuid]?.let { recipes[uuid] = it.copy(imageBlobId = imageBlobId) }
         triggerUpdate()
     }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncManager.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/FakeSyncManager.kt
@@ -25,6 +25,9 @@ class FakeSyncManager : SyncScheduler {
     var imageBackfillCount = 0
         private set
 
+    var imageUploadCount = 0
+        private set
+
     var cancelAllCount = 0
         private set
 
@@ -52,6 +55,10 @@ class FakeSyncManager : SyncScheduler {
         imageBackfillCount++
     }
 
+    override fun scheduleImageUpload() {
+        imageUploadCount++
+    }
+
     override fun cancelAllSync() {
         cancelAllCount++
     }
@@ -63,6 +70,7 @@ class FakeSyncManager : SyncScheduler {
         manualSyncCount = 0
         periodicSyncCount = 0
         imageBackfillCount = 0
+        imageUploadCount = 0
         cancelAllCount = 0
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/testutil/FakeSessionManager.kt
@@ -34,6 +34,7 @@ class FakeSyncScheduler : SyncScheduler {
     override fun requestManualSync() {}
     override fun schedulePeriodicSync() {}
     override fun scheduleImageBackfill() {}
+    override fun scheduleImageUpload() {}
     override fun cancelAllSync() {}
 }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/network/RecipeImageUploaderTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/network/RecipeImageUploaderTest.kt
@@ -1,0 +1,153 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import java.io.IOException
+import java.util.UUID
+
+private val JPEG_BYTES = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0x00, 0x01)
+private val PNG_BYTES = byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 13, 10, 26, 10)
+
+class RecipeImageUploaderTest {
+
+    private val recipeId: UUID = UUID.randomUUID()
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var engine: MockEngine
+
+    private fun uploader(engine: MockEngine): RecipeImageUploader {
+        this.engine = engine
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return RecipeImageUploader(client, json)
+    }
+
+    private val lastRequest: HttpRequestData get() = engine.requestHistory.last()
+
+    private fun okEngine(blobId: String = "x") = MockEngine {
+        respond(
+            content = """{"imageBlobId":"$blobId","updatedAt":1755100000000}""",
+            status = HttpStatusCode.OK,
+            headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+        )
+    }
+
+    private fun errorEngine(status: HttpStatusCode) = MockEngine { respondError(status) }
+
+    @Test
+    fun `a successful upload returns the blob id the server assigned`() = runTest {
+        val subject = uploader(okEngine("deadbeef"))
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isEqualTo(ImageUploadOutcome.Success("deadbeef"))
+    }
+
+    @Test
+    fun `the request PUTs the raw bytes with their hash and detected type`() = runTest {
+        val subject = uploader(okEngine())
+
+        subject.upload(recipeId, JPEG_BYTES)
+
+        val request = lastRequest
+        assertThat(request.method).isEqualTo(HttpMethod.Put)
+        assertThat(request.url.encodedPath).endsWith("/recipes/$recipeId/image")
+        assertThat(request.headers["X-Content-SHA256"]).isEqualTo(sha256Hex(JPEG_BYTES))
+        assertThat(request.body.contentType?.withoutParameters())
+            .isEqualTo(ContentType.Image.JPEG)
+        assertThat((request.body as OutgoingContent.ByteArrayContent).bytes())
+            .isEqualTo(JPEG_BYTES)
+    }
+
+    @Test
+    fun `a PNG is declared as a PNG, not blanket JPEG`() = runTest {
+        val subject = uploader(okEngine())
+
+        subject.upload(recipeId, PNG_BYTES)
+
+        assertThat(lastRequest.body.contentType?.withoutParameters())
+            .isEqualTo(ContentType.Image.PNG)
+    }
+
+    @Test
+    fun `a 4xx rejection is permanent, so the sweep stops asking`() = runTest {
+        val subject = uploader(errorEngine(HttpStatusCode.UnprocessableEntity))
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isInstanceOf(ImageUploadOutcome.Permanent::class.java)
+    }
+
+    @Test
+    fun `a disabled scraped upload is permanent — the flag will not flip on retry`() = runTest {
+        val subject = uploader(errorEngine(HttpStatusCode.Forbidden))
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isInstanceOf(ImageUploadOutcome.Permanent::class.java)
+    }
+
+    @Test
+    fun `429 is transient despite being a 4xx — it explicitly means later`() = runTest {
+        val subject = uploader(errorEngine(HttpStatusCode.TooManyRequests))
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isInstanceOf(ImageUploadOutcome.Transient::class.java)
+    }
+
+    @Test
+    fun `a 5xx is transient`() = runTest {
+        val subject = uploader(errorEngine(HttpStatusCode.BadGateway))
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isInstanceOf(ImageUploadOutcome.Transient::class.java)
+    }
+
+    @Test
+    fun `an unparseable success body is transient, not a silent success`() = runTest {
+        // A 200 we can't read leaves us not knowing the blob id, which is indistinguishable from
+        // never having uploaded. Treating it as success would strand the recipe pointing at nothing.
+        val subject = uploader(
+            MockEngine {
+                respond(
+                    content = "not json",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf("Content-Type", ContentType.Application.Json.toString()),
+                )
+            }
+        )
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isInstanceOf(ImageUploadOutcome.Transient::class.java)
+    }
+
+    @Test
+    fun `a network failure is transient`() = runTest {
+        val subject = uploader(MockEngine { throw IOException("connection reset") })
+
+        val outcome = subject.upload(recipeId, JPEG_BYTES)
+
+        assertThat(outcome).isInstanceOf(ImageUploadOutcome.Transient::class.java)
+    }
+
+    @Test
+    fun `sha256Hex matches the known digest of an empty input`() {
+        assertThat(sha256Hex(ByteArray(0)))
+            .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageUploadTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/worker/RecipeImageUploadTest.kt
@@ -1,0 +1,106 @@
+package com.tenmilelabs.chefai.recipes.data.worker
+
+import com.google.common.truth.Truth.assertThat
+import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeImageUploadCandidate
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Covers the half of the upload sweep SQL can't express — whether the bytes on disk are still the
+ * ones the backend has. The query-side predicates (unsynced rows, soft deletes, the attempt cap,
+ * user-photos-first ordering) are covered by the DAO test in androidTest.
+ */
+class RecipeImageUploadTest {
+
+    private fun candidate(
+        path: String = "/files/recipe_images/a",
+        imageBlobId: String? = null,
+        uploadedFileModifiedAt: Long? = null,
+    ) = RecipeImageUploadCandidate(
+        recipeId = UUID.randomUUID(),
+        localImagePath = path,
+        imageBlobId = imageBlobId,
+        uploadedFileModifiedAt = uploadedFileModifiedAt,
+    )
+
+    /** Stands in for the filesystem: listed paths exist with the given mtime, nothing else does. */
+    private fun mtimes(vararg pairs: Pair<String, Long>): (String) -> Long? =
+        { path -> pairs.toMap()[path] }
+
+    @Test
+    fun `an image that has never been uploaded is a candidate`() {
+        val candidates = listOf(candidate(imageBlobId = null))
+
+        val result = candidates.needingUpload(mtimes("/files/recipe_images/a" to 100L))
+
+        assertThat(result).isEqualTo(candidates)
+    }
+
+    @Test
+    fun `an image already on the backend is left alone`() {
+        val candidates = listOf(candidate(imageBlobId = "abc", uploadedFileModifiedAt = 100L))
+
+        val result = candidates.needingUpload(mtimes("/files/recipe_images/a" to 100L))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `a replaced photo is re-uploaded even though the blob pointer is set`() {
+        // The picker writes over the same path, so the row looks untouched: same localImagePath,
+        // still a non-null imageBlobId. Only the file's mtime moved. Missing this would mean a
+        // user's new photo silently never leaving the device.
+        val candidates = listOf(candidate(imageBlobId = "abc", uploadedFileModifiedAt = 100L))
+
+        val result = candidates.needingUpload(mtimes("/files/recipe_images/a" to 250L))
+
+        assertThat(result).isEqualTo(candidates)
+    }
+
+    @Test
+    fun `a row whose file has vanished is skipped, not uploaded`() {
+        // Repairing this is the download sweep's job. Trying to upload nothing would just burn
+        // attempts against a recipe that might still be recoverable.
+        val candidates = listOf(candidate(imageBlobId = null))
+
+        val result = candidates.needingUpload(mtimes())
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `an uploaded image with no recorded mtime is re-uploaded`() {
+        // Shouldn't happen — recordUploadSuccess always writes one — but treating "I don't know
+        // what I sent" as "already done" would strand the bytes. Err toward re-sending; the backend
+        // dedupes on content hash, so a redundant upload is a no-op there.
+        val candidates = listOf(candidate(imageBlobId = "abc", uploadedFileModifiedAt = null))
+
+        val result = candidates.needingUpload(mtimes("/files/recipe_images/a" to 100L))
+
+        assertThat(result).isEqualTo(candidates)
+    }
+
+    @Test
+    fun `only the rows genuinely out of date are returned`() {
+        val fresh = candidate(path = "/p/fresh", imageBlobId = "x", uploadedFileModifiedAt = 10L)
+        val never = candidate(path = "/p/never", imageBlobId = null)
+        val replaced = candidate(path = "/p/replaced", imageBlobId = "y", uploadedFileModifiedAt = 10L)
+        val gone = candidate(path = "/p/gone", imageBlobId = null)
+
+        val result = listOf(fresh, never, replaced, gone).needingUpload(
+            mtimes("/p/fresh" to 10L, "/p/never" to 20L, "/p/replaced" to 99L)
+        )
+
+        assertThat(result).containsExactly(never, replaced).inOrder()
+    }
+
+    @Test
+    fun `the batch cap bounds how many images one run sends`() {
+        val candidates = List(IMAGE_UPLOAD_BATCH * 3) { candidate(path = "/p/$it") }
+        val existing = candidates.associate { it.localImagePath to 1L }
+
+        val batch = candidates.needingUpload { existing[it] }.take(IMAGE_UPLOAD_BATCH)
+
+        assertThat(batch).hasSize(IMAGE_UPLOAD_BATCH)
+    }
+}


### PR DESCRIPTION
Third of five PRs completing Stage 2 of #132 — the upload direction.

> **Stacked.** Contains the commits from [#145](https://github.com/jmuci/ChefAI/pull/145) (base URL) and [#146](https://github.com/jmuci/ChefAI/pull/146) (schema), since it needs `BuildConfig.API_BASE_URL` and `imageBlobId`. Review the top commit only; I'll rebase once those land.

## Why this one matters most

A scraped image can, in principle, be re-derived on any device from its source URL. **A photo the user took has no source at all** — until it's uploaded, the device holding it holds the only copy in existence, and a reinstall, a lost phone, or a soft delete destroys it. The candidate query orders those first for exactly that reason: a blank `imageUrl` means "cannot be re-derived" (ADR-011 Decision 3), so if a sweep only gets partway through its batch, the irreplaceable bytes are the ones that made it.

## `syncState = 'SYNCED'` is load-bearing

The recipe row must exist server-side before an image can attach to it. Gating the query on `SYNCED` means the upload can never 404 — and it dissolves #132's open question about ordering (*"a pulled `imageUrl` pointing at our storage is useless if the upload hasn't landed"*), because the blob pointer only ever comes into existence **because** an upload completed.

## Constraints: unmetered, but not charging

Deliberately weaker than `RecipeImageBackfillWorker`. Backfill waits for a charger because a WebView spin-up per image is genuinely expensive and costs nothing to defer. An upload is one request of a few hundred kilobytes, and every hour it waits is another hour a user's only copy of a photo lives on one device — the exact window this feature exists to close.

## Two failure-handling details

**Permanent vs. transient.** A 4xx other than 408/429 fails identically on every retry — wrong hash, wrong content type, quota, a recipe that isn't ours, `SCRAPED_UPLOAD_DISABLED` — so it spends the whole attempt budget at once rather than producing two more identical rejections.

**A 200 whose body won't parse is transient, not a silent success.** Not knowing the blob id is indistinguishable from never having uploaded; treating it as success would leave the recipe pointing at nothing.

## `uploadedFileModifiedAt`

How a **replaced** photo gets noticed. The picker overwrites the same path, so the row looks untouched — same `localImagePath`, still a non-null `imageBlobId` — and the pointer alone would say the work was done. Comparing the file's mtime against the value recorded at upload catches it without hashing every candidate on every sweep.

## Transport

Raw body, not multipart: exactly one file and no form fields, so an envelope would add a boundary parser on both ends and buy nothing. Content type is sniffed from magic bytes since these files are stored extensionless.

Uses the **default authenticated** client, never `@ScraperHttpClient`, and builds its URL only from `BuildConfig.API_BASE_URL` — never from a recipe's `imageUrl`. That's the invariant that keeps a JWT from ever reaching a third-party CDN (ADR-010).

## Verification

- `:app:testDebugUnitTest` — **468 tests, 0 failures** (+17)
- `:app:connectedDebugAndroidTest` for `RecipeImageUploadDaoTest` — **12 tests green** on a Pixel 6 Pro AVD

Covered on device: the attempt cap, user-photos-first ordering (asserted against a *more recently updated* scraped recipe, so it can't pass by accident), the upload and download attempt budgets staying independent, and `updateImageBlobId` leaving `updatedAt`/`syncState`/`deletedAt` untouched.

## Not yet wired

Nothing downloads these blobs — that's PR 4. Until then an uploaded image is write-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)