### PR TITLE
Search tab: add category browse landing page

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/SearchScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/SearchScreen.kt
@@ -1,6 +1,7 @@
 package com.tenmilelabs.chefai.search.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -15,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.search.ui.components.SearchBrowseContent
 import java.util.UUID
 
 /**
@@ -31,7 +33,15 @@ fun SearchScreen(
     var expanded by rememberSaveable { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // Step 5 puts SearchBrowseContent here.
+        SearchBrowseContent(
+            onCategoryClick = { /* Step 6 */ },
+            contentPadding = PaddingValues(
+                start = dimensionResource(R.dimen.padding_medium),
+                end = dimensionResource(R.dimen.padding_medium),
+                top = dimensionResource(R.dimen.search_bar_clearance),
+                bottom = dimensionResource(R.dimen.padding_medium),
+            ),
+        )
 
         RecipeSearchBar(
             viewModel = viewModel,

--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/components/CategoryCard.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/components/CategoryCard.kt
@@ -1,0 +1,145 @@
+package com.tenmilelabs.chefai.search.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+
+/** Background/foreground pairing for a [CategoryCard]; cycled across the grid so adjacent cards differ. */
+enum class CategoryCardTone { PRIMARY, SECONDARY, TERTIARY }
+
+/** A browse shortcut on the Search tab, rendered as a themed gradient card. */
+@Composable
+fun CategoryCard(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    tone: CategoryCardTone = CategoryCardTone.PRIMARY,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    val (startColor, endColor, contentColor) = when (tone) {
+        CategoryCardTone.PRIMARY -> Triple(
+            colorScheme.primaryContainer,
+            colorScheme.secondaryContainer,
+            colorScheme.onPrimaryContainer,
+        )
+        CategoryCardTone.SECONDARY -> Triple(
+            colorScheme.secondaryContainer,
+            colorScheme.tertiaryContainer,
+            colorScheme.onSecondaryContainer,
+        )
+        CategoryCardTone.TERTIARY -> Triple(
+            colorScheme.tertiaryContainer,
+            colorScheme.primaryContainer,
+            colorScheme.onTertiaryContainer,
+        )
+    }
+
+    Card(
+        onClick = onClick,
+        modifier = modifier.testTag("CategoryCard"),
+        shape = RoundedCornerShape(dimensionResource(R.dimen.card_corner_radius)),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(dimensionResource(R.dimen.category_card_height))
+                .background(Brush.linearGradient(listOf(startColor, endColor))),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(dimensionResource(R.dimen.padding_medium)),
+            )
+        }
+    }
+}
+
+@Preview(name = "Light", showBackground = true)
+@Composable
+private fun CategoryCardLightPreview() {
+    ChefAITheme {
+        Surface {
+            CategoryCard(title = "Breakfast", onClick = {})
+        }
+    }
+}
+
+@Preview(name = "Dark", showBackground = true)
+@Composable
+private fun CategoryCardDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        Surface {
+            CategoryCard(title = "Breakfast", onClick = {})
+        }
+    }
+}
+
+@Preview(name = "Long title", showBackground = true)
+@Composable
+private fun CategoryCardLongTitlePreview() {
+    ChefAITheme {
+        Surface {
+            CategoryCard(title = "Sandwiches & Wraps", onClick = {})
+        }
+    }
+}
+
+@Preview(name = "All tones", showBackground = true)
+@Composable
+private fun CategoryCardTonesPreview() {
+    ChefAITheme {
+        Surface {
+            Row(
+                modifier = Modifier.padding(dimensionResource(R.dimen.padding_small)),
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_small)),
+            ) {
+                CategoryCard(
+                    title = "Breakfast",
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    tone = CategoryCardTone.PRIMARY,
+                )
+                CategoryCard(
+                    title = "Lunch",
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    tone = CategoryCardTone.SECONDARY,
+                )
+                CategoryCard(
+                    title = "Dinner",
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                    tone = CategoryCardTone.TERTIARY,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/components/SearchBrowseContent.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/components/SearchBrowseContent.kt
@@ -1,0 +1,101 @@
+package com.tenmilelabs.chefai.search.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tenmilelabs.chefai.R
+import com.tenmilelabs.chefai.core.ui.theme.ChefAITheme
+import com.tenmilelabs.chefai.search.ui.model.SearchCategory
+import com.tenmilelabs.chefai.search.ui.model.SearchCategoryGroup
+
+/**
+ * The Search tab's landing page: browse shortcuts grouped into sections, two cards per row.
+ * Stateless — the caller decides what a tap does.
+ */
+@Composable
+fun SearchBrowseContent(
+    onCategoryClick: (SearchCategory) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        modifier = modifier
+            .fillMaxSize()
+            .testTag("SearchBrowseContent"),
+        contentPadding = contentPadding,
+        horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_small)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_small)),
+    ) {
+        SearchCategoryGroup.entries.forEach { group ->
+            item(
+                key = "header_${group.name}",
+                span = { GridItemSpan(maxLineSpan) },
+            ) {
+                BrowseSectionHeader(title = stringResource(group.titleRes))
+            }
+            itemsIndexed(
+                items = SearchCategory.of(group),
+                key = { _, category -> category.name },
+            ) { index, category ->
+                CategoryCard(
+                    title = stringResource(category.labelRes),
+                    tone = CategoryCardTone.entries[index % CategoryCardTone.entries.size],
+                    onClick = { onCategoryClick(category) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BrowseSectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.headlineSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier.padding(
+            horizontal = dimensionResource(R.dimen.padding_extra_small),
+            vertical = dimensionResource(R.dimen.padding_medium),
+        ),
+    )
+}
+
+@Preview(name = "Light", showBackground = true)
+@Composable
+private fun SearchBrowseContentLightPreview() {
+    ChefAITheme {
+        Surface {
+            SearchBrowseContent(onCategoryClick = {})
+        }
+    }
+}
+
+@Preview(name = "Dark", showBackground = true)
+@Composable
+private fun SearchBrowseContentDarkPreview() {
+    ChefAITheme(darkTheme = true) {
+        Surface {
+            SearchBrowseContent(onCategoryClick = {})
+        }
+    }
+}

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,6 +9,7 @@
     <dimen name="recipe_card_height">120dp</dimen>
     <dimen name="category_card_height">96dp</dimen>
     <dimen name="card_corner_radius">16dp</dimen>
+    <dimen name="search_bar_clearance">72dp</dimen>
     <dimen name="row_height_medium">50dp</dimen>
     <dimen name="section_header_height">60dp</dimen>
     <dimen name="nav_bar_icon_size">30dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,6 +7,8 @@
     <dimen name="padding_extra_small">4dp</dimen>
     <dimen name="padding_extra_extra_small">2dp</dimen>
     <dimen name="recipe_card_height">120dp</dimen>
+    <dimen name="category_card_height">96dp</dimen>
+    <dimen name="card_corner_radius">16dp</dimen>
     <dimen name="row_height_medium">50dp</dimen>
     <dimen name="section_header_height">60dp</dimen>
     <dimen name="nav_bar_icon_size">30dp</dimen>


### PR DESCRIPTION
## Summary
- add reusable `CategoryCard` components with theme-driven gradient tones
- add `SearchBrowseContent`, a single two-column `LazyVerticalGrid` with full-width section headers
- place the category browse page beneath the existing pinned Search tab bar, with clearance so the first header remains visible

## Why
The Search tab now has an image-free browse landing page built from the static category catalog. Category taps intentionally remain no-ops until Step 6 wires them into the existing search pipeline.

## Validation
- `./gradlew :app:assembleDebug`