### PR TITLE
Fix SSRF guard: resolve DNS, cover IPv6, re-validate redirects

### DIFF
--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/DataModules.kt
@@ -22,8 +22,10 @@ import com.tenmilelabs.chefai.core.data.repository.DefaultMetadataRepository
 import com.tenmilelabs.chefai.core.domain.repository.MetadataRepository
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter
 import com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeRepository
+import com.tenmilelabs.chefai.recipes.data.network.SystemHostResolver
 import com.tenmilelabs.chefai.recipes.data.network.WebViewHtmlFetcher
 import com.tenmilelabs.chefai.recipes.data.network.WebViewImageFetcher
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
@@ -80,6 +82,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindRecipeSearchRepository(repository: DefaultRecipeSearchRepository): RecipeSearchRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindHostResolver(resolver: SystemHostResolver): HostResolver
 }
 
 

--- a/app/src/main/java/com/tenmilelabs/chefai/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/di/NetworkModule.kt
@@ -92,13 +92,18 @@ object NetworkModule {
     /**
      * Unauthenticated client for fetching third-party recipe pages during URL import.
      * Must never carry ChefAI auth headers or run scraped HTML through content negotiation.
+     *
+     * Redirects are followed manually by callers (see [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter]
+     * and [com.tenmilelabs.chefai.recipes.domain.usecase.CacheRecipeImage]) rather than by the
+     * client, so every hop can be re-validated against the SSRF guard before it's followed — a
+     * page can 3xx to an internal address just as easily as it can host one directly.
      */
     @Provides
     @Singleton
     @ScraperHttpClient
     fun provideScraperHttpClient(): HttpClient = HttpClient(CIO) {
         expectSuccess = true
-        followRedirects = true
+        followRedirects = false
 
         install(HttpTimeout) {
             requestTimeoutMillis = 15_000

--- a/app/src/main/java/com/tenmilelabs/chefai/core/util/ShareTextUrlExtractor.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/core/util/ShareTextUrlExtractor.kt
@@ -1,6 +1,6 @@
 package com.tenmilelabs.chefai.core.util
 
-import com.tenmilelabs.chefai.recipes.data.repository.normalizeAndValidateUrl
+import com.tenmilelabs.chefai.recipes.data.repository.normalizeUrlForDisplay
 
 private val URL_REGEX = Regex("https?://\\S+")
 
@@ -13,12 +13,15 @@ private val TRAILING_PUNCTUATION = Regex("[.,;:!?)\\]\"']+$")
  * rather than a bare URL.
  *
  * The text comes from another app and is exactly as untrusted as a pasted URL, so the candidate is
- * run through the same [normalizeAndValidateUrl] check used for manual paste — an invalid or
- * private-network URL yields `null` here too, rather than being handed to the importer.
+ * run through [normalizeUrlForDisplay] — an invalid URL, or one whose host is *itself* an obvious
+ * loopback/private-network literal, yields `null` here too, rather than being handed to the
+ * importer. This runs on the main thread (see `MainActivity.consumeShareIntent`), so it can only
+ * do a no-network check — see [normalizeUrlForDisplay]'s KDoc. The importer re-validates the URL
+ * with the full, DNS-resolving guard before ever fetching it.
  */
 fun extractSharedRecipeUrl(sharedText: String?): String? {
     val match = sharedText?.let { URL_REGEX.find(it)?.value } ?: return null
     val trimmed = match.replace(TRAILING_PUNCTUATION, "")
     if (trimmed.isBlank()) return null
-    return normalizeAndValidateUrl(trimmed)
+    return normalizeUrlForDisplay(trimmed)
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/ScraperWebView.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/ScraperWebView.kt
@@ -3,10 +3,15 @@ package com.tenmilelabs.chefai.recipes.data.network
 import android.annotation.SuppressLint
 import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.tenmilelabs.chefai.recipes.data.repository.isSafeHost
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
 import kotlinx.serialization.json.Json
 import timber.log.Timber
+import java.io.ByteArrayInputStream
+import java.net.HttpURLConnection
 
 /** Skips absurd snapshots rather than marshalling them across the JNI bridge and parsing them. */
 private const val MAX_SNAPSHOT_CHARS = 4 * 1024 * 1024
@@ -116,14 +121,45 @@ internal fun WebView.applyScraperHardening() {
  * A [WebViewClient] that keeps the load inside the web: `http(s)` navigations (including the
  * redirects a bot check bounces through) proceed, anything else — `intent://`, `market://`,
  * `tel:` — is refused rather than handed to another app.
+ *
+ * [hostResolver] defaults to real DNS ([SystemHostResolver]) rather than being Hilt-injected: this
+ * class is constructed directly at each of its three call sites (an off-screen WebView is neither
+ * a singleton nor scoped to a screen, so there's no natural injection point), and the default
+ * keeps those call sites unchanged while still letting tests substitute a fake.
  */
-internal open class ScraperWebViewClient : WebViewClient() {
+internal open class ScraperWebViewClient(
+    private val hostResolver: HostResolver = SystemHostResolver(),
+) : WebViewClient() {
 
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
         val scheme = request?.url?.scheme?.lowercase()
         val isWeb = scheme == "http" || scheme == "https"
         if (!isWeb) Timber.d("Blocked non-web navigation during scrape: %s", request?.url)
         return !isWeb
+    }
+
+    /**
+     * The authoritative SSRF guard for everything the page itself fetches — the document, every
+     * redirect hop, and every subresource (image, XHR, fetch, iframe) — not just the top-level
+     * navigation [shouldOverrideUrlLoading] sees. This callback runs off the UI thread (see the
+     * platform docs on [WebViewClient.shouldInterceptRequest]), which is what makes a blocking DNS
+     * resolution here safe where it would risk an ANR in [shouldOverrideUrlLoading].
+     */
+    override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
+        val url = request?.url ?: return null
+        val scheme = url.scheme?.lowercase()
+        if (scheme != "http" && scheme != "https") return null
+        val host = url.host
+        if (host.isNullOrEmpty() || host.isSafeHost(hostResolver)) return null
+        Timber.w("Blocked scrape request to disallowed host: %s", url)
+        return WebResourceResponse(
+            "text/plain",
+            "UTF-8",
+            HttpURLConnection.HTTP_FORBIDDEN,
+            "Forbidden",
+            emptyMap(),
+            ByteArrayInputStream(ByteArray(0)),
+        )
     }
 }
 

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/SystemHostResolver.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/network/SystemHostResolver.kt
@@ -1,0 +1,16 @@
+package com.tenmilelabs.chefai.recipes.data.network
+
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
+import java.net.InetAddress
+import java.net.UnknownHostException
+import javax.inject.Inject
+
+/** [HostResolver] backed by the platform's real DNS resolution. */
+class SystemHostResolver @Inject constructor() : HostResolver {
+
+    override fun resolve(host: String): List<InetAddress> = try {
+        InetAddress.getAllByName(host).toList()
+    } catch (e: UnknownHostException) {
+        emptyList()
+    }
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporter.kt
@@ -8,16 +8,19 @@ import com.tenmilelabs.chefai.recipes.data.mapper.toRecipeDraft
 import com.tenmilelabs.chefai.recipes.data.network.BOT_WALL_STATUSES
 import com.tenmilelabs.chefai.recipes.data.network.decodeHtml
 import com.tenmilelabs.chefai.recipes.domain.model.RecipeImportResult
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
 import com.tenmilelabs.chefai.recipes.domain.repository.RecipeImporter
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedHtmlFetcher
 import com.tenmilelabs.recipescraper.RecipeHtmlParser
 import com.tenmilelabs.recipescraper.model.ScrapeResult
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.RedirectResponseException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
 import io.ktor.http.charset
 import io.ktor.http.contentType
 import io.ktor.utils.io.readAvailable
@@ -35,6 +38,9 @@ import kotlin.time.Duration.Companion.seconds
 /** Caps how much of a fetched page is read into memory — well past any real recipe page. */
 private const val MAX_BODY_BYTES = 3 * 1024 * 1024
 
+/** Bounds manual redirect-following — the same guard rail browsers apply against redirect loops. */
+private const val MAX_REDIRECT_HOPS = 5
+
 /**
  * How long the off-screen browser gets to produce a recipe before the import gives up on it.
  *
@@ -49,11 +55,12 @@ class DefaultRecipeImporter @Inject constructor(
     private val recipeHtmlParser: RecipeHtmlParser,
     private val renderedHtmlFetcher: RenderedHtmlFetcher,
     private val metadataRepository: MetadataRepository,
+    private val hostResolver: HostResolver,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : RecipeImporter {
 
     override suspend fun import(url: String): RecipeImportResult = withContext(ioDispatcher) {
-        val normalizedUrl = normalizeAndValidateUrl(url) ?: return@withContext RecipeImportResult.InvalidUrl
+        val normalizedUrl = normalizeAndValidateUrl(url, hostResolver) ?: return@withContext RecipeImportResult.InvalidUrl
 
         val fetched = fetchHtml(normalizedUrl)
         val httpResult = when (fetched) {
@@ -117,31 +124,70 @@ class DefaultRecipeImporter @Inject constructor(
         ) : FetchOutcome
     }
 
-    private suspend fun fetchHtml(url: String): FetchOutcome = try {
+    /** One step of [fetchHtml]'s redirect loop: either a terminal [outcome], or one more [location] to follow. */
+    private sealed interface FetchStep {
+        data class Terminal(val outcome: FetchOutcome) : FetchStep
+        data class Redirect(val location: String) : FetchStep
+    }
+
+    /**
+     * Follows redirects itself (the client has `followRedirects = false` — see
+     * [com.tenmilelabs.chefai.core.di.NetworkModule.provideScraperHttpClient]) so every hop can be
+     * re-validated by [validateRedirectTarget] before it's followed, not just the first URL.
+     */
+    private suspend fun fetchHtml(url: String): FetchOutcome {
+        var currentUrl = url
+        repeat(MAX_REDIRECT_HOPS + 1) {
+            when (val step = fetchOnce(currentUrl)) {
+                is FetchStep.Terminal -> return step.outcome
+                is FetchStep.Redirect -> {
+                    val next = validateRedirectTarget(currentUrl, step.location, hostResolver)
+                    if (next == null) {
+                        Timber.w("Recipe import redirect failed the SSRF guard: %s", step.location)
+                        return FetchOutcome.Failure(RecipeImportResult.NetworkError("Redirected to a disallowed address"))
+                    }
+                    currentUrl = next
+                }
+            }
+        }
+        return FetchOutcome.Failure(RecipeImportResult.NetworkError("Too many redirects"))
+    }
+
+    private suspend fun fetchOnce(url: String): FetchStep = try {
         val response = httpClient.get(url)
         val contentType = response.contentType()
         val mimeType = contentType?.withoutParameters()?.toString().orEmpty()
-        if (!mimeType.equals("text/html", ignoreCase = true) &&
+        val outcome = if (!mimeType.equals("text/html", ignoreCase = true) &&
             !mimeType.equals("application/xhtml+xml", ignoreCase = true)
         ) {
             FetchOutcome.Failure(RecipeImportResult.NetworkError("Not an HTML page"))
         } else {
             FetchOutcome.Html(response.readBodyCapped(contentType?.charset()))
         }
+        FetchStep.Terminal(outcome)
     } catch (e: CancellationException) {
         throw e
+    } catch (e: RedirectResponseException) {
+        val location = e.response.headers[HttpHeaders.Location]
+        if (location != null) {
+            FetchStep.Redirect(location)
+        } else {
+            FetchStep.Terminal(FetchOutcome.Failure(RecipeImportResult.NetworkError("Redirect missing Location")))
+        }
     } catch (e: HttpRequestTimeoutException) {
         Timber.w(e, "Recipe import request timed out")
-        FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Request timed out"))
+        FetchStep.Terminal(FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Request timed out")))
     } catch (e: ResponseException) {
         Timber.w(e, "Recipe import received an error response")
-        FetchOutcome.Failure(
-            error = RecipeImportResult.NetworkError(e.message ?: "Request failed"),
-            looksLikeBotWall = e.response.status in BOT_WALL_STATUSES,
+        FetchStep.Terminal(
+            FetchOutcome.Failure(
+                error = RecipeImportResult.NetworkError(e.message ?: "Request failed"),
+                looksLikeBotWall = e.response.status in BOT_WALL_STATUSES,
+            ),
         )
     } catch (e: IOException) {
         Timber.w(e, "Recipe import network error")
-        FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Network error"))
+        FetchStep.Terminal(FetchOutcome.Failure(RecipeImportResult.NetworkError(e.message ?: "Network error")))
     }
 
     /**

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/RecipeUrlValidation.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/data/repository/RecipeUrlValidation.kt
@@ -1,5 +1,7 @@
 package com.tenmilelabs.chefai.recipes.data.repository
 
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
+import java.net.InetAddress
 import java.net.URI
 import java.net.URISyntaxException
 
@@ -7,12 +9,47 @@ private val SCHEME_PREFIX = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*://")
 
 /**
  * Trims and, if absent, adds an `https://` scheme, then validates the result is a plausible
- * public web URL: `http`/`https` only, a host present, and not a loopback or private-network
- * address. The URL comes from user paste, so there's no reason for the app to fetch those.
+ * public web URL: `http`/`https` only, a host present, and — once resolved — not a
+ * loopback/private-network/link-local/multicast address. The URL may come from user paste or from
+ * a scraped page's own markup, so there's no reason for the app to fetch an internal address on
+ * its behalf.
  *
- * Returns `null` when the input is not a usable URL.
+ * Validation resolves the host through [hostResolver] rather than pattern-matching the string, so
+ * a hostname whose DNS record points at an internal address is caught the same way a literal IP
+ * would be — including IPv6 and every alternate IPv4 encoding the platform resolver itself
+ * accepts, since that resolver is also what the real connection uses.
+ *
+ * Returns `null` when the input is not a usable, safe URL.
  */
-internal fun normalizeAndValidateUrl(input: String): String? {
+internal fun normalizeAndValidateUrl(input: String, hostResolver: HostResolver): String? {
+    val trimmed = input.trim()
+    if (trimmed.isEmpty()) return null
+    val withScheme = if (SCHEME_PREFIX.containsMatchIn(trimmed)) trimmed else "https://$trimmed"
+
+    val uri = try {
+        URI(withScheme)
+    } catch (e: URISyntaxException) {
+        return null
+    }
+
+    return uri.validated(hostResolver)
+}
+
+/**
+ * A cheap, no-network pre-filter for call sites that can't run [normalizeAndValidateUrl] — namely
+ * [com.tenmilelabs.chefai.core.util.extractSharedRecipeUrl], invoked synchronously from
+ * `MainActivity.onCreate`/`onNewIntent` on the main thread, where a real DNS lookup risks a
+ * `NetworkOnMainThreadException`.
+ *
+ * This recognizes only a host that is *itself* a literal loopback/private-network address or
+ * `localhost` — nowhere near as strong a guard as [normalizeAndValidateUrl], since it can't catch
+ * a hostname whose DNS record points somewhere unsafe. It exists purely so a share-sheet paste of
+ * an obviously-internal address is rejected immediately rather than momentarily populating the UI;
+ * every URL from this path still goes through the full, resolver-backed check once it reaches
+ * [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter], which is the actual
+ * security boundary.
+ */
+internal fun normalizeUrlForDisplay(input: String): String? {
     val trimmed = input.trim()
     if (trimmed.isEmpty()) return null
     val withScheme = if (SCHEME_PREFIX.containsMatchIn(trimmed)) trimmed else "https://$trimmed"
@@ -26,16 +63,15 @@ internal fun normalizeAndValidateUrl(input: String): String? {
     val scheme = uri.scheme?.lowercase()
     if (scheme != "http" && scheme != "https") return null
     val host = uri.host ?: return null
-    if (host.isBlockedHost()) return null
+    if (host.isObviouslyUnsafeLiteralHost()) return null
 
     return uri.toString()
 }
 
-private fun String.isBlockedHost(): Boolean {
-    val host = lowercase()
-    if (host == "localhost") return true
-
-    val octets = host.split(".")
+/** IPv4-octet/`localhost` string check only — see [normalizeUrlForDisplay]'s KDoc for why. */
+private fun String.isObviouslyUnsafeLiteralHost(): Boolean {
+    if (lowercase() == "localhost") return true
+    val octets = split(".")
     if (octets.size != 4) return false
     val values = octets.map { it.toIntOrNull() ?: return false }
     val (a, b) = values[0] to values[1]
@@ -47,4 +83,52 @@ private fun String.isBlockedHost(): Boolean {
         a == 169 && b == 254 -> true // 169.254.0.0/16
         else -> false
     }
+}
+
+/**
+ * Resolves [location] against [baseUrl] (it may be absolute or relative, as a redirect's
+ * `Location` header can be either) and validates the result exactly as [normalizeAndValidateUrl]
+ * would.
+ *
+ * A redirect is a second, independent trip through the SSRF guard: nothing about the original URL
+ * passing validation says anything about where it 3xx's to next.
+ */
+internal fun validateRedirectTarget(baseUrl: String, location: String, hostResolver: HostResolver): String? {
+    val base = try {
+        URI(baseUrl)
+    } catch (e: URISyntaxException) {
+        return null
+    }
+    val resolved = try {
+        base.resolve(location)
+    } catch (e: IllegalArgumentException) {
+        return null
+    }
+    return resolved.validated(hostResolver)
+}
+
+private fun URI.validated(hostResolver: HostResolver): String? {
+    val scheme = scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") return null
+    val host = host ?: return null
+    if (!host.isSafeHost(hostResolver)) return null
+    return toString()
+}
+
+/** Also used directly by [com.tenmilelabs.chefai.recipes.data.network.ScraperWebViewClient] to vet every request a scraped page itself makes. */
+internal fun String.isSafeHost(hostResolver: HostResolver): Boolean {
+    if (lowercase() == "localhost") return false
+    val addresses = hostResolver.resolve(this)
+    if (addresses.isEmpty()) return false
+    return addresses.none { it.isBlockedAddress() }
+}
+
+private fun InetAddress.isBlockedAddress(): Boolean {
+    if (isLoopbackAddress || isLinkLocalAddress || isSiteLocalAddress || isAnyLocalAddress || isMulticastAddress) {
+        return true
+    }
+    // IPv6 unique local addresses, fc00::/7 — isSiteLocalAddress above only recognizes the
+    // deprecated IPv6 site-local range (fec0::/10), not this one.
+    val bytes = address
+    return bytes.size == 16 && (bytes[0].toInt() and 0xFE) == 0xFC
 }

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/HostResolver.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/repository/HostResolver.kt
@@ -1,0 +1,17 @@
+package com.tenmilelabs.chefai.recipes.domain.repository
+
+import java.net.InetAddress
+
+/**
+ * Resolves a hostname to the addresses it actually points at.
+ *
+ * The SSRF guard in [com.tenmilelabs.chefai.recipes.data.repository.normalizeAndValidateUrl] hooks
+ * through this rather than calling [InetAddress] directly so a fake can hand back a deterministic
+ * address in tests — including a hostname resolving to a blocked address, the DNS-rebinding shape
+ * of attack a string-only host check can never catch.
+ */
+fun interface HostResolver {
+
+    /** Returns every address [host] resolves to, or an empty list if it doesn't resolve at all. */
+    fun resolve(host: String): List<InetAddress>
+}

--- a/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImage.kt
+++ b/app/src/main/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImage.kt
@@ -6,8 +6,11 @@ import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import com.tenmilelabs.chefai.recipes.data.network.BOT_WALL_STATUSES
 import com.tenmilelabs.chefai.recipes.data.network.readImageBodyCapped
 import com.tenmilelabs.chefai.recipes.data.repository.normalizeAndValidateUrl
+import com.tenmilelabs.chefai.recipes.data.repository.validateRedirectTarget
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
 import com.tenmilelabs.chefai.recipes.domain.repository.RenderedImageFetcher
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.RedirectResponseException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
@@ -23,6 +26,9 @@ import kotlin.time.Duration.Companion.seconds
 
 /** Overrides the scraper client's default HTML `Accept` for this one request. */
 private const val IMAGE_ACCEPT_HEADER = "image/avif,image/webp,image/*,*/*;q=0.8"
+
+/** Bounds manual redirect-following — mirrors [com.tenmilelabs.chefai.recipes.data.repository.DefaultRecipeImporter]. */
+private const val MAX_REDIRECT_HOPS = 5
 
 /**
  * Budget for the WebView tier — matches
@@ -49,13 +55,14 @@ class CacheRecipeImage @Inject constructor(
     @ScraperHttpClient private val httpClient: HttpClient,
     private val renderedImageFetcher: RenderedImageFetcher,
     private val recipeImageStore: RecipeImageStore,
+    private val hostResolver: HostResolver,
     @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
     suspend operator fun invoke(recipeId: UUID, imageUrl: String): String? = withContext(ioDispatcher) {
         // The URL was scraped out of a third party's HTML, not typed by the user — the same SSRF
         // guard normalizeAndValidateUrl applies to a pasted page URL applies here too.
-        val url = normalizeAndValidateUrl(imageUrl) ?: return@withContext null
+        val url = normalizeAndValidateUrl(imageUrl, hostResolver) ?: return@withContext null
 
         val bytes = fetchBytes(url) ?: return@withContext null
         recipeImageStore.write(recipeId, bytes)
@@ -73,33 +80,66 @@ class CacheRecipeImage @Inject constructor(
         }
     }
 
-    private suspend fun fetchOverHttp(url: String): FetchOutcome = try {
+    /**
+     * Follows redirects itself (the client has `followRedirects = false` — see
+     * [com.tenmilelabs.chefai.core.di.NetworkModule.provideScraperHttpClient]) so every hop can be
+     * re-validated by [validateRedirectTarget] before it's followed, not just the first URL.
+     */
+    private suspend fun fetchOverHttp(url: String): FetchOutcome {
+        var currentUrl = url
+        repeat(MAX_REDIRECT_HOPS + 1) {
+            when (val step = fetchOnce(currentUrl)) {
+                is FetchStep.Terminal -> return step.outcome
+                is FetchStep.Redirect -> {
+                    val next = validateRedirectTarget(currentUrl, step.location, hostResolver)
+                    if (next == null) {
+                        Timber.w("Recipe image redirect failed the SSRF guard: %s", step.location)
+                        return FetchOutcome.Failure(looksLikeBotWall = false)
+                    }
+                    currentUrl = next
+                }
+            }
+        }
+        return FetchOutcome.Failure(looksLikeBotWall = false)
+    }
+
+    private suspend fun fetchOnce(url: String): FetchStep = try {
         val response = httpClient.get(url) {
             headers { set(HttpHeaders.Accept, IMAGE_ACCEPT_HEADER) }
         }
         val mimeType = response.contentType()?.withoutParameters()?.toString().orEmpty()
-        if (!mimeType.startsWith("image/")) {
+        val outcome = if (!mimeType.startsWith("image/")) {
             FetchOutcome.Failure(looksLikeBotWall = false)
         } else {
             val bytes = response.readImageBodyCapped()
             if (bytes != null) FetchOutcome.Bytes(bytes) else FetchOutcome.Failure(looksLikeBotWall = false)
         }
+        FetchStep.Terminal(outcome)
     } catch (e: CancellationException) {
         throw e
+    } catch (e: RedirectResponseException) {
+        val location = e.response.headers[HttpHeaders.Location]
+        if (location != null) FetchStep.Redirect(location) else FetchStep.Terminal(FetchOutcome.Failure(looksLikeBotWall = false))
     } catch (e: ResponseException) {
         Timber.w(e, "Recipe image fetch received an error response")
-        FetchOutcome.Failure(looksLikeBotWall = e.response.status in BOT_WALL_STATUSES)
+        FetchStep.Terminal(FetchOutcome.Failure(looksLikeBotWall = e.response.status in BOT_WALL_STATUSES))
     } catch (e: Exception) {
         // Deliberately broader than DefaultRecipeImporter.fetchHtml's catch list: unlike the HTML
         // fetch (whose caller branches on a sealed RecipeImportResult), nothing upstream of this use
         // case handles a thrown exception — SaveImportedDraft has no try/catch around it — so an
         // uncaught type here would crash the import instead of just leaving it imageless.
         Timber.w(e, "Recipe image fetch failed for %s", url)
-        FetchOutcome.Failure(looksLikeBotWall = false)
+        FetchStep.Terminal(FetchOutcome.Failure(looksLikeBotWall = false))
     }
 
     private sealed interface FetchOutcome {
         data class Bytes(val bytes: ByteArray) : FetchOutcome
         data class Failure(val looksLikeBotWall: Boolean) : FetchOutcome
+    }
+
+    /** One step of [fetchOverHttp]'s redirect loop: either a terminal [outcome], or one more [location] to follow. */
+    private sealed interface FetchStep {
+        data class Terminal(val outcome: FetchOutcome) : FetchStep
+        data class Redirect(val location: String) : FetchStep
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporterTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/DefaultRecipeImporterTest.kt
@@ -37,11 +37,13 @@ class DefaultRecipeImporterTest {
     private fun importer(
         engine: MockEngine,
         renderedHtmlFetcher: FakeRenderedHtmlFetcher = FakeRenderedHtmlFetcher(),
+        hostResolver: FakeHostResolver = FakeHostResolver(),
     ): DefaultRecipeImporter = DefaultRecipeImporter(
-        httpClient = HttpClient(engine) { expectSuccess = true },
+        httpClient = HttpClient(engine) { expectSuccess = true; followRedirects = false },
         recipeHtmlParser = RecipeHtmlParser(),
         renderedHtmlFetcher = renderedHtmlFetcher,
         metadataRepository = FakeMetadataRepository(),
+        hostResolver = hostResolver,
         ioDispatcher = Dispatchers.Unconfined,
     )
 
@@ -105,7 +107,19 @@ class DefaultRecipeImporterTest {
 
     @Test
     fun `returns InvalidUrl for a private-network address`() = runTest {
-        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML)).import("http://192.168.1.5/x")
+        val hostResolver = FakeHostResolver(mapOf("192.168.1.5" to FakeHostResolver.literal("192.168.1.5")))
+
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML), hostResolver = hostResolver).import("http://192.168.1.5/x")
+
+        assertThat(result).isEqualTo(RecipeImportResult.InvalidUrl)
+    }
+
+    @Test
+    fun `returns InvalidUrl for a hostname whose DNS record points at a blocked address`() = runTest {
+        val hostResolver = FakeHostResolver(mapOf("evil.example.com" to FakeHostResolver.literal("169.254.169.254")))
+
+        val result = importer(htmlEngine(JSON_LD_RECIPE_HTML), hostResolver = hostResolver)
+            .import("https://evil.example.com/recipe")
 
         assertThat(result).isEqualTo(RecipeImportResult.InvalidUrl)
     }
@@ -174,5 +188,65 @@ class DefaultRecipeImporterTest {
 
         assertThat(result).isInstanceOf(RecipeImportResult.NetworkError::class.java)
         assertThat(fetcher.callCount).isEqualTo(0)
+    }
+
+    // --- Redirects ---
+
+    @Test
+    fun `follows a redirect to a safe address and imports from it`() = runTest {
+        val engine = MockEngine { request ->
+            if (request.url.toString() == "https://example.com/original") {
+                respond(
+                    content = ByteReadChannel(ByteArray(0)),
+                    status = HttpStatusCode.MovedPermanently,
+                    headers = headersOf(HttpHeaders.Location, "https://example.com/final"),
+                )
+            } else {
+                respond(
+                    content = ByteReadChannel(JSON_LD_RECIPE_HTML),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "text/html"),
+                )
+            }
+        }
+
+        val result = importer(engine).import("https://example.com/original")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.Success::class.java)
+    }
+
+    @Test
+    fun `returns NetworkError rather than following a redirect to a blocked address`() = runTest {
+        val hostResolver = FakeHostResolver(mapOf("internal.attacker.example" to FakeHostResolver.literal("169.254.169.254")))
+        val engine = MockEngine {
+            respond(
+                content = ByteReadChannel(ByteArray(0)),
+                status = HttpStatusCode.Found,
+                headers = headersOf(HttpHeaders.Location, "https://internal.attacker.example/steal"),
+            )
+        }
+
+        val result = importer(engine, hostResolver = hostResolver).import("https://example.com/original")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.NetworkError::class.java)
+    }
+
+    @Test
+    fun `gives up after too many redirects rather than looping forever`() = runTest {
+        var hops = 0
+        val engine = MockEngine {
+            hops++
+            respond(
+                content = ByteReadChannel(ByteArray(0)),
+                status = HttpStatusCode.Found,
+                headers = headersOf(HttpHeaders.Location, "https://example.com/hop-$hops"),
+            )
+        }
+
+        val result = importer(engine).import("https://example.com/start")
+
+        assertThat(result).isInstanceOf(RecipeImportResult.NetworkError::class.java)
+        // The initial request plus MAX_REDIRECT_HOPS follow-ups, no more.
+        assertThat(hops).isEqualTo(6)
     }
 }

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeHostResolver.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/FakeHostResolver.kt
@@ -1,0 +1,24 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.tenmilelabs.chefai.recipes.domain.repository.HostResolver
+import java.net.InetAddress
+
+/**
+ * A [HostResolver] that never touches real DNS: [resolve] looks [host] up in [addresses], falling
+ * back to an ordinary public address for anything unmapped so tests that don't care about DNS can
+ * use whatever hostname reads best.
+ */
+class FakeHostResolver(
+    private val addresses: Map<String, List<InetAddress>> = emptyMap(),
+) : HostResolver {
+
+    override fun resolve(host: String): List<InetAddress> = addresses[host] ?: DEFAULT_PUBLIC_ADDRESS
+
+    companion object {
+        /** An ordinary, non-blocked address. Parsing a literal IP never touches the network. */
+        val DEFAULT_PUBLIC_ADDRESS: List<InetAddress> = listOf(InetAddress.getByName("93.184.216.34"))
+
+        /** Parses each literal IP into an [InetAddress] — safe, a literal never triggers a DNS lookup. */
+        fun literal(vararg ip: String): List<InetAddress> = ip.map { InetAddress.getByName(it) }
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/RecipeUrlValidationTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/data/repository/RecipeUrlValidationTest.kt
@@ -1,0 +1,189 @@
+package com.tenmilelabs.chefai.recipes.data.repository
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RecipeUrlValidationTest {
+
+    private fun resolver(vararg entries: Pair<String, List<java.net.InetAddress>>) =
+        FakeHostResolver(entries.toMap())
+
+    // --- Basic shape ---
+
+    @Test
+    fun `adds an https scheme when none is given`() {
+        val result = normalizeAndValidateUrl("example.com/recipe", resolver())
+
+        assertThat(result).isEqualTo("https://example.com/recipe")
+    }
+
+    @Test
+    fun `keeps an explicit http scheme`() {
+        val result = normalizeAndValidateUrl("http://example.com/recipe", resolver())
+
+        assertThat(result).isEqualTo("http://example.com/recipe")
+    }
+
+    @Test
+    fun `rejects a non-http scheme`() {
+        assertThat(normalizeAndValidateUrl("ftp://example.com/recipe", resolver())).isNull()
+    }
+
+    @Test
+    fun `rejects blank input`() {
+        assertThat(normalizeAndValidateUrl("   ", resolver())).isNull()
+    }
+
+    @Test
+    fun `rejects text that isn't a url`() {
+        assertThat(normalizeAndValidateUrl("not a url \n with control chars", resolver())).isNull()
+    }
+
+    // --- localhost / loopback ---
+
+    @Test
+    fun `rejects localhost regardless of case`() {
+        assertThat(normalizeAndValidateUrl("http://LOCALHOST:8080/x", resolver())).isNull()
+    }
+
+    @Test
+    fun `rejects a literal IPv4 loopback address`() {
+        val host = "127.0.0.1"
+        assertThat(normalizeAndValidateUrl("http://$host/x", resolver(host to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    @Test
+    fun `rejects an IPv6 loopback address`() {
+        // java.net.URI#getHost keeps the brackets on an IPv6 literal (e.g. "[::1]"), unlike the
+        // IPv4 case above — that bracketed string is exactly what the resolver is keyed on here.
+        val host = "::1"
+        assertThat(normalizeAndValidateUrl("http://[$host]/x", resolver("[$host]" to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    // --- Private / link-local ranges ---
+
+    @Test
+    fun `rejects an RFC1918 10-slash-8 address`() {
+        val host = "10.1.2.3"
+        assertThat(normalizeAndValidateUrl("http://$host/x", resolver(host to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    @Test
+    fun `rejects an RFC1918 192-168 address`() {
+        val host = "192.168.1.5"
+        assertThat(normalizeAndValidateUrl("http://$host/x", resolver(host to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    @Test
+    fun `rejects the cloud metadata link-local address`() {
+        val host = "169.254.169.254"
+        assertThat(normalizeAndValidateUrl("http://$host/x", resolver(host to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    @Test
+    fun `rejects an IPv6 link-local address`() {
+        val host = "fe80::1"
+        assertThat(normalizeAndValidateUrl("http://[$host]/x", resolver("[$host]" to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    @Test
+    fun `rejects an IPv6 unique-local address not covered by isSiteLocalAddress`() {
+        // fc00::/7 — java.net.InetAddress#isSiteLocalAddress only recognizes the deprecated
+        // fec0::/10 range, so this needs its own check (see isBlockedAddress).
+        val host = "fd12:3456:789a::1"
+        assertThat(normalizeAndValidateUrl("http://[$host]/x", resolver("[$host]" to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    // --- Alternate encodings the underlying resolver itself normalizes ---
+
+    @Test
+    fun `rejects the decimal-integer encoding of a loopback address`() {
+        // "2130706433" is 127.0.0.1 — java.net.InetAddress parses this form as a literal, so
+        // resolving before checking closes this off automatically.
+        val host = "2130706433"
+        assertThat(normalizeAndValidateUrl("http://$host/x", resolver(host to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    @Test
+    fun `rejects an IPv4-mapped IPv6 loopback address`() {
+        val host = "::ffff:127.0.0.1"
+        assertThat(normalizeAndValidateUrl("http://[$host]/x", resolver("[$host]" to FakeHostResolver.literal(host)))).isNull()
+    }
+
+    // --- DNS rebinding: the actual gap this issue is about ---
+
+    @Test
+    fun `rejects a hostname whose DNS record points at a blocked address`() {
+        val result = normalizeAndValidateUrl(
+            "https://evil.example.com/recipe",
+            resolver("evil.example.com" to FakeHostResolver.literal("169.254.169.254")),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `rejects a hostname when any of its resolved addresses is blocked`() {
+        val result = normalizeAndValidateUrl(
+            "https://multi.example.com/recipe",
+            resolver("multi.example.com" to FakeHostResolver.literal("93.184.216.34", "10.0.0.1")),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `rejects a hostname that fails to resolve`() {
+        val result = normalizeAndValidateUrl("https://nowhere.invalid/recipe", resolver("nowhere.invalid" to emptyList()))
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `accepts a hostname that resolves only to public addresses`() {
+        val result = normalizeAndValidateUrl(
+            "https://good.example.com/recipe",
+            resolver("good.example.com" to FakeHostResolver.literal("93.184.216.34")),
+        )
+
+        assertThat(result).isEqualTo("https://good.example.com/recipe")
+    }
+
+    // --- Redirect re-validation ---
+
+    @Test
+    fun `follows a relative redirect and validates the resolved target`() {
+        val result = validateRedirectTarget(
+            "https://good.example.com/recipe",
+            "/moved",
+            resolver("good.example.com" to FakeHostResolver.literal("93.184.216.34")),
+        )
+
+        assertThat(result).isEqualTo("https://good.example.com/moved")
+    }
+
+    @Test
+    fun `rejects a redirect to a different host that resolves to a blocked address`() {
+        val result = validateRedirectTarget(
+            "https://good.example.com/recipe",
+            "https://internal.attacker.example/steal",
+            resolver(
+                "good.example.com" to FakeHostResolver.literal("93.184.216.34"),
+                "internal.attacker.example" to FakeHostResolver.literal("169.254.169.254"),
+            ),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `rejects a redirect whose Location is unparseable`() {
+        val result = validateRedirectTarget(
+            "https://good.example.com/recipe",
+            "http://[not a valid host",
+            resolver("good.example.com" to FakeHostResolver.literal("93.184.216.34")),
+        )
+
+        assertThat(result).isNull()
+    }
+}

--- a/app/src/test/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImageTest.kt
+++ b/app/src/test/java/com/tenmilelabs/chefai/recipes/domain/usecase/CacheRecipeImageTest.kt
@@ -3,6 +3,7 @@ package com.tenmilelabs.chefai.recipes.domain.usecase
 import com.google.common.truth.Truth.assertThat
 import com.tenmilelabs.chefai.recipes.data.local.RecipeImageStore
 import com.tenmilelabs.chefai.recipes.data.network.MAX_IMAGE_BYTES
+import com.tenmilelabs.chefai.recipes.data.repository.FakeHostResolver
 import com.tenmilelabs.chefai.recipes.data.repository.FakeRenderedImageFetcher
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -29,10 +30,12 @@ class CacheRecipeImageTest {
         engine: MockEngine,
         renderedImageFetcher: FakeRenderedImageFetcher = FakeRenderedImageFetcher(),
         recipeImageStore: RecipeImageStore = mockk { coEvery { write(any(), any()) } returns STORED_PATH },
+        hostResolver: FakeHostResolver = FakeHostResolver(),
     ) = CacheRecipeImage(
-        httpClient = HttpClient(engine) { expectSuccess = true },
+        httpClient = HttpClient(engine) { expectSuccess = true; followRedirects = false },
         renderedImageFetcher = renderedImageFetcher,
         recipeImageStore = recipeImageStore,
+        hostResolver = hostResolver,
         ioDispatcher = Dispatchers.Unconfined,
     )
 
@@ -127,11 +130,73 @@ class CacheRecipeImageTest {
         val store = mockk<RecipeImageStore>(relaxed = true)
         // The engine would throw if reached — its handler is never installed.
         val engine = MockEngine { respondError(HttpStatusCode.InternalServerError) }
+        val hostResolver = FakeHostResolver(mapOf("169.254.169.254" to FakeHostResolver.literal("169.254.169.254")))
 
-        val result = useCase(engine, fetcher, store).invoke(UUID.randomUUID(), "http://169.254.169.254/latest/meta-data/")
+        val result = useCase(engine, fetcher, store, hostResolver)
+            .invoke(UUID.randomUUID(), "http://169.254.169.254/latest/meta-data/")
 
         assertThat(result).isNull()
         assertThat(fetcher.callCount).isEqualTo(0)
+        coVerify(exactly = 0) { store.write(any(), any()) }
+    }
+
+    @Test
+    fun `an image url whose DNS record points at a blocked address is rejected`() = runTest {
+        val fetcher = FakeRenderedImageFetcher(IMAGE_BYTES)
+        val store = mockk<RecipeImageStore>(relaxed = true)
+        val engine = MockEngine { respondError(HttpStatusCode.InternalServerError) }
+        val hostResolver = FakeHostResolver(mapOf("evil.example.com" to FakeHostResolver.literal("169.254.169.254")))
+
+        val result = useCase(engine, fetcher, store, hostResolver)
+            .invoke(UUID.randomUUID(), "https://evil.example.com/img.jpg")
+
+        assertThat(result).isNull()
+        assertThat(fetcher.callCount).isEqualTo(0)
+        coVerify(exactly = 0) { store.write(any(), any()) }
+    }
+
+    @Test
+    fun `follows a redirect to a safe address and caches the bytes`() = runTest {
+        val store = mockk<RecipeImageStore> { coEvery { write(any(), any()) } returns STORED_PATH }
+        val recipeId = UUID.randomUUID()
+        val engine = MockEngine { request ->
+            if (request.url.toString() == "https://example.com/original.jpg") {
+                respond(
+                    content = ByteReadChannel(ByteArray(0)),
+                    status = HttpStatusCode.MovedPermanently,
+                    headers = headersOf(HttpHeaders.Location, "https://example.com/final.jpg"),
+                )
+            } else {
+                respond(
+                    content = ByteReadChannel(IMAGE_BYTES),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "image/jpeg"),
+                )
+            }
+        }
+
+        val result = useCase(engine, recipeImageStore = store).invoke(recipeId, "https://example.com/original.jpg")
+
+        assertThat(result).isEqualTo(STORED_PATH)
+        coVerify(exactly = 1) { store.write(recipeId, IMAGE_BYTES) }
+    }
+
+    @Test
+    fun `does not follow a redirect to a blocked address`() = runTest {
+        val store = mockk<RecipeImageStore>(relaxed = true)
+        val hostResolver = FakeHostResolver(mapOf("internal.attacker.example" to FakeHostResolver.literal("169.254.169.254")))
+        val engine = MockEngine {
+            respond(
+                content = ByteReadChannel(ByteArray(0)),
+                status = HttpStatusCode.Found,
+                headers = headersOf(HttpHeaders.Location, "https://internal.attacker.example/steal.jpg"),
+            )
+        }
+
+        val result = useCase(engine, recipeImageStore = store, hostResolver = hostResolver)
+            .invoke(UUID.randomUUID(), "https://example.com/original.jpg")
+
+        assertThat(result).isNull()
         coVerify(exactly = 0) { store.write(any(), any()) }
     }
 


### PR DESCRIPTION
## Summary

`normalizeAndValidateUrl` (used by both `DefaultRecipeImporter.import()` and `CacheRecipeImage`) only pattern-matched the host string, which left the four gaps from #175:

1. **No DNS resolution** — a hostname's own A/AAAA record was never checked, so DNS pointed at `169.254.169.254` or an RFC1918 address sailed through.
2. **IPv6 not recognized** — `isBlockedHost` only parsed 4-octet dotted-quad IPv4, so `::1`, `fe80::...`, `fc00::/7`, and `::ffff:127.0.0.1` all fell through to `else -> false`.
3. **Alternate IPv4 encodings** — decimal (`2130706433`), octal, hex forms bypassed the octet check.
4. **Redirects never re-validated** — both the Ktor scraper client (`followRedirects = true`) and the WebView tier (`shouldOverrideUrlLoading` only checked scheme) would follow a 3xx to an internal address without re-checking it.

## Approach

- **Resolve, don't pattern-match.** Host safety now goes through a new `HostResolver` interface (`SystemHostResolver` in prod, `FakeHostResolver` in tests) and checks the real `InetAddress`: `isLoopbackAddress`/`isLinkLocalAddress`/`isSiteLocalAddress`/`isAnyLocalAddress`/`isMulticastAddress`, plus an explicit `fc00::/7` check (Java's `isSiteLocalAddress` only covers the deprecated IPv6 `fec0::/10` range, not IPv6 ULA). Resolving via the same mechanism as the actual connection also closes the alternate-encoding class of bug for free — whatever a hostname or literal resolves to is what gets checked.
- **Redirects are a second trip through the guard.** `provideScraperHttpClient` now sets `followRedirects = false`; `DefaultRecipeImporter` and `CacheRecipeImage` follow redirects themselves (capped at 5 hops), re-validating each `Location` via a new `validateRedirectTarget()` before following it.
- **WebView tier.** `ScraperWebViewClient` gained a `shouldInterceptRequest` override — it runs off the UI thread (unlike `shouldOverrideUrlLoading`), so a blocking DNS check is safe there. This covers the main document, every redirect hop, and every subresource (image/XHR/fetch/iframe) a scraped page's own JS might request — closing gap 4 more thoroughly than the issue's own suggestion of just re-checking `Location` headers.
- **One exception: `extractSharedRecipeUrl`.** It runs synchronously on the main thread (`MainActivity.onCreate`/`onNewIntent`), where a blocking DNS lookup risks `NetworkOnMainThreadException`. It keeps a cheap, non-resolving literal-IP/`localhost` pre-filter (`normalizeUrlForDisplay`) for immediate UX feedback; the URL still goes through the full resolver-backed check once it reaches the importer, which is the actual security boundary.

## Test plan

- [x] New `RecipeUrlValidationTest` — loopback/RFC1918/link-local/IPv6 ULA/IPv4-mapped-IPv6/decimal-encoding rejections, DNS-rebinding (hostname resolving to a blocked address), multi-address resolution, unresolvable host, and redirect-target validation (relative + absolute + malformed).
- [x] `DefaultRecipeImporterTest` / `CacheRecipeImageTest` extended with DNS-rebinding and redirect-following/redirect-blocked/too-many-redirects cases; existing literal-IP tests updated to route through the fake resolver.
- [x] `./gradlew :app:testDebugUnitTest` — 615 tests, 0 failures.
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)