### PR TITLE
Recipe search: SearchBar UI + Home wiring

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipeListCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/ui/components/RecipeListCard.kt
@@ -1,5 +1,6 @@
 package com.tenmilelabs.chefai.core.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,8 +13,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -21,8 +27,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -41,14 +49,26 @@ import com.tenmilelabs.chefai.core.ui.recipeImageModel
 import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
 import java.util.UUID
 
+/**
+ * @param modifier Merged with this card's own padding/height/width so a caller's modifier is
+ * never silently dropped.
+ * @param isInCollection Whether [recipe] is already saved — shows a filled bookmark instead of an
+ * outline. Only rendered when [onSaveToCollection] is non-null.
+ * @param onSaveToCollection When non-null, shows a bookmark button that invokes this with the
+ * recipe UUID. Left null (the default) at this card's three existing call sites, which don't want
+ * inline save — introduced for search results, where saving without opening the recipe matters.
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun RecipeListCard(
     recipe: RecipePreview,
+    modifier: Modifier = Modifier,
+    isInCollection: Boolean = false,
+    onSaveToCollection: ((UUID) -> Unit)? = null,
     navigateToDetail: (UUID) -> Unit = {}
 ) {
     Card(
-        modifier = Modifier
+        modifier = modifier
             .padding(horizontal = dimensionResource(id = R.dimen.padding_small))
             .height(dimensionResource(id = R.dimen.recipe_card_height))
             .fillMaxWidth(),
@@ -62,20 +82,44 @@ fun RecipeListCard(
             modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_small)),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(recipeImageModel(recipe.localImagePath, recipe.imageUrlThumbnail))
-                    .crossfade(true)
-                    .build(),
-                placeholder = painterResource(R.drawable.ic_img_placeholder),
-                error = painterResource(R.drawable.ic_img_error),
-                contentDescription = stringResource(R.string.recipe_image_content_description),
-                contentScale = ContentScale.Crop,
-                alignment = Alignment.Center,
-                modifier = Modifier
-                    .size(width = 100.dp, height = 100.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
+            Box {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(recipeImageModel(recipe.localImagePath, recipe.imageUrlThumbnail))
+                        .crossfade(true)
+                        .build(),
+                    placeholder = painterResource(R.drawable.ic_img_placeholder),
+                    error = painterResource(R.drawable.ic_img_error),
+                    contentDescription = stringResource(R.string.recipe_image_content_description),
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.Center,
+                    modifier = Modifier
+                        .size(width = 100.dp, height = 100.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+
+                if (onSaveToCollection != null) {
+                    IconButton(
+                        onClick = { onSaveToCollection(recipe.uuid) },
+                        modifier = Modifier
+                            .testTag("SaveToCollectionButton")
+                            .align(Alignment.TopEnd)
+                            .padding(2.dp)
+                            .size(28.dp)
+                            .background(
+                                color = Color.Black.copy(alpha = 0.5f),
+                                shape = RoundedCornerShape(50)
+                            )
+                    ) {
+                        Icon(
+                            imageVector = if (isInCollection) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
+                            contentDescription = stringResource(R.string.save_to_collection_content_description),
+                            tint = if (isInCollection) Color(0xFFFFD700) else Color.White,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
 
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/tenmilelabs/chefai/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/home/ui/HomeScreen.kt
@@ -1,8 +1,11 @@
 package com.tenmilelabs.chefai.home.ui
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.SnackbarDuration
@@ -10,11 +13,13 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tenmilelabs.chefai.R
@@ -24,6 +29,7 @@ import com.tenmilelabs.chefai.core.util.EmptyContent
 import com.tenmilelabs.chefai.core.util.LoadingContent
 import com.tenmilelabs.chefai.home.data.model.ComponentModel
 import com.tenmilelabs.chefai.home.ui.components.ComponentRenderer
+import com.tenmilelabs.chefai.search.ui.RecipeSearchOverlay
 import java.util.UUID
 
 /**
@@ -55,20 +61,32 @@ fun HomeScreen(
         }
     }
 
-    when (val state = uiState) {
-        HomeUiState.Loading -> LoadingContent()
+    Box(modifier = Modifier.fillMaxSize()) {
+        when (val state = uiState) {
+            HomeUiState.Loading -> LoadingContent()
 
-        is HomeUiState.Error -> EmptyContent(
-            title = state.message,
-            subtitle = R.string.no_recipes_subtitle,
-            noRecipesIconRes = R.drawable.ic_chef_hat_black_24dp,
-        )
+            is HomeUiState.Error -> EmptyContent(
+                title = state.message,
+                subtitle = R.string.no_recipes_subtitle,
+                noRecipesIconRes = R.drawable.ic_chef_hat_black_24dp,
+            )
 
-        is HomeUiState.Success -> HomeContent(
-            components = state.components,
-            recipes = state.recipes,
-            bookmarkedRecipeIds = state.bookmarkedRecipeIds,
-            onAction = viewModel::onAction,
+            is HomeUiState.Success -> HomeContent(
+                components = state.components,
+                recipes = state.recipes,
+                bookmarkedRecipeIds = state.bookmarkedRecipeIds,
+                onAction = viewModel::onAction,
+            )
+        }
+
+        // Not a LazyColumn item — its expanded state must not scroll away or fight the list.
+        RecipeSearchOverlay(
+            snackbarHostState = snackbarHostState,
+            onRecipeClick = onRecipeClick,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .padding(horizontal = dimensionResource(R.dimen.padding_small)),
         )
     }
 }
@@ -100,7 +118,12 @@ fun HomeContent(
             .testTag("HomeScreen")
             .fillMaxSize()
             .animateContentSize(),
-        contentPadding = PaddingValues(vertical = dimensionResource(R.dimen.padding_extra_small)),
+        // Extra top clearance so the collapsed search bar (a Box overlay, not a list item —
+        // see HomeScreen's RecipeSearchOverlay) doesn't sit on top of the first section's text.
+        contentPadding = PaddingValues(
+            top = 64.dp,
+            bottom = dimensionResource(R.dimen.padding_extra_small),
+        ),
     ) {
         items(
             items = components,

--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchOverlay.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchOverlay.kt
@@ -1,0 +1,164 @@
+package com.tenmilelabs.chefai.search.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.components.RecipeListCard
+import com.tenmilelabs.chefai.core.util.EmptyContent
+import com.tenmilelabs.chefai.core.util.LoadingContent
+import java.util.UUID
+
+/**
+ * Home's search bar. Owns its own expanded/collapsed state locally — deliberately not lifted into
+ * [com.tenmilelabs.chefai.home.ui.HomeViewModel], which stays untouched. [RecipeSearchViewModel]
+ * (via its own [hiltViewModel]) owns only query text and results; neither ViewModel knows the
+ * other exists.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecipeSearchOverlay(
+    snackbarHostState: SnackbarHostState,
+    onRecipeClick: (UUID) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: RecipeSearchViewModel = hiltViewModel(),
+) {
+    val query by viewModel.query.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.uiEvents.collect { event ->
+            when (event) {
+                is SearchUiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(
+                    message = context.getString(event.messageRes),
+                    duration = SnackbarDuration.Short,
+                )
+            }
+        }
+    }
+
+    SearchBar(
+        modifier = modifier,
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        inputField = {
+            SearchBarDefaults.InputField(
+                query = query,
+                onQueryChange = viewModel::onQueryChanged,
+                onSearch = { expanded = true },
+                expanded = expanded,
+                onExpandedChange = { expanded = it },
+                placeholder = { Text(stringResource(R.string.placeholder_search)) },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (expanded) {
+                        IconButton(onClick = {
+                            expanded = false
+                            viewModel.onQueryChanged("")
+                        }) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = stringResource(R.string.search_clear_content_description),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) {
+        SearchResultsContent(
+            uiState = uiState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            onRecipeClick = { recipeId ->
+                expanded = false
+                onRecipeClick(recipeId)
+            },
+            onSaveToCollection = viewModel::onSaveToCollection,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.SearchResultsContent(
+    uiState: SearchUiState,
+    onRecipeClick: (UUID) -> Unit,
+    onSaveToCollection: (UUID) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (uiState) {
+        SearchUiState.Idle -> Unit
+
+        SearchUiState.Searching -> LoadingContent(modifier = modifier)
+
+        SearchUiState.Empty -> EmptyContent(
+            title = R.string.search_empty_results,
+            subtitle = R.string.search_empty_results_subtitle,
+            noRecipesIconRes = R.drawable.ic_chef_hat_black_24dp,
+            modifier = modifier,
+        )
+
+        is SearchUiState.Error -> Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                text = stringResource(uiState.messageRes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+
+        is SearchUiState.Results -> Box(modifier = modifier) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                if (uiState.isOffline) {
+                    item(key = "offline_banner") {
+                        Text(
+                            text = stringResource(R.string.search_offline_results),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(dimensionResource(R.dimen.padding_small)),
+                        )
+                    }
+                }
+                items(items = uiState.items, key = { it.uuid }) { recipe ->
+                    RecipeListCard(
+                        recipe = recipe,
+                        isInCollection = recipe.uuid in uiState.bookmarkedRecipeIds,
+                        onSaveToCollection = onSaveToCollection,
+                        navigateToDetail = onRecipeClick,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,6 @@
     <string name="recipes_title">Ready to cook?</string>
     <string name="save_button">Save</string>
     <string name="search_added_to_collection">Added to your collection</string>
-    <string name="search_error">Something went wrong while searching</string>
     <string name="search_clear_content_description">Clear search</string>
     <string name="search_empty_results">No recipes found</string>
     <string name="search_empty_results_subtitle">Try a different search term.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,11 @@
     <string name="save_button">Save</string>
     <string name="search_added_to_collection">Added to your collection</string>
     <string name="search_error">Something went wrong while searching</string>
+    <string name="search_clear_content_description">Clear search</string>
+    <string name="search_empty_results">No recipes found</string>
+    <string name="search_empty_results_subtitle">Try a different search term.</string>
+    <string name="search_error">Something went wrong while searching</string>
+    <string name="search_offline_results">Showing results saved on this device</string>
     <string name="search_recipe_not_yet_synced">This recipe hasn\'t synced to your device yet</string>
     <string name="section_basic_information">Basic Information</string>
     <string name="section_ingredients">Ingredients *</string>


### PR DESCRIPTION
## Summary
Next PR for recipe search (#151) — targets `main` directly, no chaining this time.

- M3 `SearchBar` in `HomeScreen`, layered above the SDUI `LazyColumn` in a `Box` (not a list item),
  so its expanded state doesn't scroll away or fight the list.
- `RecipeListCard` gains `modifier`/`isInCollection`/`onSaveToCollection`, all optional — its three
  existing call sites (Home, Recipes tab, its own `@Preview`) are unaffected by default.
- Fixes a real layout bug found during manual verification: the collapsed search bar overlapped
  the first SDUI section's subtitle text. `HomeContent`'s `LazyColumn` now reserves 64dp of top
  clearance.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — full suite passes on this branch
- [ ] Reviewed by a human before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)