### PR TITLE
Search tab (6/8): category cards run a recipe search

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/SearchScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/SearchScreen.kt
@@ -34,7 +34,10 @@ fun SearchScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         SearchBrowseContent(
-            onCategoryClick = { /* Step 6 */ },
+            onCategoryClick = { category ->
+                viewModel.onQueryChanged(category.query)
+                expanded = true
+            },
             contentPadding = PaddingValues(
                 start = dimensionResource(R.dimen.padding_medium),
                 end = dimensionResource(R.dimen.padding_medium),


### PR DESCRIPTION
Step 6 of `docs/prompts/search-tab-plan.md`, on top of #166, #167 and #168 (Steps 1–5, already merged). One file, one behavioral change.

## What changed

`SearchScreen.kt`'s category-tap handler was a placeholder (`/* Step 6 */`) since #168. This wires it up:

```kotlin
onCategoryClick = { category ->
    viewModel.onQueryChanged(category.query)
    expanded = true
},
```

Tapping a card runs the same search a typed query would — same 300ms debounce, same remote-then-local-fallback pipeline, same results rendering. No new endpoint, no new ViewModel state. Every `SearchCategory.query` is already ≥3 characters (checked against `RecipeSearchViewModel`'s `MIN_QUERY_LENGTH`), so no category silently no-ops.

## Verification

Not build-verified — this session's network policy still denies `dl.google.com` (documented in `docs/claude/cloud-environment-setup.md`), so neither `assembleDebug` nor `testDebugUnitTest` could run here. Verified by inspection instead: `onQueryChanged`/`category.query` types line up, every category's query clears the 3-char minimum, and no leftover placeholder remains anywhere in `app/src/main`. **Please build locally before merging**, same as the earlier PRs in this series had to be.

One thing inspection can't settle: whether Material3's `SearchBar` already collapses on the system back button, or needs an explicit `BackHandler(enabled = expanded)` as the plan flags as a possibility. Left as-is since recent M3 versions typically register their own handler and a second one can conflict — but this needs a real back-press test on a device, which I can't do from here.

## Note on branch history

This PR's branch was restarted from current `main` rather than continuing the old `claude/search-tab-category-cards-xmyxuz` history: that branch had been fully merged (twice, via #166 then #167/#168), and a separate, no-longer-current attempt at Step 2 that never landed anywhere had accumulated locally in the meantime. Since everything in that stray work was already superseded by what #167 actually shipped (confirmed by diffing both), it was dropped rather than rebased forward — nothing in it was unique. This PR is just Step 6 against current `main`.

## What's left

Step 7 (Compose tests for `CategoryCard` and `SearchBrowseContent`, plus an optional `RecipeSearchViewModel` case) and Step 8 (docs: `CLAUDE.md`'s gap table still describes the old on-Home search bar, and `.claude/session-context.md` doesn't exist yet despite `CLAUDE.md` instructing sessions to read it at startup).

---
_Generated by [Claude Code](https://claude.ai/code/session_013LVrCGM3QLV2ccjVEqenFF)_