### PR TITLE
Fix search bar overlapping browse category cards

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/SearchScreen.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/SearchScreen.kt
@@ -9,11 +9,15 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.tenmilelabs.chefai.R
 import com.tenmilelabs.chefai.search.ui.components.SearchBrowseContent
@@ -31,6 +35,8 @@ fun SearchScreen(
     viewModel: RecipeSearchViewModel = hiltViewModel(),
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
+    var searchBarHeight by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
 
     Box(modifier = Modifier.fillMaxSize()) {
         SearchBrowseContent(
@@ -41,7 +47,7 @@ fun SearchScreen(
             contentPadding = PaddingValues(
                 start = dimensionResource(R.dimen.padding_medium),
                 end = dimensionResource(R.dimen.padding_medium),
-                top = dimensionResource(R.dimen.search_bar_clearance),
+                top = searchBarHeight + dimensionResource(R.dimen.padding_small),
                 bottom = dimensionResource(R.dimen.padding_medium),
             ),
         )
@@ -55,7 +61,12 @@ fun SearchScreen(
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .fillMaxWidth()
-                .padding(horizontal = dimensionResource(R.dimen.padding_small)),
+                .padding(horizontal = dimensionResource(R.dimen.padding_small))
+                .onSizeChanged { size ->
+                    if (!expanded) {
+                        searchBarHeight = with(density) { size.height.toDp() }
+                    }
+                },
         )
     }
 }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,7 +9,6 @@
     <dimen name="recipe_card_height">120dp</dimen>
     <dimen name="category_card_height">96dp</dimen>
     <dimen name="card_corner_radius">16dp</dimen>
-    <dimen name="search_bar_clearance">72dp</dimen>
     <dimen name="row_height_medium">50dp</dimen>
     <dimen name="section_header_height">60dp</dimen>
     <dimen name="nav_bar_icon_size">30dp</dimen>


### PR DESCRIPTION
The collapsed search bar's top clearance was a fixed 72dp guess (search_bar_clearance), which was shorter than the bar's actual rendered height and cut into the "Search by Meal" header. Measure the bar's real height via onSizeChanged and use it for the grid's top content padding instead.


Claude-Session: https://claude.ai/code/session_011wrS4h8N8fY8hLnUEVf9j5