### PR TITLE
Fix search results opening to "recipe not found"

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchBar.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchBar.kt
@@ -64,6 +64,13 @@ fun RecipeSearchBar(
         }
     }
 
+    LaunchedEffect(viewModel, onExpandedChange, onRecipeClick) {
+        viewModel.navigateToRecipe.collect { recipeId ->
+            onExpandedChange(false)
+            onRecipeClick(recipeId)
+        }
+    }
+
     SearchBar(
         modifier = modifier,
         expanded = expanded,
@@ -98,10 +105,7 @@ fun RecipeSearchBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
-            onRecipeClick = { recipeId ->
-                onExpandedChange(false)
-                onRecipeClick(recipeId)
-            },
+            onRecipeClick = viewModel::onRecipeClick,
             onSaveToCollection = viewModel::onSaveToCollection,
         )
     }

--- a/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchViewModel.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/search/ui/RecipeSearchViewModel.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +40,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -84,6 +86,14 @@ class RecipeSearchViewModel @Inject constructor(
 
     private val _uiEvent = MutableSharedFlow<SearchUiEvent>(replay = 1)
     val uiEvents: SharedFlow<SearchUiEvent> = _uiEvent.asSharedFlow()
+
+    /**
+     * One-shot, not replayed (unlike [uiEvents]) — a stale navigation event replaying into a
+     * freshly recomposed collector would silently re-navigate the user to a recipe they already
+     * backed out of.
+     */
+    private val _navigateToRecipe = Channel<UUID>(Channel.BUFFERED)
+    val navigateToRecipe: Flow<UUID> = _navigateToRecipe.receiveAsFlow()
 
     private val _bookmarkedIds: Flow<Set<UUID>> = sessionManager.userSession
         .flatMapLatest { session ->
@@ -137,6 +147,24 @@ class RecipeSearchViewModel @Inject constructor(
 
     fun onQueryChanged(newQuery: String) {
         _query.value = newQuery
+    }
+
+    /**
+     * [RecipeDetailsScreen] reads only from Room, but a search result may be a recipe this device
+     * hasn't pulled yet (see [onSaveToCollection]'s doc for why that's real, not just theoretical).
+     * Navigating straight there would land on the "recipe not found" screen, so gate on local
+     * existence first: if it's missing, kick a sync and tell the user instead of opening a dead
+     * end — mirroring the same check [onSaveToCollection] already does for bookmarking.
+     */
+    fun onRecipeClick(recipeId: UUID) {
+        viewModelScope.launch {
+            if (recipesRepository.getRecipeStream(recipeId).first() != null) {
+                _navigateToRecipe.send(recipeId)
+            } else {
+                syncScheduler.requestImmediateSync()
+                _uiEvent.emit(SearchUiEvent.ShowSnackbar(R.string.search_recipe_not_yet_synced))
+            }
+        }
     }
 
     /**

--- a/app/src/test/java/com/tenmilelabs/chefai/search/ui/RecipeSearchViewModelTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/search/ui/RecipeSearchViewModelTest.kt
@@ -304,4 +304,36 @@ class RecipeSearchViewModelTest {
             assertThat(event.messageRes).isEqualTo(R.string.search_recipe_not_yet_synced)
         }
     }
+
+    @Test
+    fun `clicking a recipe present in Room emits a navigation event`() = testScope.runTest {
+        val recipeId = UUID.randomUUID()
+        recipesRepository.emitRecipe(recipeId, recipe1)
+
+        turbineScope {
+            val navigations = viewModel.navigateToRecipe.testIn(backgroundScope)
+            viewModel.onRecipeClick(recipeId)
+            runCurrent()
+
+            assertThat(navigations.awaitItem()).isEqualTo(recipeId)
+        }
+    }
+
+    @Test
+    fun `clicking a recipe absent from Room requests a sync and shows the not-yet-synced snackbar, without navigating`() =
+        testScope.runTest {
+            val recipeId = UUID.randomUUID()
+            recipesRepository.emitRecipe(recipeId, null) // Room: not found
+
+            turbineScope {
+                val navigations = viewModel.navigateToRecipe.testIn(backgroundScope)
+                val events = viewModel.uiEvents.testIn(backgroundScope)
+                viewModel.onRecipeClick(recipeId)
+                runCurrent()
+
+                val event = events.awaitItem() as SearchUiEvent.ShowSnackbar
+                assertThat(event.messageRes).isEqualTo(R.string.search_recipe_not_yet_synced)
+                navigations.expectNoEvents()
+            }
+        }
 }


### PR DESCRIPTION
## Summary
- Tapping a search result card could navigate to a recipe that's on the backend but hasn't synced into this device's Room DB yet — `RecipeDetailsScreen` reads only from Room, so that landed on a "recipe not found" dead end. Bookmarking the same card silently no-opped for the same reason.
- Routed the tap through a new `RecipeSearchViewModel.onRecipeClick`, mirroring the existing `onSaveToCollection` guard: check local (Room) existence first — if found, emit a one-shot navigation event; if not, kick an immediate sync and show the same "hasn't synced yet" snackbar instead of opening a dead end.
- `RecipeSearchBar` now collects `viewModel.navigateToRecipe` (a `Channel`-backed flow, not replayed) and calls `onRecipeClick` through the view model rather than navigating directly.

## Test plan
- [x] Added `RecipeSearchViewModelTest` cases: clicking a recipe present in Room emits a navigation event; clicking one absent from Room requests a sync, shows the not-yet-synced snackbar, and does not navigate.
- [ ] `./gradlew :app:testDebugUnitTest` — could not run in this sandbox (outbound proxy blocks `dl.google.com`, so the Android Gradle Plugin can't resolve). Please run locally/CI before merge.
- [ ] Manual check on device/emulator: search for a recipe not yet synced locally, tap the card, confirm the snackbar (not a dead "recipe not found" screen), then confirm bookmarking behaves the same way.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPt35xEoE1B9pzs8s4zSM9)_