### PR TITLE
Fix recipe labels/tags/ingredients missing + details scrolling

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeIngredientDao.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/local/room/dao/RecipeIngredientDao.kt
@@ -35,6 +35,16 @@ interface RecipeIngredientDao {
     suspend fun updateSyncStateForRecipe(recipeId: UUID, syncState: SyncState, updatedAt: Long)
 
     /**
+     * Like [updateSyncStateForRecipe] but scoped to specific ingredient refs. Unlike steps/tags/
+     * labels, ingredient refs are filtered before push (see buildSyncRecipeDto — the backend
+     * requires a pre-seeded catalog entry, #101), so "recipe X was accepted" doesn't mean every
+     * local ingredient ref for X was actually sent. Marking the wrong ones SYNCED here previously
+     * caused the following pull to delete them as stale, permanently losing data.
+     */
+    @Query("UPDATE recipe_ingredients SET syncState = :syncState, updatedAt = :updatedAt WHERE recipeId = :recipeId AND ingredientId IN (:ingredientIds)")
+    suspend fun updateSyncStateForRecipeIngredients(recipeId: UUID, ingredientIds: List<UUID>, syncState: SyncState, updatedAt: Long)
+
+    /**
      * Upserts all ingredient cross-references for a recipe.
      * This is a transactional operation that replaces all existing ingredients for the recipe.
      */

--- a/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestrator.kt
@@ -146,7 +146,7 @@ class SyncOrchestrator @Inject constructor(
             Timber.d("Push: Sending batch of ${recipeBatch.size} recipes, ${bookmarkBatch.size} bookmarks, ${mealPlanBatch.size} meal plans")
             // TODO decouple synchronization of unrelated entities such a recipes and meal plans.
             val response = syncNetworkDataSource.pushRecipes(SyncPushRequest(recipeBatch, bookmarkBatch, mealPlanBatch))
-            processPushResponse(response)
+            processPushResponse(response, recipeBatch)
             totalAccepted += response.accepted.size
             totalConflicts += response.conflicts.size
             totalErrors += response.errors.size
@@ -192,14 +192,30 @@ class SyncOrchestrator @Inject constructor(
         return recipe.toSyncDto(steps, ingredients, tags, labels)
     }
 
-    private suspend fun processPushResponse(response: SyncPushResponse) {
+    private suspend fun processPushResponse(response: SyncPushResponse, pushedRecipes: List<SyncRecipeDto>) {
+        // Unlike steps/tags/labels, ingredient refs are filtered before push (buildSyncRecipeDto
+        // only sends ones already known to the server; see #101) — so "recipe X was accepted"
+        // doesn't mean every local ingredient ref for X was actually sent. Blanket-marking every
+        // local row SYNCED used to lie about the ones filtered out, which made the following pull's
+        // upsertRecipeAggregate treat them as safe to delete — permanently losing ingredients the
+        // server was never told about. Marking only the ones actually included keeps the rest
+        // PENDING so upsertRecipeAggregate can tell the two cases apart and preserve them.
+        val pushedIngredientIdsByRecipe = pushedRecipes.associate { dto ->
+            dto.uuid to dto.ingredients.map { UUID.fromString(it.ingredientId) }
+        }
+
         // Process accepted recipes
         for (accepted in response.accepted) {
             val uuid = UUID.fromString(accepted.uuid)
             transactionRunner {
                 recipeDao.updateSyncState(uuid, SyncState.SYNCED, accepted.serverUpdatedAt)
                 recipeStepDao.updateSyncStateForRecipe(uuid, SyncState.SYNCED, accepted.serverUpdatedAt)
-                recipeIngredientDao.updateSyncStateForRecipe(uuid, SyncState.SYNCED, accepted.serverUpdatedAt)
+                val pushedIngredientIds = pushedIngredientIdsByRecipe[accepted.uuid].orEmpty()
+                if (pushedIngredientIds.isNotEmpty()) {
+                    recipeIngredientDao.updateSyncStateForRecipeIngredients(
+                        uuid, pushedIngredientIds, SyncState.SYNCED, accepted.serverUpdatedAt
+                    )
+                }
                 recipeTagCrossRefDao.updateSyncStateForRecipe(uuid, SyncState.SYNCED, accepted.serverUpdatedAt)
                 recipeLabelCrossRefDao.updateSyncStateForRecipe(uuid, SyncState.SYNCED, accepted.serverUpdatedAt)
             }
@@ -368,19 +384,31 @@ class SyncOrchestrator @Inject constructor(
         recipeStepDao.deleteAllForRecipe(recipeId)
         recipeStepDao.upsertAll(syncRecipe.toStepEntities())
 
+        // Ingredients this device already has that the server has never accepted — buildSyncRecipeDto
+        // filters these out of every push until their catalog entry is SYNCED (#101), so a PENDING
+        // cross-ref here doesn't mean "stale," it means "not yet offered to the server." A pull is
+        // otherwise server-authoritative, but for this table specifically the server's list is known
+        // incomplete, so these must survive the delete-and-replace below or they're gone for good.
+        val localPendingIngredients = recipeIngredientDao.getIngredientsForRecipe(recipeId)
+            .filter { it.syncState == SyncState.PENDING }
+
         recipeIngredientDao.deleteAllForRecipe(recipeId)
         val ingredientEntities = syncRecipe.toIngredientEntities()
         // We prevent upserting recipes that reference ingredients that that don't exist in Room.
-        if (ingredientEntities.isNotEmpty()) {
+        val validEntities = if (ingredientEntities.isEmpty()) {
+            emptyList()
+        } else {
             val referencedIds = ingredientEntities.map { it.ingredientId }
             val existingIds = ingredientDao.getExistingIds(referencedIds).toSet()
-            val validEntities = ingredientEntities.filter { it.ingredientId in existingIds }
-            if (validEntities.size < ingredientEntities.size) {
+            val valid = ingredientEntities.filter { it.ingredientId in existingIds }
+            if (valid.size < ingredientEntities.size) {
                 val missing = referencedIds.filterNot { it in existingIds }
                 Timber.w("upsertRecipeAggregate: recipe %s references %d unknown ingredientId(s), skipping them: %s", syncRecipe.uuid, missing.size, missing)
             }
-            recipeIngredientDao.upsertAll(validEntities)
+            valid
         }
+        // Server-confirmed entries win on overlap; distinctBy keeps the first occurrence.
+        recipeIngredientDao.upsertAll((validEntities + localPendingIngredients).distinctBy { it.ingredientId })
 
         recipeTagCrossRefDao.deleteAllForRecipe(recipeId)
         val tagCrossRefs = syncRecipe.toTagCrossRefs()

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/ui/details/RecipeDetailsScreen.kt
@@ -1,11 +1,9 @@
 package com.tenmilelabs.chefai.recipes.ui.details
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,10 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Delete
@@ -39,7 +35,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -70,7 +68,6 @@ import com.tenmilelabs.chefai.core.util.EmptyContent
 import com.tenmilelabs.chefai.core.util.LoadingContent
 import com.tenmilelabs.chefai.core.util.MathUtils
 import com.tenmilelabs.chefai.recipes.ui.components.DeleteConfirmationDialog
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 
@@ -138,7 +135,6 @@ fun RecipeDetailsScreen(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RecipeDetailsContent(
     recipe: Recipe,
@@ -159,13 +155,13 @@ fun RecipeDetailsContent(
     }
 
     val tabTitles = listOf(stringResource(R.string.ingredients), stringResource(R.string.steps))
-    val pagerState = rememberPagerState { tabTitles.size }
-    val coroutineScope = rememberCoroutineScope()
+    var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
 
     Box(modifier = Modifier.fillMaxSize()) {
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
     ) {
         Column(modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.padding_medium))) {
             Row(
@@ -247,29 +243,22 @@ fun RecipeDetailsContent(
             }
         }
 
-        TabRow(selectedTabIndex = pagerState.currentPage) {
+        TabRow(selectedTabIndex = selectedTabIndex) {
             tabTitles.forEachIndexed { index, title ->
                 Tab(
-                    selected = pagerState.currentPage == index,
-                    onClick = {
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(index)
-                        }
-                    },
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
                     text = { Text(text = title) }
                 )
             }
         }
 
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.fillMaxSize(),
-            verticalAlignment = Alignment.Top
-        ) { page ->
-            when (page) {
-                0 -> IngredientsList(ingredients = recipe.ingredients)
-                1 -> StepsList(steps = recipe.steps)
-            }
+        // Plain content, not its own scrollable — it's part of the single scroll on the outer
+        // Column above so the whole screen (header + tab content) scrolls as one, rather than the
+        // tab section being squeezed into whatever space is left and scrolling independently.
+        when (selectedTabIndex) {
+            0 -> IngredientsList(ingredients = recipe.ingredients)
+            1 -> StepsList(steps = recipe.steps)
         }
     }
 
@@ -308,19 +297,19 @@ private fun RecipeDescription(description: String) {
 
 @Composable
 fun IngredientsList(ingredients: List<RecipeIngredient>) {
-    LazyColumn(contentPadding = PaddingValues(all = dimensionResource(id = R.dimen.padding_medium))) {
-        items(ingredients) { ingredient ->
-            Row() {
+    Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))) {
+        ingredients.forEach { ingredient ->
+            Row {
                 Text(
                     text = ingredient.ingredientDisplayName,
                     modifier = Modifier
+                        .weight(1f)
                         .padding(vertical = dimensionResource(id = R.dimen.padding_small)),
                     style = MaterialTheme.typography.bodyLarge
                 )
                 Text(
                     text = MathUtils.removeTrailingZeros(ingredient.quantity.toString()) + " " + ingredient.unit,
                     modifier = Modifier
-                        .fillMaxWidth()
                         .padding(vertical = dimensionResource(id = R.dimen.padding_small)),
                     textAlign = TextAlign.End,
                     style = MaterialTheme.typography.bodyLarge
@@ -333,8 +322,8 @@ fun IngredientsList(ingredients: List<RecipeIngredient>) {
 
 @Composable
 fun StepsList(steps: List<RecipeStep>) {
-    LazyColumn(contentPadding = PaddingValues(all = dimensionResource(id = R.dimen.padding_medium))) {
-        items(steps.sortedBy { it.orderIndex }) { step ->
+    Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))) {
+        steps.sortedBy { it.orderIndex }.forEach { step ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeIngredientDao.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/local/room/dao/FakeRecipeIngredientDao.kt
@@ -55,6 +55,22 @@ class FakeRecipeIngredientDao : RecipeIngredientDao {
         }
     }
 
+    override suspend fun updateSyncStateForRecipeIngredients(
+        recipeId: UUID,
+        ingredientIds: List<UUID>,
+        syncState: SyncState,
+        updatedAt: Long
+    ) {
+        val ids = ingredientIds.toSet()
+        recipeIngredientsFlow.value = recipeIngredientsFlow.value.map { ingredient ->
+            if (ingredient.recipeId == recipeId && ingredient.ingredientId in ids) {
+                ingredient.copy(syncState = syncState, updatedAt = updatedAt)
+            } else {
+                ingredient
+            }
+        }
+    }
+
     override suspend fun markPendingForRecipes(recipeIds: List<UUID>, updatedAt: Long) {
         recipeIngredientsFlow.value = recipeIngredientsFlow.value.map { ri ->
             if (ri.recipeId in recipeIds) {

--- a/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/core/data/sync/SyncOrchestratorTest.kt
@@ -648,6 +648,42 @@ class SyncOrchestratorTest {
         assertThat(dto.ingredients).isEmpty()
     }
 
+    @Test
+    fun `pull does not wipe a locally-pending ingredient the server was never told about`() = runTest(testDispatcher) {
+        // Reproduces a data-loss bug: a brand-new ingredient (its catalog entry not yet SYNCED) is
+        // filtered out of the push — see "push filters out ingredient refs not known to server" —
+        // so the recipe is accepted server-side with zero ingredients. The pull that immediately
+        // follows must not treat that empty server list as authoritative and delete the ingredient
+        // this device still has; it was never given a chance to actually sync.
+        val newIngredientId = UuidV7Generator.newId() // not in ingredientDao -> not SYNCED, filtered from push
+        val recipe = createDirtyRecipe(uuid = recipeId1)
+        recipeDao.upsertRecipe(recipe)
+        recipeIngredientDao.upsertRecipeIngredient(
+            RecipeIngredientEntity(recipeId1, newIngredientId, 2.0, "cups", 1000L)
+        )
+
+        syncNetworkDataSource.pushResponses.addLast(
+            SyncPushResponse(
+                accepted = listOf(AcceptedEntityDto(recipeId1.toString(), 5000L)),
+                conflicts = emptyList(),
+                errors = emptyList(),
+                serverTimestamp = 5000L
+            )
+        )
+        // Server echoes back exactly what it received: the recipe, with no ingredients.
+        val serverEcho = createSyncRecipeDto(uuid = recipeId1, updatedAt = 5000L).copy(ingredients = emptyList())
+        syncNetworkDataSource.pullResponses.addLast(
+            SyncPullResponse(recipes = listOf(serverEcho), serverTimestamp = 6000L, hasMore = false)
+        )
+
+        syncOrchestrator.sync()
+
+        val ingredients = recipeIngredientDao.getIngredientsForRecipe(recipeId1)
+        assertThat(ingredients).hasSize(1)
+        assertThat(ingredients[0].ingredientId).isEqualTo(newIngredientId)
+        assertThat(ingredients[0].syncState).isEqualTo(SyncState.PENDING)
+    }
+
     // ==================== INTEGRATION TESTS ====================
 
     @Test


### PR DESCRIPTION
## Summary
- **Sync data-loss bug (the real root cause of missing ingredients/tags)**: newly-imported ingredients whose names aren't already in the shared catalog get filtered out of the first sync push (backend requires pre-seeded ingredients, #101), but the code used to mark them synced anyway — so the very next pull deleted them locally to match the server's incomplete copy. Confirmed via a live pull of production data: 38/188 local recipes, including all of the reporter's actual bookmarked recipes, had silently lost every ingredient this way.
- **Details screen scrolling**: the Ingredients/Steps `HorizontalPager` lived inside a non-scrollable outer `Column` with `fillMaxSize()`, so it overflowed off-screen instead of sizing to the remaining space — only the nested list scrolled, not the page. Replaced with click-only tabs inside one unified `verticalScroll` page. Also fixes a latent Row-layout bug that would have clipped ingredient quantities once ingredients started rendering again.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — 515 tests, 0 failures (includes a new regression test reproducing the sync data-loss scenario)
- [x] `./gradlew :app:assembleDebugAndroidTest` — instrumented tests compile clean
- [x] Manually verified on a disposable emulator loaded with a copy of real data: tags/ingredients render correctly, whole details page scrolls as one unit
- [x] Verified the sync fix against the real device's live database (repaired data survived an app launch + sync cycle without being re-wiped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)