### PR TITLE
Recipe privacy: surface and set visibility in the UI

### DIFF
--- a/app/schemas/com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase/5.json
+++ b/app/schemas/com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase/5.json
@@ -1,0 +1,1360 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "b78906823b9c138b5adfc2eaeb6ad637",
+    "entities": [
+      {
+        "tableName": "allergens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_allergens_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_allergens_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarked_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` BLOB NOT NULL, `recipeId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`userId`, `recipeId`), FOREIGN KEY(`userId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "recipeId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarked_recipes_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarked_recipes_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_bookmarked_recipes_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarked_recipes_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ingredients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `allergenId` BLOB, `sourcePrimaryId` BLOB, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`allergenId`) REFERENCES `allergens`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT , FOREIGN KEY(`sourcePrimaryId`) REFERENCES `source_classifications`(`uuid`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allergenId",
+            "columnName": "allergenId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "sourcePrimaryId",
+            "columnName": "sourcePrimaryId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ingredients_allergenId",
+            "unique": false,
+            "columnNames": [
+              "allergenId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_allergenId` ON `${TABLE_NAME}` (`allergenId`)"
+          },
+          {
+            "name": "index_ingredients_sourcePrimaryId",
+            "unique": false,
+            "columnNames": [
+              "sourcePrimaryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_sourcePrimaryId` ON `${TABLE_NAME}` (`sourcePrimaryId`)"
+          },
+          {
+            "name": "index_ingredients_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ingredients_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "allergens",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "allergenId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "source_classifications",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourcePrimaryId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "labels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_labels_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_labels_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `userId` BLOB NOT NULL, `name` TEXT NOT NULL, `status` TEXT NOT NULL, `preferencesJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`userId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preferencesJson",
+            "columnName": "preferencesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plans_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plans_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_meal_plans_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plans_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "meal_plan_days",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `mealPlanId` BLOB NOT NULL, `dayIndex` INTEGER NOT NULL, `dinnerRecipeId` BLOB, `lunchRecipeId` BLOB, PRIMARY KEY(`uuid`), FOREIGN KEY(`mealPlanId`) REFERENCES `meal_plans`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mealPlanId",
+            "columnName": "mealPlanId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayIndex",
+            "columnName": "dayIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dinnerRecipeId",
+            "columnName": "dinnerRecipeId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "lunchRecipeId",
+            "columnName": "lunchRecipeId",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_meal_plan_days_mealPlanId",
+            "unique": false,
+            "columnNames": [
+              "mealPlanId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_meal_plan_days_mealPlanId` ON `${TABLE_NAME}` (`mealPlanId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meal_plans",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "mealPlanId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `isNewRecipe` INTEGER NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `localImagePath` TEXT, `prepTimeMinutes` TEXT NOT NULL, `cookTimeMinutes` TEXT NOT NULL, `servings` TEXT NOT NULL, `externalUrl` TEXT NOT NULL, `privacy` TEXT NOT NULL, `ingredientsJson` TEXT NOT NULL, `stepsJson` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `labelsJson` TEXT NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`recipeId`))",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNewRecipe",
+            "columnName": "isNewRecipe",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "localImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "prepTimeMinutes",
+            "columnName": "prepTimeMinutes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cookTimeMinutes",
+            "columnName": "cookTimeMinutes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalUrl",
+            "columnName": "externalUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "privacy",
+            "columnName": "privacy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientsJson",
+            "columnName": "ingredientsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stepsJson",
+            "columnName": "stepsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelsJson",
+            "columnName": "labelsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId"
+          ]
+        }
+      },
+      {
+        "tableName": "recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `imageUrlThumbnail` TEXT NOT NULL, `localImagePath` TEXT, `imageBlobId` TEXT, `prepTimeMinutes` INTEGER NOT NULL, `cookTimeMinutes` INTEGER NOT NULL, `servings` INTEGER NOT NULL, `creatorId` BLOB NOT NULL, `recipeExternalUrl` TEXT, `privacy` TEXT NOT NULL, `version` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`creatorId`) REFERENCES `users`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrlThumbnail",
+            "columnName": "imageUrlThumbnail",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localImagePath",
+            "columnName": "localImagePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlobId",
+            "columnName": "imageBlobId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "prepTimeMinutes",
+            "columnName": "prepTimeMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cookTimeMinutes",
+            "columnName": "cookTimeMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "servings",
+            "columnName": "servings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creatorId",
+            "columnName": "creatorId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeExternalUrl",
+            "columnName": "recipeExternalUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "privacy",
+            "columnName": "privacy",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipes_creatorId",
+            "unique": false,
+            "columnNames": [
+              "creatorId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipes_creatorId` ON `${TABLE_NAME}` (`creatorId`)"
+          },
+          {
+            "name": "index_recipes_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipes_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "creatorId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_image_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER NOT NULL, `uploadAttempts` INTEGER NOT NULL, `lastUploadAttemptAt` INTEGER NOT NULL, `uploadedFileModifiedAt` INTEGER, PRIMARY KEY(`recipeId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadAttempts",
+            "columnName": "uploadAttempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUploadAttemptAt",
+            "columnName": "lastUploadAttemptAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadedFileModifiedAt",
+            "columnName": "uploadedFileModifiedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_ingredients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `ingredientId` BLOB NOT NULL, `quantity` REAL NOT NULL, `unit` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `ingredientId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`ingredientId`) REFERENCES `ingredients`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientId",
+            "columnName": "ingredientId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "ingredientId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_ingredients_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_recipe_ingredients_ingredientId",
+            "unique": false,
+            "columnNames": [
+              "ingredientId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_ingredientId` ON `${TABLE_NAME}` (`ingredientId`)"
+          },
+          {
+            "name": "index_recipe_ingredients_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_ingredients_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "ingredients",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "ingredientId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_labels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `labelId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `labelId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`labelId`) REFERENCES `labels`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelId",
+            "columnName": "labelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "labelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_labels_labelId",
+            "unique": false,
+            "columnNames": [
+              "labelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_labels_labelId` ON `${TABLE_NAME}` (`labelId`)"
+          },
+          {
+            "name": "index_recipe_labels_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_labels_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "labels",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "labelId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_steps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `recipeId` BLOB NOT NULL, `orderIndex` INTEGER NOT NULL, `instruction` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instruction",
+            "columnName": "instruction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_steps_recipeId",
+            "unique": false,
+            "columnNames": [
+              "recipeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_steps_recipeId` ON `${TABLE_NAME}` (`recipeId`)"
+          },
+          {
+            "name": "index_recipe_steps_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_steps_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "recipe_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipeId` BLOB NOT NULL, `tagId` BLOB NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`recipeId`, `tagId`), FOREIGN KEY(`recipeId`) REFERENCES `recipes`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `tags`(`uuid`) ON UPDATE NO ACTION ON DELETE RESTRICT )",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipeId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipeId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recipe_tags_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_tags_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          },
+          {
+            "name": "index_recipe_tags_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recipe_tags_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "recipes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "recipeId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "tags",
+            "onDelete": "RESTRICT",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "source_classifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `category` TEXT NOT NULL, `subcategory` TEXT, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subcategory",
+            "columnName": "subcategory",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_source_classifications_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_source_classifications_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entityType` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`entityType`))",
+        "fields": [
+          {
+            "fieldPath": "entityType",
+            "columnName": "entityType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "entityType"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tags_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tags_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` BLOB NOT NULL, `displayName` TEXT NOT NULL, `email` TEXT NOT NULL, `avatarUrl` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, `deletedAt` INTEGER, `syncState` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncState",
+            "columnName": "syncState",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_syncState_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "syncState",
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_syncState_updatedAt` ON `${TABLE_NAME}` (`syncState`, `updatedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b78906823b9c138b5adfc2eaeb6ad637')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/ChefAIDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/ChefAIDatabaseMigrationTest.kt
@@ -7,6 +7,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_1_2
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_2_3
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_3_4
+import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_4_5
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -130,11 +131,44 @@ class ChefAIDatabaseMigrationTest {
     }
 
     @Test
-    fun migrateAll1To4_succeeds() {
+    fun migrate4To5_addsPrivacyColumnBackfilledToPublic() {
+        val draftId = UUID.randomUUID()
+
+        helper.createDatabase(TEST_DB, 4).use { db ->
+            db.execSQL(
+                """
+                INSERT INTO recipe_drafts (
+                    recipeId, isNewRecipe, title, description, imageUrl, localImagePath,
+                    prepTimeMinutes, cookTimeMinutes, servings, externalUrl,
+                    ingredientsJson, stepsJson, tagsJson, labelsJson, version, updatedAt
+                ) VALUES (?, 1, 'Carbonara', 'Classic', 'https://example.com/x.jpg', NULL,
+                    '10', '20', '2', '', '[]', '[]', '[]', '[]', 1, 555)
+                """.trimIndent(),
+                arrayOf(draftId.toBlob())
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 5, true, MIGRATION_4_5)
+
+        db.query("SELECT title, privacy FROM recipe_drafts").use { cursor ->
+            assertTrue("the pre-existing draft row should survive the migration", cursor.moveToFirst())
+            assertEquals("Carbonara", cursor.getString(0))
+            assertEquals(
+                "a draft in flight before this migration was going to save as PUBLIC — " +
+                    "RecipeDraft.toRecipe() hardcoded it — so the backfill preserves that",
+                "PUBLIC",
+                cursor.getString(1)
+            )
+            assertEquals(1, cursor.count)
+        }
+    }
+
+    @Test
+    fun migrateAll1To5_succeeds() {
         helper.createDatabase(TEST_DB, 1).close()
 
         helper.runMigrationsAndValidate(
-            TEST_DB, 4, true, MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4
+            TEST_DB, 5, true, MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5
         )
     }
 }

--- a/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDraftDaoTest.kt
+++ b/app/src/androidTest/java/com/tenmilelabs/chefai/data/source/local/RecipeDraftDaoTest.kt
@@ -7,6 +7,7 @@ import androidx.test.filters.SmallTest
 import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity
 import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,6 +43,7 @@ class RecipeDraftDaoTest {
             cookTimeMinutes = "20",
             servings = "4",
             externalUrl = "https://example.com/recipe",
+            privacy = RecipePrivacy.PRIVATE,
             ingredientsJson = "[]",
             stepsJson = "[]",
             tagsJson = "[]",

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/RecipeDraftEntity.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/RecipeDraftEntity.kt
@@ -2,6 +2,7 @@ package com.tenmilelabs.chefai.core.data.local.room
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import java.util.UUID
 
 /**
@@ -23,6 +24,7 @@ data class RecipeDraftEntity(
     val cookTimeMinutes: String,
     val servings: String,
     val externalUrl: String,
+    val privacy: RecipePrivacy,
     val ingredientsJson: String,
     val stepsJson: String,
     val tagsJson: String,

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/ChefAIDataBase.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/ChefAIDataBase.kt
@@ -44,7 +44,7 @@ import com.tenmilelabs.chefai.core.data.local.room.UuidConverters
         TagEntity::class,
         UserEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(UuidConverters::class)
@@ -155,5 +155,18 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
         db.execSQL("ALTER TABLE recipe_image_state ADD COLUMN uploadAttempts INTEGER NOT NULL DEFAULT 0")
         db.execSQL("ALTER TABLE recipe_image_state ADD COLUMN lastUploadAttemptAt INTEGER NOT NULL DEFAULT 0")
         db.execSQL("ALTER TABLE recipe_image_state ADD COLUMN uploadedFileModifiedAt INTEGER")
+    }
+}
+
+/**
+ * Adds [com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity.privacy].
+ *
+ * Existing rows are backfilled to 'PUBLIC' rather than to the new Kotlin default of PRIVATE:
+ * before this change `RecipeDraft.toRecipe()` hardcoded PUBLIC, so a draft already in flight was
+ * going to save as public, and a migration should preserve that rather than silently change it.
+ */
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE recipe_drafts ADD COLUMN privacy TEXT NOT NULL DEFAULT 'PUBLIC'")
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -16,6 +16,7 @@ import com.tenmilelabs.chefai.core.data.local.room.dao.ChefAIDataBase
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_1_2
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_2_3
 import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_3_4
+import com.tenmilelabs.chefai.core.data.local.room.dao.MIGRATION_4_5
 import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
@@ -87,7 +88,7 @@ object DatabaseModules {
             ChefAIDataBase::class.java,
             "ChefAI.db"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipeListCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipeListCard.kt
@@ -120,6 +120,7 @@ fun RecipeListCard(
                         verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_extra_small)),
                         maxLines = 1
                     ) {
+                        RecipePrivacyBadge(privacy = recipe.privacy)
                         recipe.labels.take(3).forEach { label ->
                             InfoChip(text = label.displayName, type = InfoChipType.LABEL)
                         }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipePrivacyBadge.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipePrivacyBadge.kt
@@ -1,0 +1,83 @@
+package com.tenmilelabs.chefai.core.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+
+/**
+ * A small lock+label chip marking a recipe as private.
+ *
+ * Renders nothing for [RecipePrivacy.PUBLIC] — a public recipe is the unremarkable case, and the
+ * surfaces this appears on (recipe list cards, the details screen) already carry up to six
+ * tag/label [InfoChip]s, so a chip on every row would be noise.
+ *
+ * A sibling of [InfoChip] rather than a third [InfoChipType]: `InfoChip` takes text only with no
+ * icon slot, and its three existing call sites shouldn't grow a parameter for this.
+ */
+@Composable
+fun RecipePrivacyBadge(privacy: RecipePrivacy, modifier: Modifier = Modifier) {
+    if (privacy != RecipePrivacy.PRIVATE) return
+
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = modifier.padding(end = dimensionResource(id = R.dimen.padding_extra_small)),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(
+                horizontal = dimensionResource(id = R.dimen.padding_small),
+                vertical = dimensionResource(id = R.dimen.padding_extra_small),
+            ),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier
+                    .size(12.dp)
+                    .padding(end = 2.dp),
+            )
+            Text(
+                text = stringResource(R.string.privacy_private),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RecipePrivacyBadgePreview() {
+    ChefAITheme {
+        RecipePrivacyBadge(privacy = RecipePrivacy.PRIVATE)
+    }
+}
+
+@Preview
+@Composable
+private fun RecipePrivacyBadgeDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        RecipePrivacyBadge(privacy = RecipePrivacy.PRIVATE)
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/preview/PreviewData.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/preview/PreviewData.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.core.ui.preview
 
 import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipePreview
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -57,6 +58,7 @@ object PreviewData {
         cookTimeMinutes = 180,
         servings = 8,
         creatorId = SharedData.user.uuid,
+        privacy = RecipePrivacy.PRIVATE, // exercises RecipePrivacyBadge in previews
         tags = listOf(Tag(UuidV7Generator.newId(), "Slow Cook"), Tag(UuidV7Generator.newId(), "Beef")),
         labels = listOf(Label(UuidV7Generator.newId(), "Batch Cook")),
     )

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/DraftMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/DraftMapper.kt
@@ -2,7 +2,6 @@ package com.tenmilelabs.chefai.recipes.data.mapper
 
 import com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
-import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.Recipe
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
@@ -119,6 +118,7 @@ fun Recipe.toRecipeDraft(): RecipeDraft = RecipeDraft(
     cookTimeMinutes = cookTimeMinutes.toString(),
     servings = servings.toString(),
     externalUrl = recipeExternalUrl.orEmpty(),
+    privacy = privacy,
     ingredients = ingredients,
     steps = steps,
     tags = tags,
@@ -142,6 +142,7 @@ fun RecipeDraft.toRecipeDraftEntity(): RecipeDraftEntity = RecipeDraftEntity(
     cookTimeMinutes = cookTimeMinutes,
     servings = servings,
     externalUrl = externalUrl,
+    privacy = privacy,
     ingredientsJson = draftJson.encodeToString(ingredients.map { it.toDto() }),
     stepsJson = draftJson.encodeToString(steps.map { it.toDto() }),
     tagsJson = draftJson.encodeToString(tags.map { it.toDto() }),
@@ -165,6 +166,7 @@ fun RecipeDraftEntity.toRecipeDraft(): RecipeDraft = RecipeDraft(
     cookTimeMinutes = cookTimeMinutes,
     servings = servings,
     externalUrl = externalUrl,
+    privacy = privacy,
     ingredients = draftJson.decodeFromString<List<DraftIngredientDto>>(ingredientsJson).map { it.toDomain() },
     steps = draftJson.decodeFromString<List<DraftStepDto>>(stepsJson).map { it.toDomain() },
     tags = draftJson.decodeFromString<List<DraftTagDto>>(tagsJson).map { it.toDomain() },
@@ -191,7 +193,7 @@ fun RecipeDraft.toRecipe(creator: User): Recipe = Recipe(
     servings = servings.toInt(),
     creator = creator,
     recipeExternalUrl = externalUrl.ifBlank { null },
-    privacy = RecipePrivacy.PUBLIC,
+    privacy = privacy,
     version = version,
     ingredients = ingredients,
     steps = steps,

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapper.kt
@@ -2,6 +2,7 @@ package com.tenmilelabs.chefai.recipes.data.mapper
 
 import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Ingredient
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -24,7 +25,9 @@ private const val DEFAULT_UNIT = "unit"
  * stays disabled until the user fills in what's missing. Ingredients and tags are matched by name
  * (case-insensitively) against the app's existing catalogs before minting a new id, mirroring
  * [com.tenmilelabs.chefai.recipes.ui.editor.RecipeEditorViewModel.selectIngredient] and
- * `addTagByName` — otherwise every import would duplicate catalog rows.
+ * `addTagByName` — otherwise every import would duplicate catalog rows. Privacy defaults to
+ * `PUBLIC`: a scraped recipe is someone else's already-published page, unlike a recipe the user
+ * writes from scratch, which starts `PRIVATE` (see [RecipeDraft.privacy]).
  */
 fun ScrapedRecipe.toRecipeDraft(
     recipeId: UUID,
@@ -40,6 +43,7 @@ fun ScrapedRecipe.toRecipeDraft(
     cookTimeMinutes = cookTimeMinutesOrFallback(),
     servings = servings?.toString() ?: "0",
     externalUrl = sourceUrl,
+    privacy = RecipePrivacy.PUBLIC,
     ingredients = ingredients.toRecipeIngredients(knownIngredients),
     steps = instructions.toRecipeSteps(),
     tags = keywords.toTags(knownTags),

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/model/RecipeDraft.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/model/RecipeDraft.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.recipes.domain.model
 
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -26,6 +27,12 @@ data class RecipeDraft(
     val cookTimeMinutes: String = "",
     val servings: String = "",
     val externalUrl: String = "",
+    /**
+     * Defaults to [RecipePrivacy.PRIVATE]: a recipe the user writes stays theirs until they say
+     * otherwise. The import path overrides this to `PUBLIC` — see
+     * [com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraft].
+     */
+    val privacy: RecipePrivacy = RecipePrivacy.PRIVATE,
     val ingredients: List<RecipeIngredient> = emptyList(),
     val steps: List<RecipeStep> = emptyList(),
     val tags: List<Tag> = emptyList(),

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
@@ -56,10 +56,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Recipe
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.ui.components.InfoChip
 import com.tenmilelabs.chefai.core.ui.components.InfoChipType
+import com.tenmilelabs.chefai.core.ui.components.RecipePrivacyBadge
 import com.tenmilelabs.chefai.core.ui.components.RecipeTimeRow
 import com.tenmilelabs.chefai.core.ui.preview.RecipeData
 import com.tenmilelabs.chefai.core.ui.recipeImageModel
@@ -230,6 +232,7 @@ fun RecipeDetailsContent(
                 horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_extra_small)),
                 verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_extra_small))
             ) {
+                RecipePrivacyBadge(privacy = recipe.privacy)
                 recipe.labels.forEach { label ->
                     InfoChip(text = label.displayName, type = InfoChipType.LABEL)
                 }
@@ -375,6 +378,17 @@ fun RecipeDetailsDeleteConfirmationPreview() {
             recipe = RecipeData.recipe,
             onDeleteClick = {},
             showDeleteConfirmation = true,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RecipeDetailsPrivatePreview() {
+    ChefAITheme {
+        RecipeDetailsContent(
+            recipe = RecipeData.recipe.copy(privacy = RecipePrivacy.PRIVATE),
+            isBookmarked = false,
         )
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/EditorFieldModels.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/EditorFieldModels.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.recipes.ui.editor
 
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -15,6 +16,7 @@ data class RecipeFields(
     val cookTimeMinutes: String = "",
     val servings: String = "",
     val externalUrl: String = "",
+    val privacy: RecipePrivacy = RecipePrivacy.PRIVATE,
 )
 
 data class IngredientsFields(

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorReducer.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorReducer.kt
@@ -53,6 +53,10 @@ object RecipeEditorReducer {
             recipeFields = state.recipeFields.copy(externalUrl = action.url)
         ).markDirty()
 
+        is EditorAction.PrivacyChanged -> state.copy(
+            recipeFields = state.recipeFields.copy(privacy = action.privacy)
+        ).markDirty()
+
         // localImagePath is cleared alongside the field it was cached for — otherwise the user
         // keeps seeing the stale on-device copy from before their edit.
         is EditorAction.ImageUrlChanged -> state.copy(
@@ -293,6 +297,7 @@ fun RecipeEditorState.toRecipeDraft(): RecipeDraft = RecipeDraft(
     cookTimeMinutes = recipeFields.cookTimeMinutes,
     servings = recipeFields.servings,
     externalUrl = recipeFields.externalUrl,
+    privacy = recipeFields.privacy,
     ingredients = ingredients.selectedIngredients,
     steps = steps.steps,
     tags = tags.selectedTags,

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Public
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -33,6 +35,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -56,6 +61,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -172,6 +178,11 @@ fun RecipeEditorScreen(
                     onCookTimeChange = { viewModel.dispatch(EditorAction.CookTimeChanged(it)) },
                     onServingsChange = { viewModel.dispatch(EditorAction.ServingsChanged(it)) },
                     onExternalUrlChange = { viewModel.dispatch(EditorAction.ExternalUrlChanged(it)) },
+                )
+
+                VisibilitySection(
+                    privacy = state.recipeFields.privacy,
+                    onPrivacyChange = { viewModel.dispatch(EditorAction.PrivacyChanged(it)) },
                 )
 
                 ImageUploadSection(
@@ -387,6 +398,55 @@ private fun CoreRecipeForm(
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+        )
+    }
+}
+
+/** Left-to-right order is deliberate: Private first, so the more restrictive option reads as the
+ *  default rather than an afterthought — [RecipeFields.privacy] defaults to PRIVATE for the same
+ *  reason. [RecipePrivacy.entries] declares PUBLIC first, so this iterates an explicit local order
+ *  rather than the enum's declaration order. */
+private val PRIVACY_OPTIONS = listOf(RecipePrivacy.PRIVATE, RecipePrivacy.PUBLIC)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VisibilitySection(
+    privacy: RecipePrivacy,
+    onPrivacyChange: (RecipePrivacy) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        SectionHeader(title = stringResource(R.string.section_visibility))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            PRIVACY_OPTIONS.forEachIndexed { index, option ->
+                SegmentedButton(
+                    selected = privacy == option,
+                    onClick = { onPrivacyChange(option) },
+                    shape = SegmentedButtonDefaults.itemShape(index, PRIVACY_OPTIONS.size),
+                    icon = {
+                        Icon(
+                            imageVector = if (option == RecipePrivacy.PRIVATE) Icons.Default.Lock else Icons.Default.Public,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    modifier = Modifier.testTag("PrivacyOption_${option.name}"),
+                ) {
+                    Text(
+                        stringResource(
+                            if (option == RecipePrivacy.PRIVATE) R.string.privacy_private
+                            else R.string.privacy_public
+                        )
+                    )
+                }
+            }
+        }
+        Text(
+            text = stringResource(
+                if (privacy == RecipePrivacy.PRIVATE) R.string.visibility_private_description
+                else R.string.visibility_public_description
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorState.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorState.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.recipes.ui.editor
 
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -20,6 +21,7 @@ sealed interface EditorAction {
     data class CookTimeChanged(val time: String) : EditorAction
     data class ServingsChanged(val servings: String) : EditorAction
     data class ExternalUrlChanged(val url: String) : EditorAction
+    data class PrivacyChanged(val privacy: RecipePrivacy) : EditorAction
     data class ImageUrlChanged(val url: String) : EditorAction
     data class ImageSelected(val uri: String?) : EditorAction
 

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModel.kt
@@ -194,6 +194,7 @@ class RecipeEditorViewModel @Inject constructor(
                         cookTimeMinutes = draft.cookTimeMinutes,
                         servings = draft.servings,
                         externalUrl = draft.externalUrl,
+                        privacy = draft.privacy,
                     ),
                     ingredients = IngredientsFields(
                         selectedIngredients = draft.ingredients,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,12 @@
     <string name="delete_recipe_error">Couldn\'t delete recipe</string>
     <string name="cancel_button">Cancel</string>
     <string name="edit_button">Edit</string>
+    <string name="section_visibility">Visibility</string>
+    <string name="privacy_public">Public</string>
+    <string name="privacy_private">Private</string>
+    <string name="visibility_public_description">Anyone can find and view this recipe.</string>
+    <string name="visibility_private_description">Only you can see this recipe.</string>
+    <string name="privacy_private_badge_content_description">Private recipe</string>
 
     <!-- Meal Plans -->
     <string name="no_meal_plans_title">No meal plans yet</string>

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDraftDaoTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDraftDaoTest.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.core.data.local.room.dao
 
 import com.tenmilelabs.chefai.core.data.local.room.RecipeDraftEntity
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -25,6 +26,7 @@ class FakeRecipeDraftDaoTest {
         cookTimeMinutes = "20",
         servings = "4",
         externalUrl = "",
+        privacy = RecipePrivacy.PRIVATE,
         ingredientsJson = "[]",
         stepsJson = "[]",
         tagsJson = "[]",

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/DraftMapperTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/DraftMapperTest.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.recipes.data.mapper
 
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -31,6 +32,13 @@ class DraftMapperTest {
         assertEquals(recipe1.recipeExternalUrl.orEmpty(), draft.externalUrl)
         assertEquals(recipe1.version, draft.version)
         assertEquals(recipe1.updatedAt, draft.updatedAt)
+    }
+
+    @Test
+    fun `Recipe toDraft carries privacy`() {
+        val draft = recipe1.toRecipeDraft()
+
+        assertEquals(recipe1.privacy, draft.privacy)
     }
 
     @Test
@@ -129,6 +137,22 @@ class DraftMapperTest {
     }
 
     @Test
+    fun `draft privacy round-trips through entity for every enum value`() {
+        RecipePrivacy.entries.forEach { privacy ->
+            val original = RecipeDraft(
+                recipeId = UUID.randomUUID(),
+                isNewRecipe = true,
+                privacy = privacy,
+                updatedAt = 1L,
+            )
+
+            val restored = original.toRecipeDraftEntity().toRecipeDraft()
+
+            assertEquals(privacy, restored.privacy)
+        }
+    }
+
+    @Test
     fun `draft entity JSON preserves null optional fields on ingredient`() {
         val original = RecipeDraft(
             recipeId = UUID.randomUUID(),
@@ -216,6 +240,25 @@ class DraftMapperTest {
         assertEquals(creator, recipe.creator)
         assertEquals(2, recipe.version)
         assertEquals(5000L, recipe.updatedAt)
+    }
+
+    @Test
+    fun `draft toRecipe honours the draft's privacy for every enum value`() {
+        val creator = User(UUID.randomUUID(), "Chef", "chef@example.com", "")
+
+        RecipePrivacy.entries.forEach { privacy ->
+            val draft = RecipeDraft(
+                recipeId = UUID.randomUUID(),
+                isNewRecipe = true,
+                privacy = privacy,
+                prepTimeMinutes = "1",
+                cookTimeMinutes = "1",
+                servings = "1",
+                updatedAt = 1L,
+            )
+
+            assertEquals(privacy, draft.toRecipe(creator).privacy)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapperTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/mapper/ScrapedRecipeMapperTest.kt
@@ -1,5 +1,6 @@
 package com.tenmilelabs.chefai.recipes.data.mapper
 
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Ingredient
 import com.tenmilelabs.chefai.core.domain.model.Tag
 import com.tenmilelabs.chefai.core.domain.model.User
@@ -61,6 +62,15 @@ class ScrapedRecipeMapperTest {
         assertEquals("https://example.com/recipe", draft.externalUrl)
         assertEquals(1, draft.version)
         assertEquals(emptyList<Any>(), draft.labels)
+    }
+
+    @Test
+    fun `a scraped recipe always starts PUBLIC`() {
+        // Unlike a recipe written from scratch (RecipeDraft's own default is PRIVATE), a scraped
+        // recipe is someone else's already-published page.
+        val draft = minimalScrapedRecipe().toRecipeDraft(UUID.randomUUID(), emptyList(), emptyList())
+
+        assertEquals(RecipePrivacy.PUBLIC, draft.privacy)
     }
 
     @Test

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorReducerTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorReducerTest.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.recipes.ui.editor
 
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.Label
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.domain.model.Tag
@@ -111,6 +112,58 @@ class RecipeEditorReducerTest {
         val result = RecipeEditorReducer.reduce(state, EditorAction.ClearImage)
         assertEquals(null, result.recipeFields.localImagePath)
         assertEquals("", result.recipeFields.imageUrl)
+    }
+
+    // --- Privacy ---
+
+    @Test
+    fun `RecipeFields defaults to PRIVATE`() {
+        assertEquals(RecipePrivacy.PRIVATE, emptyState.recipeFields.privacy)
+    }
+
+    @Test
+    fun `PrivacyChanged updates privacy`() {
+        val result = RecipeEditorReducer.reduce(emptyState, EditorAction.PrivacyChanged(RecipePrivacy.PUBLIC))
+        assertEquals(RecipePrivacy.PUBLIC, result.recipeFields.privacy)
+    }
+
+    @Test
+    fun `PrivacyChanged alone does not mark dirty in create mode`() {
+        // Create-mode dirty tracking only looks at title/description/ingredients/steps — the same
+        // as ExternalUrlChanged and ImageUrlChanged, neither of which marks dirty alone either. An
+        // otherwise-empty draft isn't form-valid regardless, so there's nothing worth a discard
+        // warning over.
+        val result = RecipeEditorReducer.reduce(emptyState, EditorAction.PrivacyChanged(RecipePrivacy.PUBLIC))
+        assertFalse(result.isDirty)
+    }
+
+    @Test
+    fun `PrivacyChanged marks dirty in edit mode when it differs from the original`() {
+        val recipeId = UUID.randomUUID()
+        val originalDraft = RecipeDraft(
+            recipeId = recipeId,
+            isNewRecipe = false,
+            title = "Pasta",
+            privacy = RecipePrivacy.PRIVATE,
+            updatedAt = 1000L,
+        )
+        val state = RecipeEditorState(
+            mode = EditorMode.Edit(recipeId),
+            recipeId = recipeId,
+            recipeFields = RecipeFields(title = "Pasta", privacy = RecipePrivacy.PRIVATE),
+            originalDraft = originalDraft,
+        )
+
+        val result = RecipeEditorReducer.reduce(state, EditorAction.PrivacyChanged(RecipePrivacy.PUBLIC))
+        assertTrue(result.isDirty)
+    }
+
+    @Test
+    fun `toRecipeDraft carries the current privacy`() {
+        val state = emptyState.copy(
+            recipeFields = RecipeFields(privacy = RecipePrivacy.PUBLIC)
+        )
+        assertEquals(RecipePrivacy.PUBLIC, state.toRecipeDraft().privacy)
     }
 
     // --- Ingredients ---

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModelTest.kt
@@ -6,6 +6,7 @@ import com.tenmilelabs.chefai.collections.data.repository.FakeCollectionsReposit
 import com.tenmilelabs.chefai.core.data.local.UuidV7Generator
 import com.tenmilelabs.chefai.core.data.local.room.dao.FakeRecipeDraftDao
 import com.tenmilelabs.chefai.core.data.local.room.relations.RecipeIngredient
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
 import com.tenmilelabs.chefai.core.domain.model.RecipeStep
 import com.tenmilelabs.chefai.core.ui.navigation.AppDestinationArgs
 import com.tenmilelabs.chefai.core.data.repository.FakeMetadataRepository
@@ -135,6 +136,19 @@ class RecipeEditorViewModelTest {
     }
 
     @Test
+    fun `seeded PUBLIC draft leaves the privacy toggle PUBLIC`() = runTest {
+        // Regression guard: populateFromDraft must copy draft.privacy into RecipeFields, or every
+        // imported draft would silently reset to the RecipeFields default of PRIVATE on open.
+        val draftId = UuidV7Generator.newId()
+        recipeDraftDao.saveDraft(completeImportedDraft(draftId).toRecipeDraftEntity())
+
+        val vm = createViewModel(draftId = draftId.toString())
+
+        assertEquals(RecipePrivacy.PUBLIC, vm.state.value.recipeFields.privacy)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
     fun `saving a seeded draft takes the create path not update`() = runTest {
         val draftId = UuidV7Generator.newId()
         recipeDraftDao.saveDraft(completeImportedDraft(draftId).toRecipeDraftEntity())
@@ -171,7 +185,11 @@ class RecipeEditorViewModelTest {
         vm.viewModelScope.cancel()
     }
 
-    /** Mirrors what the recipe URL importer persists before handing off to the editor. */
+    /**
+     * Mirrors what the recipe URL importer persists before handing off to the editor — including
+     * `privacy = PUBLIC`, which is what [com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraft]
+     * (the scraper mapper) always sets.
+     */
     private fun completeImportedDraft(draftId: java.util.UUID) = RecipeDraft(
         recipeId = draftId,
         isNewRecipe = true,
@@ -181,6 +199,7 @@ class RecipeEditorViewModelTest {
         cookTimeMinutes = "15",
         servings = "4",
         externalUrl = "https://example.com/pancakes",
+        privacy = RecipePrivacy.PUBLIC,
         ingredients = listOf(
             RecipeIngredient(
                 ingredientId = UuidV7Generator.newId(),
@@ -271,6 +290,48 @@ class RecipeEditorViewModelTest {
         assertNotNull(recipesRepository.lastCreatedRecipe)
         assertEquals("New Recipe", recipesRepository.lastCreatedRecipe?.title)
         assertFalse(vm.state.value.isSaving)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
+    fun `a from-scratch create saves as PRIVATE by default`() = runTest {
+        val vm = createViewModel()
+
+        vm.dispatch(EditorAction.TitleChanged("New Recipe"))
+        vm.dispatch(EditorAction.DescriptionChanged("Description"))
+        vm.dispatch(EditorAction.PrepTimeChanged("10"))
+        vm.dispatch(EditorAction.CookTimeChanged("20"))
+        vm.dispatch(EditorAction.ServingsChanged("4"))
+        vm.dispatch(EditorAction.IngredientQuantityChanged("200"))
+        vm.dispatch(EditorAction.IngredientSelected("Flour", java.util.UUID.randomUUID()))
+        vm.dispatch(EditorAction.StepInputChanged("Mix"))
+        vm.dispatch(EditorAction.AddStep)
+        // Privacy left untouched — the user never opened the toggle.
+
+        vm.dispatch(EditorAction.Save)
+
+        assertEquals(RecipePrivacy.PRIVATE, recipesRepository.lastCreatedRecipe?.privacy)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
+    fun `toggling to PUBLIC before save persists PUBLIC`() = runTest {
+        val vm = createViewModel()
+
+        vm.dispatch(EditorAction.TitleChanged("New Recipe"))
+        vm.dispatch(EditorAction.DescriptionChanged("Description"))
+        vm.dispatch(EditorAction.PrepTimeChanged("10"))
+        vm.dispatch(EditorAction.CookTimeChanged("20"))
+        vm.dispatch(EditorAction.ServingsChanged("4"))
+        vm.dispatch(EditorAction.IngredientQuantityChanged("200"))
+        vm.dispatch(EditorAction.IngredientSelected("Flour", java.util.UUID.randomUUID()))
+        vm.dispatch(EditorAction.StepInputChanged("Mix"))
+        vm.dispatch(EditorAction.AddStep)
+        vm.dispatch(EditorAction.PrivacyChanged(RecipePrivacy.PUBLIC))
+
+        vm.dispatch(EditorAction.Save)
+
+        assertEquals(RecipePrivacy.PUBLIC, recipesRepository.lastCreatedRecipe?.privacy)
         vm.viewModelScope.cancel()
     }
 

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/ui/editor/RecipeEditorViewModelTest.kt
@@ -354,6 +354,25 @@ class RecipeEditorViewModelTest {
     }
 
     @Test
+    fun `changing only privacy on a valid existing recipe keeps save enabled and persists it`() = runTest {
+        // recipe1 already has ingredients and steps, so isFormValid is true the moment it loads —
+        // PrivacyChanged doesn't call revalidate() (privacy isn't a required field), but it must not
+        // regress an already-valid form either.
+        recipesRepository.addStoredRecipe(recipe1.copy(privacy = RecipePrivacy.PRIVATE))
+
+        val vm = createViewModel(recipeId = recipe1.uuid.toString())
+        assertTrue(vm.state.value.isFormValid)
+
+        vm.dispatch(EditorAction.PrivacyChanged(RecipePrivacy.PUBLIC))
+        assertTrue(vm.state.value.isFormValid)
+
+        vm.dispatch(EditorAction.Save)
+
+        assertEquals(RecipePrivacy.PUBLIC, recipesRepository.lastUpdatedRecipe?.privacy)
+        vm.viewModelScope.cancel()
+    }
+
+    @Test
     fun `save clears draft from Room`() = runTest {
         val vm = createViewModel()
 


### PR DESCRIPTION
## Summary
- `RecipePrivacy` already flowed through the whole data layer (entity, domain model, sync DTO), but was invisible in the UI and unreachable — `RecipeDraft` had no `privacy` field, and `RecipeDraft.toRecipe()` hardcoded `PUBLIC` on every save, silently flipping an edited private recipe to public.
- Adds a **Visibility** segmented control (🔒 Private / 🌐 Public) to the recipe editor, defaulting to **Private** for a recipe written from scratch and **Public** for a URL import (someone else's already-published page).
- Adds a private-only badge to the recipe list card and details screen — shown only when a recipe is private, since those surfaces already carry up to 6 tag/label chips.
- `RecipeDraftEntity` gained a `privacy` column via `MIGRATION_4_5` (Room **v4 → v5**) — renumbered from the original v3→v4 after rebasing onto main's own v3→v4 migration (#146, `imageBlobId`/upload bookkeeping). Existing in-flight drafts are backfilled to `PUBLIC` to match the prior hardcoded behavior rather than silently changing them.

## Test plan
- [x] `:app:testDebugUnitTest` — 490 tests, 0 failures (new coverage in the editor reducer/ViewModel, `DraftMapper`, `ScrapedRecipeMapper`, and two new Room migration tests: `migrate4To5_addsPrivacyColumnBackfilledToPublic` and the extended `migrateAll1To5_succeeds` chain)
- [x] `:app:assembleDebug` — Room regenerates `app/schemas/.../5.json`, confirmed to carry both `recipe_drafts.privacy` and main's `recipes.imageBlobId`/`recipe_image_state` upload columns
- [x] Manual on-device: create a recipe → Visibility defaults to Private → save → 🔒 Private badge shows on the list card and details screen
- [x] Investigated a report that toggling privacy on an *existing* recipe didn't unlock Save — root-caused to an unrelated, pre-existing (and correct) safeguard: recipes without locally-synced ingredients/steps keep Save disabled regardless of what's edited, since saving would otherwise wipe them. Added `changing only privacy on a valid existing recipe keeps save enabled and persists it` as a direct regression guard on the privacy path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)