### PR TITLE
Recipe search 2/6: RecipeSearchViewModel

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchViewModel.kt
@@ -1,0 +1,180 @@
+package com.tenmilelabs.chefai.search.ui
+
+import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.auth.domain.SessionManager
+import com.tenmilelabs.chefai.auth.domain.model.UserSession
+import com.tenmilelabs.chefai.collections.domain.repository.CollectionsRepository
+import com.tenmilelabs.chefai.core.data.sync.SyncScheduler
+import com.tenmilelabs.chefai.core.domain.model.RecipePreview
+import com.tenmilelabs.chefai.core.ui.recipeImageModel
+import com.tenmilelabs.chefai.core.util.WhileUiSubscribed
+import com.tenmilelabs.chefai.recipes.domain.repository.RecipesRepository
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchOutcome
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchRepository
+import com.tenmilelabs.chefai.search.domain.repository.RecipeSearchSource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+
+private const val SEARCH_DEBOUNCE_MILLIS = 300L
+private const val MIN_QUERY_LENGTH = 3
+
+/** UI state for the Home search overlay. */
+sealed interface SearchUiState {
+    data object Idle : SearchUiState
+    data object Searching : SearchUiState
+    data class Results(
+        val items: List<RecipePreview>,
+        val bookmarkedRecipeIds: Set<UUID> = emptySet(),
+        /** True when [items] came from the on-device fallback, not the server — see [RecipeSearchSource]. */
+        val isOffline: Boolean,
+    ) : SearchUiState
+    data object Empty : SearchUiState
+    data class Error(val messageRes: Int) : SearchUiState
+}
+
+/** One-time events for the Home search overlay. */
+sealed interface SearchUiEvent {
+    data class ShowSnackbar(val messageRes: Int) : SearchUiEvent
+}
+
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class RecipeSearchViewModel @Inject constructor(
+    private val recipeSearchRepository: RecipeSearchRepository,
+    private val recipesRepository: RecipesRepository,
+    private val collectionsRepository: CollectionsRepository,
+    private val sessionManager: SessionManager,
+    private val syncScheduler: SyncScheduler,
+    private val imageLoader: ImageLoader,
+    @param:ApplicationContext private val appContext: Context,
+) : ViewModel() {
+
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<SearchUiEvent>(replay = 1)
+    val uiEvents: SharedFlow<SearchUiEvent> = _uiEvent.asSharedFlow()
+
+    private val _bookmarkedIds: Flow<Set<UUID>> = sessionManager.userSession
+        .flatMapLatest { session ->
+            when (session) {
+                is UserSession.Loading -> flowOf(emptySet())
+                is UserSession.Anonymous -> collectionsRepository.observeBookmarkedRecipeIds(session.localUserId)
+                is UserSession.Authenticated -> collectionsRepository.observeBookmarkedRecipeIds(session.user.uuid)
+            }
+        }
+
+    private val _searchResult: Flow<SearchUiState> = _query
+        .debounce(SEARCH_DEBOUNCE_MILLIS)
+        .map { it.trim() }
+        .distinctUntilChanged()
+        .flatMapLatest<_, SearchUiState> { trimmed ->
+            if (trimmed.length < MIN_QUERY_LENGTH) {
+                flowOf(SearchUiState.Idle)
+            } else {
+                flow {
+                    emit(SearchUiState.Searching)
+                    emit(runSearch(trimmed))
+                }
+            }
+        }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            Timber.e(e, "Search failed")
+            emit(SearchUiState.Error(R.string.search_error))
+        }
+
+    val uiState: StateFlow<SearchUiState> = combine(_searchResult, _bookmarkedIds) { result, bookmarkedIds ->
+        if (result is SearchUiState.Results) result.copy(bookmarkedRecipeIds = bookmarkedIds) else result
+    }.stateIn(
+        scope = viewModelScope,
+        started = WhileUiSubscribed,
+        initialValue = SearchUiState.Idle,
+    )
+
+    private suspend fun runSearch(query: String): SearchUiState {
+        val outcome: RecipeSearchOutcome = recipeSearchRepository.search(query)
+        prefetchImages(outcome.results)
+        return if (outcome.results.isEmpty()) {
+            SearchUiState.Empty
+        } else {
+            SearchUiState.Results(
+                items = outcome.results,
+                isOffline = outcome.source == RecipeSearchSource.LOCAL_FALLBACK,
+            )
+        }
+    }
+
+    fun onQueryChanged(newQuery: String) {
+        _query.value = newQuery
+    }
+
+    /**
+     * Sync pull already ships every PUBLIC recipe to every device, so this is rare — only a
+     * recipe made public since the device's last pull is missing locally — but search is what
+     * makes a not-yet-synced recipe's UUID reachable at all, which nothing else in the app could
+     * do before. [BookmarkedRecipeEntity] enforces its FK to [RecipeEntity] at runtime (Room emits
+     * `PRAGMA foreign_keys = ON`), so this must be real, not just documented intent.
+     */
+    fun onSaveToCollection(recipeId: UUID) {
+        val userId = when (val session = sessionManager.userSession.value) {
+            is UserSession.Anonymous -> session.localUserId
+            is UserSession.Authenticated -> session.user.uuid
+            is UserSession.Loading -> return
+        }
+        viewModelScope.launch {
+            if (recipesRepository.getRecipeStream(recipeId).first() == null) {
+                syncScheduler.requestImmediateSync()
+                _uiEvent.emit(SearchUiEvent.ShowSnackbar(R.string.search_recipe_not_yet_synced))
+                return@launch
+            }
+            try {
+                collectionsRepository.addBookmark(userId, recipeId)
+                _uiEvent.emit(SearchUiEvent.ShowSnackbar(R.string.search_added_to_collection))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: SQLiteConstraintException) {
+                Timber.w(e, "Bookmark failed for $recipeId — recipe not yet synced")
+                _uiEvent.emit(SearchUiEvent.ShowSnackbar(R.string.search_recipe_not_yet_synced))
+            }
+        }
+    }
+
+    /** Enqueues Coil prefetch requests so thumbnails are warm in the cache when cards render. */
+    private fun prefetchImages(recipes: List<RecipePreview>) {
+        recipes.forEach { recipe ->
+            val model = recipeImageModel(recipe.localImagePath, recipe.imageUrlThumbnail) ?: return@forEach
+            imageLoader.enqueue(ImageRequest.Builder(appContext).data(model).build())
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,9 @@
     <string name="recipes_subtitle">Browse recipes and pick your next meal.</string>
     <string name="recipes_title">Ready to cook?</string>
     <string name="save_button">Save</string>
+    <string name="search_added_to_collection">Added to your collection</string>
+    <string name="search_error">Something went wrong while searching</string>
+    <string name="search_recipe_not_yet_synced">This recipe hasn\'t synced to your device yet</string>
     <string name="section_basic_information">Basic Information</string>
     <string name="section_ingredients">Ingredients *</string>
     <string name="section_instructions">Instructions *</string>

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeDao.kt
@@ -314,4 +314,26 @@ class FakeRecipeDao : RecipeDao {
     override suspend fun countRecipesForUser(creatorId: UUID): Int {
         return recipes.values.count { it.creatorId == creatorId && it.deletedAt == null }
     }
+
+    // --- Search (offline/anonymous fallback) ---
+
+    /** Mirrors the real `LIKE`-based query's semantics: title OR an active tag/label match. */
+    override suspend fun searchRecipesWithDetails(query: String, limit: Int): List<RecipeWithDetails> {
+        return recipes.values
+            .filter { it.deletedAt == null }
+            .filter { recipe ->
+                recipe.title.contains(query, ignoreCase = true) ||
+                    recipeTags.any {
+                        it.recipeId == recipe.uuid && it.deletedAt == null &&
+                            tags[it.tagId]?.displayName?.contains(query, ignoreCase = true) == true
+                    } ||
+                    recipeLabels.any {
+                        it.recipeId == recipe.uuid && it.deletedAt == null &&
+                            labels[it.labelId]?.displayName?.contains(query, ignoreCase = true) == true
+                    }
+            }
+            .sortedByDescending { it.updatedAt }
+            .take(limit)
+            .map { assembleRecipeWithDetails(it) }
+    }
 }


### PR DESCRIPTION
## Summary
Replaces #153, which GitHub's stacked-PR tracking wouldn't let me retarget directly (base-branch
edits are blocked via both the GraphQL and REST APIs while a PR is "part of a stack" — verified
against both endpoints). Same branch (`claude/recipe-search-android-2-viewmodel`), same commits,
now targeting `main` since #152 is merged.

Part 2 of 6 for recipe search (#151).

`MutableStateFlow<String> → debounce(300) → trim → distinctUntilChanged → flatMapLatest` to a
search, 3-character minimum. Its own ViewModel via `hiltViewModel()` — `HomeViewModel`'s SDUI
logic stays untouched.

The one hard constraint this handles: `BookmarkedRecipeEntity`'s FK to `RecipeEntity` is enforced
at runtime, and search is what makes a not-yet-synced recipe's UUID reachable for the first time
in this app. `onSaveToCollection` checks Room first and falls back to "request a sync + tell the
user" rather than attempting the write blind, with a `SQLiteConstraintException` catch as a second
guard.

Also includes two build fixes discovered via failing CI on #153 — see the third commit:
- `RecipeSearchViewModel.kt` referenced three string resources that were filed under the later
  UI-wiring PR, so this branch didn't compile standalone. Moved just those three here.
- `RecipeDao.searchRecipesWithDetails` (added on `main` via #152) had no `FakeRecipeDao`
  implementation, which breaks compilation for **every** test in the module that touches
  `FakeRecipeDao` — ten unrelated test files, not just search. **This is currently broken on
  `main` itself**, independent of this PR — flagging separately.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — 490/490 pass, standalone on this branch
- [ ] Reviewed by a human before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)