### PR TITLE
Recipe search 1/6: search data layer

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeDao.kt
@@ -204,4 +204,37 @@ interface RecipeDao {
     @Query("SELECT COUNT(*) FROM recipes WHERE creatorId = :creatorId AND deletedAt IS NULL")
     suspend fun countRecipesForUser(creatorId: UUID): Int
 
+    // --- Search (offline/anonymous fallback — see RecipeSearchRepository) ---
+
+    /**
+     * Plain `LIKE` scan over title plus tag/label display names — the fallback used when the
+     * network search is unreachable (offline) or unavailable (anonymous sessions have no JWT).
+     * No FTS4, no ranking, no stemming: at the local corpus size (a single device's synced
+     * recipes) a `LIKE` scan is sub-millisecond, and this is a deliberate degradation the UI
+     * flags to the user, not a second source of truth to keep polished.
+     */
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM recipes r
+        WHERE r.deletedAt IS NULL
+          AND (
+            r.title LIKE '%' || :query || '%'
+            OR EXISTS (
+                SELECT 1 FROM recipe_tags rt
+                INNER JOIN tags t ON t.uuid = rt.tagId
+                WHERE rt.recipeId = r.uuid AND rt.deletedAt IS NULL AND t.displayName LIKE '%' || :query || '%'
+            )
+            OR EXISTS (
+                SELECT 1 FROM recipe_labels rl
+                INNER JOIN labels l ON l.uuid = rl.labelId
+                WHERE rl.recipeId = r.uuid AND rl.deletedAt IS NULL AND l.displayName LIKE '%' || :query || '%'
+            )
+          )
+        ORDER BY r.updatedAt DESC
+        LIMIT :limit
+        """
+    )
+    suspend fun searchRecipesWithDetails(query: String, limit: Int): List<RecipeWithDetails>
+
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -27,6 +27,8 @@ import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
+import com.tenmilelabs.chefai.search.data.repository.DefaultRecipeSearchRepository
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -73,6 +75,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindRenderedImageFetcher(fetcher: WebViewImageFetcher): RenderedImageFetcher
+
+    @Singleton
+    @Binds
+    abstract fun bindRecipeSearchRepository(repository: DefaultRecipeSearchRepository): RecipeSearchRepository
 }
 
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/NetworkModule.kt
@@ -4,6 +4,8 @@ import com.tenmilelabs.chefai.auth.data.network.AuthInterceptor
 import com.tenmilelabs.chefai.auth.domain.TokenProvider
 import com.tenmilelabs.chefai.recipes.data.network.ChefAIApiService
 import com.tenmilelabs.chefai.recipes.data.network.RecipeNetworkDataSource
+import com.tenmilelabs.chefai.search.data.network.RecipeSearchApiService
+import com.tenmilelabs.chefai.search.data.network.RecipeSearchNetworkDataSource
 import com.tenmilelabs.recipescraper.RecipeHtmlParser
 import dagger.Binds
 import dagger.Module
@@ -38,6 +40,11 @@ abstract class RecipeNetworkDataSourceModule {
     abstract fun bindRecipeNetworkDataSource(
         chefAIApiService: ChefAIApiService
     ): RecipeNetworkDataSource
+
+    @Binds
+    abstract fun bindRecipeSearchNetworkDataSource(
+        recipeSearchApiService: RecipeSearchApiService
+    ): RecipeSearchNetworkDataSource
 }
 
 @Module
@@ -60,6 +67,16 @@ object NetworkModule {
         // Install authentication interceptor
         install(AuthInterceptor) {
             this.tokenProvider = tokenProvider
+        }
+
+        // No requestTimeoutMillis here deliberately: SyncApiService.pullRecipes pages ~100
+        // recipes at a time and image upload/download stream bytes, both of which can
+        // legitimately run longer than a search-appropriate timeout. Callers that need a tight
+        // request timeout (e.g. search) set their own via a per-request `timeout { }` block,
+        // which Ktor allows to override this client-level config.
+        install(HttpTimeout) {
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 10_000
         }
 
         install(Logging) {

--- a/app/src/main/java/com/tenmilelabs/chefai/search/data/mapper/RecipeSearchMapper.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/data/mapper/RecipeSearchMapper.kt
@@ -1,0 +1,29 @@
+package com.tenmilelabs.chefai.search.data.mapper
+
+import com.tenmilelabs.chefai.core.data.local.util.RecipePrivacy
+import com.tenmilelabs.chefai.core.domain.model.Label
+import com.tenmilelabs.chefai.core.domain.model.RecipePreview
+import com.tenmilelabs.chefai.core.domain.model.Tag
+import com.tenmilelabs.chefai.search.data.network.dto.RecipeSearchResultDto
+import java.util.UUID
+
+/**
+ * Maps a search result directly to the domain model — no Room write, no sidecar upsert. Room is
+ * only consulted reactively, on tap or bookmark (see `RecipeSearchViewModel.onSaveToCollection`).
+ * [RecipePreview.localImagePath] is always null here: a search result was never cached on this
+ * device, so `recipeImageModel()` falls back to the remote thumbnail, exactly as intended.
+ */
+fun RecipeSearchResultDto.toRecipePreview(): RecipePreview = RecipePreview(
+    uuid = UUID.fromString(uuid),
+    title = title,
+    description = description,
+    imageUrlThumbnail = imageUrlThumbnail,
+    localImagePath = null,
+    prepTimeMinutes = prepTimeMinutes,
+    cookTimeMinutes = cookTimeMinutes,
+    servings = servings,
+    creatorId = UUID.fromString(creatorId),
+    privacy = RecipePrivacy.valueOf(privacy),
+    tags = tags.map { Tag(UUID.fromString(it.uuid), it.displayName) },
+    labels = labels.map { Label(UUID.fromString(it.uuid), it.displayName) },
+)

--- a/app/src/main/java/com/tenmilelabs/chefai/search/data/network/RecipeSearchApiService.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/data/network/RecipeSearchApiService.kt
@@ -1,0 +1,65 @@
+package com.tenmilelabs.chefai.search.data.network
+
+import com.tenmilelabs.chefai.BuildConfig
+import com.tenmilelabs.chefai.search.data.network.dto.RecipeSearchResponseDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Outcome of a single search call — never thrown, this fires on every keystroke. */
+sealed interface RecipeSearchNetworkResult {
+    data class Success(val response: RecipeSearchResponseDto) : RecipeSearchNetworkResult
+
+    /**
+     * Distinct from [Error] because the shared client has no automatic 401 refresh outside
+     * `SyncWorker` — the repository retries this once via `SessionManager.refreshToken()` rather
+     * than treating it as a generic failure.
+     */
+    data object Unauthorized : RecipeSearchNetworkResult
+    data class Error(val message: String) : RecipeSearchNetworkResult
+}
+
+/**
+ * Injects the unqualified (authenticated) [HttpClient] — never `@ScraperHttpClient`, see gotcha
+ * #18. Applies its own tight request timeout: this fires on every keystroke, and the shared
+ * client deliberately sets no default `requestTimeoutMillis` (search/sync/image-upload all need
+ * different budgets).
+ */
+@Singleton
+class RecipeSearchApiService @Inject constructor(
+    private val client: HttpClient
+) : RecipeSearchNetworkDataSource {
+    override suspend fun search(query: String, limit: Int, offset: Int): RecipeSearchNetworkResult {
+        return try {
+            val httpResponse = client.get(SEARCH_ENDPOINT) {
+                parameter("q", query)
+                parameter("limit", limit)
+                parameter("offset", offset)
+                expectSuccess = false
+                timeout { requestTimeoutMillis = SEARCH_REQUEST_TIMEOUT_MILLIS }
+            }
+            when {
+                httpResponse.status == HttpStatusCode.Unauthorized -> RecipeSearchNetworkResult.Unauthorized
+                httpResponse.status.isSuccess() -> RecipeSearchNetworkResult.Success(httpResponse.body())
+                else -> RecipeSearchNetworkResult.Error("Search failed: ${httpResponse.status}")
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            RecipeSearchNetworkResult.Error(e.message ?: "Unknown network error")
+        }
+    }
+
+    private companion object {
+        val SEARCH_ENDPOINT = "${BuildConfig.API_BASE_URL}/api/v1/recipes/search"
+        const val SEARCH_REQUEST_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/search/data/network/RecipeSearchNetworkDataSource.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/data/network/RecipeSearchNetworkDataSource.kt
@@ -1,0 +1,5 @@
+package com.tenmilelabs.chefai.search.data.network
+
+interface RecipeSearchNetworkDataSource {
+    suspend fun search(query: String, limit: Int, offset: Int): RecipeSearchNetworkResult
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/search/data/network/dto/RecipeSearchDtos.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/data/network/dto/RecipeSearchDtos.kt
@@ -1,0 +1,33 @@
+package com.tenmilelabs.chefai.search.data.network.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RecipeSearchResponseDto(
+    val query: String,
+    val results: List<RecipeSearchResultDto>,
+    val hasMore: Boolean,
+)
+
+@Serializable
+data class RecipeSearchResultDto(
+    val uuid: String,
+    val title: String,
+    val description: String,
+    val imageUrl: String,
+    val imageUrlThumbnail: String,
+    val prepTimeMinutes: Int,
+    val cookTimeMinutes: Int,
+    val servings: Int,
+    val creatorId: String,
+    val privacy: String,
+    val updatedAt: Long,
+    val tags: List<RecipeSearchTagDto>,
+    val labels: List<RecipeSearchLabelDto>,
+)
+
+@Serializable
+data class RecipeSearchTagDto(val uuid: String, val displayName: String)
+
+@Serializable
+data class RecipeSearchLabelDto(val uuid: String, val displayName: String)

--- a/app/src/main/java/com/tenmilelabs/chefai/search/data/repository/DefaultRecipeSearchRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/data/repository/DefaultRecipeSearchRepository.kt
@@ -1,0 +1,64 @@
+package com.tenmilelabs.chefai.search.data.repository
+
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.auth.domain.model.UserSession
+import com.tenmilelabs.chefai.core.data.local.room.dao.RecipeDao
+import com.tenmilelabs.chefai.recipes.data.mapper.toRecipePreviewDomain
+import com.tenmilelabs.chefai.search.data.mapper.toRecipePreview
+import com.tenmilelabs.chefai.search.data.network.RecipeSearchNetworkDataSource
+import com.tenmilelabs.chefai.search.data.network.RecipeSearchNetworkResult
+import com.tenmilelabs.chefai.search.data.network.dto.RecipeSearchResponseDto
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchOutcome
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchRepository
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchSource
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DefaultRecipeSearchRepository @Inject constructor(
+    private val apiService: RecipeSearchNetworkDataSource,
+    private val recipeDao: RecipeDao,
+    private val sessionManager: SessionManager,
+) : RecipeSearchRepository {
+
+    override suspend fun search(query: String, limit: Int, offset: Int): RecipeSearchOutcome {
+        // Anonymous sessions have no JWT and would 401 on every keystroke — skip the guaranteed
+        // round trip and go straight to the local fallback.
+        if (sessionManager.userSession.value is UserSession.Anonymous) {
+            return localFallback(query, limit)
+        }
+
+        return when (val result = apiService.search(query, limit, offset)) {
+            is RecipeSearchNetworkResult.Success -> result.response.toOutcome()
+            is RecipeSearchNetworkResult.Error -> localFallback(query, limit)
+            RecipeSearchNetworkResult.Unauthorized -> onUnauthorized(query, limit, offset)
+        }
+    }
+
+    /** Mirrors SyncWorker.doWork(): a single refresh-then-retry, never a loop. */
+    private suspend fun onUnauthorized(query: String, limit: Int, offset: Int): RecipeSearchOutcome {
+        if (sessionManager.refreshToken().isFailure) {
+            return localFallback(query, limit)
+        }
+        return when (val retryResult = apiService.search(query, limit, offset)) {
+            is RecipeSearchNetworkResult.Success -> retryResult.response.toOutcome()
+            else -> localFallback(query, limit)
+        }
+    }
+
+    private fun RecipeSearchResponseDto.toOutcome() =
+        RecipeSearchOutcome(
+            results = results.map { it.toRecipePreview() },
+            hasMore = hasMore,
+            source = RecipeSearchSource.REMOTE,
+        )
+
+    private suspend fun localFallback(query: String, limit: Int): RecipeSearchOutcome {
+        val rows = recipeDao.searchRecipesWithDetails(query, limit)
+        return RecipeSearchOutcome(
+            results = rows.toRecipePreviewDomain(),
+            hasMore = false,
+            source = RecipeSearchSource.LOCAL_FALLBACK,
+        )
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/search/domain/repository/RecipeSearchRepository.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/domain/repository/RecipeSearchRepository.kt
@@ -1,0 +1,26 @@
+package com.tenmilelabs.chefai.search.domain.repository
+
+import com.tenmilelabs.chefai.core.domain.model.RecipePreview
+
+/** Where [RecipeSearchOutcome.results] actually came from — the UI uses this to flag degraded results. */
+enum class RecipeSearchSource { REMOTE, LOCAL_FALLBACK }
+
+data class RecipeSearchOutcome(
+    val results: List<RecipePreview>,
+    val hasMore: Boolean,
+    val source: RecipeSearchSource,
+)
+
+interface RecipeSearchRepository {
+    /**
+     * Searches recipes by title, tag, and label. Falls back to an on-device `LIKE` scan — see
+     * [RecipeSearchSource.LOCAL_FALLBACK] — for anonymous sessions (no JWT) and whenever the
+     * network call fails; that fallback is a deliberate degradation, not a second source of
+     * truth, so it never carries `hasMore = true`.
+     */
+    suspend fun search(query: String, limit: Int = DEFAULT_LIMIT, offset: Int = 0): RecipeSearchOutcome
+
+    companion object {
+        const val DEFAULT_LIMIT = 20
+    }
+}


### PR DESCRIPTION
## Summary
Part 1 of 6 for recipe search (#151). Data layer only — no UI yet.

- `RecipeSearchApiService` (behind `RecipeSearchNetworkDataSource`, mirroring the existing
  `RecipeNetworkDataSource` pattern) hits `GET /api/v1/recipes/search` via the shared
  authenticated `HttpClient`. Returns a sealed outcome rather than throwing, since this fires
  per keystroke.
- The shared client gains an `HttpTimeout` install — connect/socket only, no blanket request
  timeout (sync pagination and image streaming both legitimately outlast a search-appropriate
  timeout). It had none before this.
- `DefaultRecipeSearchRepository`: anonymous sessions skip the network outright, a 401 gets one
  refresh-then-retry (mirrors `SyncWorker`), anything else falls back to a new
  `RecipeDao.searchRecipesWithDetails` — a plain `LIKE` scan, deliberately not Room FTS4 (see
  commit message for why).
- Search results map DTO → domain `RecipePreview` directly. No Room write on this path.

Backend companion PRs: jmuci/Chef.ai_Backend#51, #52, #53, #54.

## Test plan
- [x] `./gradlew :app:assembleDebug` compiles
- [ ] Unit tests land in PR 4, stacked later in this sequence
- [ ] Reviewed by a human before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)