### PR TITLE
Fix recipe import silently saving zero ingredients

### DIFF
--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParser.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParser.kt
@@ -18,8 +18,9 @@ import com.tenmilelabs.recipescraper.model.ScrapedRecipe
  *
  * Two extraction tiers are tried in order, JSON-LD then microdata, since JSON-LD is both the more
  * common format on recipe sites and the more reliably structured one. A tier only counts as a hit
- * when it produces a recipe with a non-blank title *and* at least one ingredient or instruction —
- * a schema.org block that carries only a name is not a usable recipe, so the next tier is tried.
+ * when it produces a recipe with a non-blank title *and* at least one ingredient — a block with
+ * instructions but no ingredients has nothing to show on the ingredients tab, so the next tier is
+ * tried instead of silently succeeding with an empty list.
  */
 class RecipeHtmlParser {
 
@@ -47,4 +48,4 @@ class RecipeHtmlParser {
 }
 
 private fun ScrapedRecipe.isUsable(): Boolean =
-    title.isNotBlank() && (ingredients.isNotEmpty() || instructions.isNotEmpty())
+    title.isNotBlank() && ingredients.isNotEmpty()

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdRecipeMapper.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdRecipeMapper.kt
@@ -51,13 +51,19 @@ private fun JsonElement.yieldStrings(): List<String> = when (this) {
     is JsonObject -> emptyList()
 }
 
+/**
+ * Handles the flat `JsonArray` of string primitives schema.org specifies, plus shapes sites publish
+ * in practice that it doesn't: a lone string instead of an array, an array of objects (e.g.
+ * `HowToSupply`-typed entries with a `name`/`text` field), and ingredients grouped into nested
+ * arrays — mirroring how [toInstructionSteps] already handles a typed/nested shape.
+ */
 private fun JsonElement.toIngredients(): List<ScrapedIngredient> =
     when (this) {
-        is JsonArray -> mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
-            .mapNotNull(::cleanHtmlText)
+        is JsonArray -> flatMap { it.toIngredients() }
+        is JsonObject -> listOfNotNull(cleanHtmlText(stringOrNull("name") ?: stringOrNull("text")))
             .map(::parseIngredient)
 
-        else -> emptyList()
+        is JsonPrimitive -> listOfNotNull(contentOrNull?.let(::cleanHtmlText)).map(::parseIngredient)
     }
 
 private fun JsonElement.toInstructionSteps(): List<String> = when (this) {

--- a/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapeResult.kt
+++ b/recipe-scraper/src/commonMain/kotlin/com/tenmilelabs/recipescraper/model/ScrapeResult.kt
@@ -13,7 +13,7 @@ sealed interface ScrapeResult {
 
     /**
      * The document parsed cleanly but carried no usable recipe — either no recipe markup at all,
-     * or markup too incomplete to use (no title, or neither ingredients nor instructions).
+     * or markup too incomplete to use (no title, or no ingredients).
      */
     data object NoRecipeFound : ScrapeResult
 

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParserTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/RecipeHtmlParserTest.kt
@@ -48,6 +48,26 @@ class RecipeHtmlParserTest {
     }
 
     @Test
+    fun `falls through to NoRecipeFound when the only JSON-LD candidate has instructions but no ingredients`() {
+        assertEquals(
+            ScrapeResult.NoRecipeFound,
+            parser.parse(JsonLdFixtures.INSTRUCTIONS_ONLY, "https://example.com/r"),
+        )
+    }
+
+    @Test
+    fun `falls back to microdata when JSON-LD has instructions but no ingredients and microdata does`() {
+        val html = JsonLdFixtures.INSTRUCTIONS_ONLY.replace("</body></html>", "") +
+            MicrodataFixtures.FULL_RECIPE.substringAfter("<body>")
+
+        val result = parser.parse(html, "https://example.com/r")
+
+        val success = assertIs<ScrapeResult.Success>(result)
+        assertEquals(ExtractionSource.MICRODATA, success.source)
+        assertEquals("Chocolate Chip Cookies", success.recipe.title)
+    }
+
+    @Test
     fun `falls through to NoRecipeFound when the only microdata scope has no ingredients or instructions`() {
         assertEquals(ScrapeResult.NoRecipeFound, parser.parse(MicrodataFixtures.NAME_ONLY, "https://example.com/r"))
     }

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdExtractorTest.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdExtractorTest.kt
@@ -93,4 +93,28 @@ class JsonLdExtractorTest {
         assertEquals(emptyList(), recipe?.ingredients)
         assertEquals(emptyList(), recipe?.instructions)
     }
+
+    @Test
+    fun `maps HowToSupply-style ingredient objects by their name or text field`() {
+        val recipe = extract(JsonLdFixtures.OBJECT_INGREDIENTS)
+
+        assertEquals(listOf("2 cups flour", "1 cup milk"), recipe?.ingredients?.map { it.raw })
+    }
+
+    @Test
+    fun `maps a single ingredient string instead of an array`() {
+        val recipe = extract(JsonLdFixtures.SINGLE_STRING_INGREDIENT)
+
+        assertEquals(listOf("1 cup rice"), recipe?.ingredients?.map { it.raw })
+    }
+
+    @Test
+    fun `flattens ingredients grouped into nested arrays`() {
+        val recipe = extract(JsonLdFixtures.GROUPED_INGREDIENTS)
+
+        assertEquals(
+            listOf("1 cup sugar", "2 eggs", "1 tsp vanilla"),
+            recipe?.ingredients?.map { it.raw },
+        )
+    }
 }

--- a/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdFixtures.kt
+++ b/recipe-scraper/src/commonTest/kotlin/com/tenmilelabs/recipescraper/jsonld/JsonLdFixtures.kt
@@ -138,4 +138,61 @@ internal object JsonLdFixtures {
         </script>
         </head><body></body></html>
     """.trimIndent()
+
+    val INSTRUCTIONS_ONLY = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Instructions Only Recipe",
+          "recipeInstructions": ["Do the thing.", "Do another thing."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val OBJECT_INGREDIENTS = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "HowToSupply Ingredients Recipe",
+          "recipeIngredient": [
+            {"@type": "HowToSupply", "name": "2 cups flour"},
+            {"@type": "HowToSupply", "text": "1 cup milk"}
+          ],
+          "recipeInstructions": ["Mix it all together."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val SINGLE_STRING_INGREDIENT = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Single String Ingredient Recipe",
+          "recipeIngredient": "1 cup rice",
+          "recipeInstructions": ["Cook the rice."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
+
+    val GROUPED_INGREDIENTS = """
+        <html><head>
+        <script type="application/ld+json">
+        {
+          "@type": "Recipe",
+          "name": "Grouped Ingredients Recipe",
+          "recipeIngredient": [
+            ["1 cup sugar", "2 eggs"],
+            ["1 tsp vanilla"]
+          ],
+          "recipeInstructions": ["Combine everything."]
+        }
+        </script>
+        </head><body></body></html>
+    """.trimIndent()
 }


### PR DESCRIPTION
## Summary
Fixes #176. Two compounding gaps in `:recipe-scraper` let an imported recipe save with a completely empty ingredients list while everything else (title, image, steps) came through fine:

- `RecipeHtmlParser`'s tier hit-test only required a non-blank title **and** *either* an ingredient **or** an instruction. A page with parseable instructions but an ingredients shape the mapper couldn't handle still counted as a JSON-LD hit and returned `Success` with `ingredients = emptyList()`, instead of falling through to the microdata tier.
- `JsonLdRecipeMapper.toIngredients()` only handled the schema.org-standard flat `JsonArray` of string primitives. Any other shape sites publish in practice — a single string instead of an array, an array of objects (`HowToSupply`-style `name`/`text` fields), or ingredients grouped into nested arrays — silently produced an empty list, unlike `toInstructionSteps()` a few lines below which already handles a typed/nested shape.

## Changes
- `isUsable()` now requires ingredients specifically (title + ingredients), not ingredients-or-instructions. A JSON-LD block with instructions but no ingredients now falls through to microdata, and from there into the app's existing rendered-fetch retry — instead of silently succeeding.
- `toIngredients()` now mirrors `toInstructionSteps()`'s shape handling: object entries, a lone string, and nested/grouped arrays.
- Updated stale doc comments referencing the old "ingredients or instructions" rule (`RecipeHtmlParser` class doc, `ScrapeResult.NoRecipeFound`).

Deliberately did not add a new `RecipeImportResult` signal for "imported with 0 ingredients" (the issue's third, explicitly-optional suggestion) — with the tier now correctly failing instead of silently succeeding, the app's existing `NoRecipeFound` → rendered-fetch-retry → failure path already covers it.

## Test plan
- [x] `./gradlew :recipe-scraper:jvmTest` — new + existing tests pass (tightened hit-test, object/string/nested ingredient shapes)
- [x] `./gradlew :app:testDebugUnitTest --tests "*DefaultRecipeImporterTest" --tests "*ScrapedRecipeMapperTest"` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)